### PR TITLE
Remove an unused function on tutorial

### DIFF
--- a/docs/tutorials/circuits.ipynb
+++ b/docs/tutorials/circuits.ipynb
@@ -287,9 +287,6 @@
     }
    ],
    "source": [
-    "def some_fun(circuit):\n",
-    "    return get_depth(circuit)\n",
-    "\n",
     "def get_depth(circuit):\n",
     "    # This function adds some gates despite its name!\n",
     "    depth = circuit.depth\n",


### PR DESCRIPTION
Delete the function of `some_fun`  as it is not referenced.