### PR TITLE
Add a tutorial for sampling on a real device; small bug fix

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -9,5 +9,5 @@ Tutorials
     tutorials/parametric
     tutorials/variational
     tutorials/sampling_simulation
-    .. tutorials/sampling_real
+    tutorials/sampling_real
     tutorials/noise_error

--- a/docs/tutorials/sampling_real.ipynb
+++ b/docs/tutorials/sampling_real.ipynb
@@ -1,0 +1,374 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a533cde3",
+   "metadata": {},
+   "source": [
+    "# Sampling on a real quantum computer\n",
+    "\n",
+    "In the previous section ([Sampling simulation](sampling_simulation.ipynb)), we described how to estimate expectation value of operators using sampling measurements on a quantum circuit simulator. Since QURI Parts is designed to be platform independent, you can execute almost the same code on a real quantum computer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0ff7af6",
+   "metadata": {},
+   "source": [
+    "## Prerequisite\n",
+    "\n",
+    "This section requires topics described in the previous section ([Sampling simulation](sampling_simulation.ipynb)), so you need to read it before this section.\n",
+    "\n",
+    "We use [Amazon Braket](https://aws.amazon.com/braket/) as an example of a platform with real quantum computers. In order to use Braket devices provided on AWS, you need to have an AWS account and enable Braket service. Please see [Amazon Braket Documentation](https://docs.aws.amazon.com/braket/index.html) for details. In this section, instead, we use the local simulator included in [Amazon Braket SDK](https://amazon-braket-sdk-python.readthedocs.io/en/latest/index.html), which does not require an AWS account. The Braket devices provided on AWS and the local simulator have the same interface, you can simply replace them each other.\n",
+    "\n",
+    "QURI Parts modules used in this tutorial: `quri-parts-circuit`, `quri-parts-core` and `quri-parts-braket`. You can install them as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdf46a7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"quri-parts[braket]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8aaa543b",
+   "metadata": {},
+   "source": [
+    "## Prepare a circuit\n",
+    "\n",
+    "As a preparation, we create a circuit to be sampled:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "89fd8970",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from math import pi\n",
+    "from quri_parts.circuit import QuantumCircuit\n",
+    "# A circuit with 4 qubits\n",
+    "circuit = QuantumCircuit(4)\n",
+    "circuit.add_X_gate(0)\n",
+    "circuit.add_H_gate(1)\n",
+    "circuit.add_Y_gate(2)\n",
+    "circuit.add_CNOT_gate(1, 2)\n",
+    "circuit.add_RX_gate(3, pi/4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddbcded0",
+   "metadata": {},
+   "source": [
+    "## SamplingBackend and Sampler\n",
+    "\n",
+    "In order to use a real device, you need to create a `SamplingBackend` object and then a `Sampler` using the backend. The `SamplingBackend` provides a unified interface for handling various backend devices, computation jobs for the devices and results of the jobs. \n",
+    "\n",
+    "How to create a `SamplingBackend` object depends on the used backend. For Braket devices, you can create a `BraketSamplingBackend` by passing a `braket.devices.Device` object (provided by Amazon Braket SDK):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cad810b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from braket.aws import AwsDevice\n",
+    "from braket.devices import LocalSimulator\n",
+    "\n",
+    "# A device for QPU provided on AWS\n",
+    "# device = AwsDevice(\"arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-2\")\n",
+    "\n",
+    "# A device for the local simulator\n",
+    "device = LocalSimulator()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c6e85888",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from quri_parts.braket.backend import BraketSamplingBackend\n",
+    "\n",
+    "# Create a SamplingBackend with the device\n",
+    "backend = BraketSamplingBackend(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d552513b",
+   "metadata": {},
+   "source": [
+    "It is possible to use this backend directly, though it is usually unnecessary as we will see below. The `SamplingBackend` has `sample()` method, which returns a `SamplingJob` object, and you can extract a result of the sampling job:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e0e34af0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Counter({5: 445, 3: 397, 13: 82, 11: 76})\n"
+     ]
+    }
+   ],
+   "source": [
+    "job = backend.sample(circuit, n_shots=1000)\n",
+    "result = job.result()\n",
+    "print(result.counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99617015",
+   "metadata": {},
+   "source": [
+    "Instead of using the backend directly, you can create a `Sampler` from it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "af6eb6fb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Counter({3: 448, 5: 417, 13: 70, 11: 65})\n"
+     ]
+    }
+   ],
+   "source": [
+    "from quri_parts.core.sampling import create_sampler_from_sampling_backend\n",
+    "\n",
+    "sampler = create_sampler_from_sampling_backend(backend)\n",
+    "sampling_result = sampler(circuit, 1000)\n",
+    "print(sampling_result)\n",
+    "\n",
+    "# A concurrent sampler can also be created\n",
+    "from quri_parts.core.sampling import create_concurrent_sampler_from_sampling_backend\n",
+    "\n",
+    "concurrent_sampler = create_concurrent_sampler_from_sampling_backend(backend)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb130a1a",
+   "metadata": {},
+   "source": [
+    "With the `Sampler`, you can perform sampling estimation of an operator on a quantum state exactly in the same way as described in [the previous section](sampling_simulation.ipynb):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d5e7bcb0",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimated expectation value: (0.7253113103278891-0.007043979821499793j)\n",
+      "Standard error of estimation: 0.07072986943220279\n"
+     ]
+    }
+   ],
+   "source": [
+    "from quri_parts.core.operator import Operator, pauli_label, PAULI_IDENTITY\n",
+    "op = Operator({\n",
+    "    pauli_label(\"Z0\"): 0.25,\n",
+    "    pauli_label(\"Z1 Z2\"): 2.0,\n",
+    "    pauli_label(\"X1 X2\"): 0.5 + 0.25j,\n",
+    "    pauli_label(\"Z1 Y3\"): 1.0j,\n",
+    "    pauli_label(\"Z2 Y3\"): 1.5 + 0.5j,\n",
+    "    pauli_label(\"X1 Y3\"): 2.0j,\n",
+    "    PAULI_IDENTITY: 3.0,\n",
+    "})\n",
+    "\n",
+    "from quri_parts.core.state import ComputationalBasisState\n",
+    "initial_state = ComputationalBasisState(4, bits=0b0101)\n",
+    "\n",
+    "from quri_parts.core.measurement import bitwise_commuting_pauli_measurement\n",
+    "from quri_parts.core.sampling.shots_allocator import create_weighted_random_shots_allocator\n",
+    "allocator = create_weighted_random_shots_allocator(seed=777)\n",
+    "\n",
+    "from quri_parts.core.estimator.sampling import sampling_estimate\n",
+    "estimate = sampling_estimate(\n",
+    "    op,            # Operator to estimate\n",
+    "    initial_state, # Initial (circuit) state\n",
+    "    5000,          # Total sampling shots\n",
+    "    concurrent_sampler, # ConcurrentSampler\n",
+    "    bitwise_commuting_pauli_measurement, # Factory function for CommutablePauliSetMeasurement\n",
+    "    allocator,     # PauliSamplingShotsAllocator\n",
+    ")\n",
+    "print(f\"Estimated expectation value: {estimate.value}\")\n",
+    "print(f\"Standard error of estimation: {estimate.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5fb91e6",
+   "metadata": {},
+   "source": [
+    "You can also create a `QuantumEstimator` that performs sampling estimation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "70759ad0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Estimated expectation value: (0.6310222899695139-0.04464326805968584j)\n",
+      "Standard error of estimation: 0.07028525906672647\n"
+     ]
+    }
+   ],
+   "source": [
+    "from quri_parts.core.estimator.sampling import create_sampling_estimator\n",
+    "estimator = create_sampling_estimator(\n",
+    "    5000,          # Total sampling shots\n",
+    "    concurrent_sampler, # ConcurrentSampler\n",
+    "    bitwise_commuting_pauli_measurement, # Factory function for CommutablePauliSetMeasurement\n",
+    "    allocator,     # PauliSamplingShotsAllocator\n",
+    ")\n",
+    "estimate = estimator(op, initial_state)\n",
+    "print(f\"Estimated expectation value: {estimate.value}\")\n",
+    "print(f\"Standard error of estimation: {estimate.error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32041bd2",
+   "metadata": {},
+   "source": [
+    "## Qubit mapping\n",
+    "\n",
+    "When you use a real quantum device, you may want to use specific device qubits selected by inspecting calibration data of the device. A `SamplingBackend` supports such usage with `qubit_mapping` argument. With `qubit_mapping` you can specify an arbitrary one-to-one mapping between qubit indices in the input circuit and device qubits. For example, if you want to map qubits in the circuit into device qubits as 0 → 3, 1 → 2, 2 → 0 and 3 → 1, you can specify the mapping as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "70104976",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{3: 442, 5: 400, 13: 70, 11: 88}\n"
+     ]
+    }
+   ],
+   "source": [
+    "backend = BraketSamplingBackend(device, qubit_mapping={0: 3, 1: 2, 2: 0, 3: 1})\n",
+    "sampler = create_sampler_from_sampling_backend(backend)\n",
+    "sampling_result = sampler(circuit, 1000)\n",
+    "print(sampling_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91c01db0",
+   "metadata": {},
+   "source": [
+    "The result looks similar to one with no qubit mapping, since the measurement result from the device is mapped backward so that it is interpreted in terms of the original qubit indices."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c98e4dda",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "    You may notice that the above mapping is a permutation of the original qubit indices and device qubits with indices larger than 3 are not involved. The reason for choosing such a mapping is to avoid an error of <code>LocalSimulator</code>: the <code>LocalSimulator</code> does not accept non-contiguous qubit indices. On the other hand, the qubit mapping feature of the <code>SamplingBackend</code> accepts such a mapping, as shown below.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b51b2d11",
+   "metadata": {},
+   "source": [
+    "When you apply qubit mapping to devices provided on AWS, you will need to [enable manual qubit allocation by passing disable_qubit_rewiring=True](https://docs.aws.amazon.com/braket/latest/developerguide/braket-constructing-circuit.html#manual-qubit-allocation) to the device. You can specify such an argument (i.e. keyword arguments for `run` method of a `braket.devices.Device` object) via `run_kwargs` argument of the `BraketSamplingBackend` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "5ae085fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Commented out because it requires an access to a real device on AWS\n",
+    "\n",
+    "# device = AwsDevice(\"arn:aws:braket:us-west-1::device/qpu/rigetti/Aspen-M-2\")\n",
+    "# backend = BraketSamplingBackend(\n",
+    "#     device,\n",
+    "#     qubit_mapping={0: 10, 1: 13, 2: 17, 3: 21},\n",
+    "#     run_kwargs={\"disable_qubit_rewiring\": True},\n",
+    "# )\n",
+    "# sampler = create_sampler_from_sampling_backend(backend)\n",
+    "# sampling_result = sampler(circuit, 1000)\n",
+    "# print(sampling_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af882249",
+   "metadata": {},
+   "source": [
+    "## Circuit transpilation before execution\n",
+    "\n",
+    "When the `SamplingBackend` receives an input circuit, it performs circuit transpilation before sending the circuit to its backend since each device can have a different supported gate set. The transpilation performed by default depends on the backend; in the case of `BraketSamplingBackend`, it uses `quri_parts.braket.circuit.BraketTranspiler` for all devices, and also performs some device-specific transpilation defined in `quri_parts.braket.backend.transpiler`. It is possible to change the former one (device-independent transpilation) by supplying `circuit_transpiler` argument to `BraketSamplingBackend`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/braket/quri_parts/braket/backend/sampling.py
+++ b/packages/braket/quri_parts/braket/backend/sampling.py
@@ -53,7 +53,7 @@ class BraketSamplingResult(SamplingResult):
             raise BackendError("No valid measurement results retrieved.")
         m_qubits = self._braket_result.measured_qubits
         digits = np.array([2**q for q in m_qubits])
-        return Counter(np.dot(digits, m) for m in measurements)
+        return Counter(int(np.dot(digits, m)) for m in measurements)
 
 
 class BraketSamplingJob(SamplingJob):

--- a/packages/braket/tests/braket/backend/test_braket_sampling.py
+++ b/packages/braket/tests/braket/backend/test_braket_sampling.py
@@ -61,6 +61,7 @@ class TestBraketSamplingResult:
         result = BraketSamplingResult(braket_result)
         counts = result.counts
         assert counts == {0b00: 2, 0b10: 2}
+        assert all(isinstance(k, int) for k in counts.keys())
 
     def test_large_qubits(self) -> None:
         measurements = np.array(


### PR DESCRIPTION
The keys of a SamplingCounts were `numpy.int64` but should be `int` since we use `int.bit_length()` method when estimating Pauli expectation value.