### PR TITLE
estimator fix for pauli Identity group

### DIFF
--- a/packages/core/quri_parts/core/estimator/sampling/estimator.py
+++ b/packages/core/quri_parts/core/estimator/sampling/estimator.py
@@ -121,8 +121,16 @@ def sampling_estimate(
         if len(op) == 1:
             return _ConstEstimate(const)
 
-    measurements = measurement_factory(op)
-    measurements = [m for m in measurements if m.pauli_set != {PAULI_IDENTITY}]
+    # If there is a standalone Identity group then eliminate, else set const 0.
+    standalone = False
+    measurements = []
+    for m in measurement_factory(op):
+        if m.pauli_set == {PAULI_IDENTITY}:
+            standalone = True
+        else:
+            measurements.append(m)
+    if not standalone:
+        const = 0
 
     pauli_sets = tuple(m.pauli_set for m in measurements)
     shot_allocs = shots_allocator(op, pauli_sets, total_shots)

--- a/packages/core/quri_parts/core/estimator/sampling/estimator.py
+++ b/packages/core/quri_parts/core/estimator/sampling/estimator.py
@@ -115,22 +115,17 @@ def sampling_estimate(
     if len(op) == 0:
         return _ConstEstimate(0.0)
 
-    const: complex = 0.0
-    if PAULI_IDENTITY in op:
-        const = op[PAULI_IDENTITY]
-        if len(op) == 1:
-            return _ConstEstimate(const)
+    if len(op) == 1 and PAULI_IDENTITY in op:
+        return _ConstEstimate(op[PAULI_IDENTITY])
 
     # If there is a standalone Identity group then eliminate, else set const 0.
-    standalone = False
+    const: complex = 0.0
     measurements = []
     for m in measurement_factory(op):
         if m.pauli_set == {PAULI_IDENTITY}:
-            standalone = True
+            const = op[PAULI_IDENTITY]
         else:
             measurements.append(m)
-    if not standalone:
-        const = 0
 
     pauli_sets = tuple(m.pauli_set for m in measurements)
     shot_allocs = shots_allocator(op, pauli_sets, total_shots)


### PR DESCRIPTION
The estimator has an implicit assumption about the Pauli Identity being in a separate group. This has remained consistent over the current bitwise implementation. A grouping that puts the Pauli Identity into a different set is valid and possible. The current implementation of the estimator will incorrectly calculate the Expectation value for the aforementioned case.

The recommended fix was to set `const` to zero whenever the Pauli Identity is not in the standalone group. This PR captures the same.