### PR TITLE
Remodulation of `braket.ht` module as subpart of `braket.backend` 

### DIFF
--- a/packages/braket/quri_parts/braket/__init__.py
+++ b/packages/braket/quri_parts/braket/__init__.py
@@ -7,7 +7,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .ht_grouping import device_connectivity_graph, graph_state_circuit
-
-__all__ = ["graph_state_circuit", "device_connectivity_graph"]

--- a/packages/braket/quri_parts/braket/backend/__init__.py
+++ b/packages/braket/quri_parts/braket/backend/__init__.py
@@ -8,10 +8,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .device import device_connectivity_graph
 from .sampling import BraketSamplingBackend, BraketSamplingJob, BraketSamplingResult
 
 __all__ = [
     "BraketSamplingBackend",
     "BraketSamplingJob",
     "BraketSamplingResult",
+    "device_connectivity_graph",
 ]

--- a/packages/braket/quri_parts/braket/backend/device.py
+++ b/packages/braket/quri_parts/braket/backend/device.py
@@ -10,7 +10,6 @@
 
 import networkx as nx
 from braket.aws import AwsDevice
-from braket.circuits import Circuit
 
 
 def device_connectivity_graph(device: AwsDevice) -> nx.Graph:
@@ -35,33 +34,3 @@ def device_connectivity_graph(device: AwsDevice) -> nx.Graph:
     adj_list = [f"{key} {' '.join(val)}" for key, val in connectivityGraph.items()]
 
     return nx.parse_adjlist(adj_list)
-
-
-def _get_adjacency_list(graph: nx.Graph) -> list[tuple[int, int]]:
-    edge_set = set()
-
-    for edge in graph.edges():
-        # ignoring the weight if any
-        a, b = int(edge[0]), int(edge[1])
-        # ordering to (min, max)
-        a, b = min(a, b), max(a, b)
-
-        if (a, b) not in edge_set:
-            edge_set.add((a, b))
-
-    return list(edge_set)
-
-
-def graph_state_circuit(device: AwsDevice) -> Circuit:
-    graph = device_connectivity_graph(device)
-    num_qubits = getattr(device.properties.paradigm, "qubitCount", -1)
-
-    adj_list = _get_adjacency_list(graph)
-
-    circ = Circuit()
-    for a, b in adj_list:
-        circ.cz(control=a, target=b)
-
-    circ.h(range(num_qubits))
-
-    return circ

--- a/packages/braket/tests/braket/backend/test_device_connectivity.py
+++ b/packages/braket/tests/braket/backend/test_device_connectivity.py
@@ -9,11 +9,9 @@
 # limitations under the License.
 
 import networkx as nx
-import numpy as np
 import pytest
-from braket.circuits import Circuit
 
-from quri_parts.braket import device_connectivity_graph, graph_state_circuit
+from quri_parts.braket.backend import device_connectivity_graph
 
 
 class MockConnectivity:
@@ -38,7 +36,7 @@ class MockHardware:
         self.properties = properties
 
 
-class TestHTDiagonalization:
+class TestDeviceConnectivity:
     def test_adjacency(self) -> None:
         graph = {"0": ["1"], "1": ["0", "2"], "2": ["1", "3"], "3": ["2"]}
         connectivity = MockConnectivity(fullyConnected=False, graph=graph)
@@ -55,19 +53,6 @@ class TestHTDiagonalization:
 
         print(received_graph.edges, constructed_graph.edges)
         assert nx.is_isomorphic(received_graph, constructed_graph)
-
-    def test_graph_circuit(self) -> None:
-        graph = {"0": ["1"], "1": ["0"]}
-        connectivity = MockConnectivity(fullyConnected=False, graph=graph)
-        paradigm = MockParadigm(connectivity, qubitCount=2)
-        properties = MockProperties(paradigm)
-        device = MockHardware(properties)
-
-        circuit = graph_state_circuit(device)
-
-        correct_circuit = Circuit().cz(0, 1).h(0).h(1)
-
-        np.testing.assert_equal(circuit, correct_circuit)
 
     def test_fully_connected_graph(self) -> None:
         connectivity = MockConnectivity(fullyConnected=True, graph={})


### PR DESCRIPTION
The original `braket.ht` module had two functionalities, namely `graph_state_circuit` and `device_connectivity_graph`. These two functionalities are tackled as follows:

- `graph_state_circuit` was a function that constructed the required circuit for HT in the `braket` framework. This can be removed as the circuit can be implemented in native `qp` and then converted to `braket` if necessary. The required circuit has already been made available in the `ht` module.
- `device_connectivity_graph` is a backend-specific functionality that can be moved to `braket.backend` as it is independent of the process that demands the same.