### PR TITLE
Add `gates_and_params` property to `UnboundParametricQuantumCircuitBase`

### DIFF
--- a/packages/circuit/quri_parts/circuit/circuit_parametric.py
+++ b/packages/circuit/quri_parts/circuit/circuit_parametric.py
@@ -151,6 +151,15 @@ class UnboundParametricQuantumCircuitBase(UnboundParametricQuantumCircuitProtoco
         return [gate for gate, _ in self._gates]
 
     @property
+    def gates_and_params(
+        self,
+    ) -> Sequence[
+        Union[tuple[QuantumGate, None], tuple[ParametricQuantumGate, Parameter]]
+    ]:
+        """Returns the sequence of the tuples of gate and it's parameter."""
+        return tuple(self._gates)
+
+    @property
     def has_trivial_parameter_mapping(self) -> bool:
         return True
 


### PR DESCRIPTION
`~UnboundParametricQuantumCircuit` doesn't provide the way to access gate parameters of the circuit with public property or variable. Here we add `gates_and_params` property to `UnboundParametricQuantumCircuitBase`