### PR TITLE
Transpiler to decompose single qubit UnitaryMatrix gates into RY and RZ gates

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -59,6 +59,7 @@ from .transpiler import (
     ParallelDecomposer,
     SequentialTranspiler,
 )
+from .unitary_matrix_decomposer import SingleQubitUnitaryMatrix2RYRZ
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only X, SqrtX, CNOT, and RZ.
@@ -153,6 +154,7 @@ __all__ = [
     "RY2RZSqrtXTranspiler",
     "S2RZTranspiler",
     "Sdag2RZTranspiler",
+    "SingleQubitUnitaryMatrix2RYRZ",
     "SqrtX2RXTranspiler",
     "SqrtX2RZHTranspiler",
     "SqrtXdag2RXTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -59,7 +59,10 @@ from .transpiler import (
     ParallelDecomposer,
     SequentialTranspiler,
 )
-from .unitary_matrix_decomposer import SingleQubitUnitaryMatrix2RYRZTranspiler
+from .unitary_matrix_decomposer import (
+    SingleQubitUnitaryMatrix2RYRZTranspiler,
+    su2_decompose,
+)
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only X, SqrtX, CNOT, and RZ.
@@ -178,4 +181,5 @@ __all__ = [
     "Y2RZXTranspiler",
     "Z2HXTranspiler",
     "Z2RZTranspiler",
+    "su2_decompose",
 ]

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -59,7 +59,7 @@ from .transpiler import (
     ParallelDecomposer,
     SequentialTranspiler,
 )
-from .unitary_matrix_decomposer import SingleQubitUnitaryMatrix2RYRZ
+from .unitary_matrix_decomposer import SingleQubitUnitaryMatrix2RYRZTranspiler
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only X, SqrtX, CNOT, and RZ.
@@ -154,7 +154,7 @@ __all__ = [
     "RY2RZSqrtXTranspiler",
     "S2RZTranspiler",
     "Sdag2RZTranspiler",
-    "SingleQubitUnitaryMatrix2RYRZ",
+    "SingleQubitUnitaryMatrix2RYRZTranspiler",
     "SqrtX2RXTranspiler",
     "SqrtX2RZHTranspiler",
     "SqrtXdag2RXTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -90,7 +90,7 @@ class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
     Ref:
         [1]: Tomonori Shirakawa, Hiroshi Ueda, and Seiji Yunoki,
             Automatic quantum circuit encoding of a given arbitrary quantum state,
-            arXiv:2112.14524, p.22, (2021).
+            arXiv:2112.14524v1, p.22, (2021).
     """
 
     def is_target_gate(self, gate: QuantumGate) -> bool:

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -46,7 +46,7 @@ class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
         self, v: Sequence[Sequence[complex]], eps: float = 1.0e-15
     ) -> Sequence[float]:
 
-        if abs(v[0][1]) < eps or abs(v[1][0]) < eps:
+        if abs(v[0][1]) < eps and abs(v[1][0]) < eps:
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(v[0][0] * v[1][1])).real
             theta[1] = (1j * cmath.log(v[0][0] / v[1][1])).real
@@ -62,7 +62,7 @@ class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
 
             return tuple(theta)
 
-        elif abs(v[0][0]) < eps or abs(v[1][1]) < eps:
+        elif abs(v[0][0]) < eps and abs(v[1][1]) < eps:
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(-v[1][0] * v[0][1])).real
             theta[1] = (1j * cmath.log(-v[1][0] / v[0][1])).real

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -8,17 +8,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cmath
+import math
 from collections.abc import Sequence
 
 import numpy as np
-import math
-import cmath
 
 from quri_parts.circuit import QuantumGate, gate_names, gates
+
 from .transpiler import GateDecomposer
 
 
-class SingleQubitUnitaryMatrixTranspiler(GateDecomposer):
+class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
     def is_target_gate(self, gate: QuantumGate) -> bool:
         return gate.name == gate_names.UnitaryMatrix and len(gate.target_indices) == 1
 
@@ -33,9 +34,9 @@ class SingleQubitUnitaryMatrixTranspiler(GateDecomposer):
             gates.RZ(target, theta[3]),
         ]
 
-    def _su2_decompose(v: Sequence[Sequence[complex]]) -> Sequence[complex]:
-        eps = 1.0e-15
-
+    def _su2_decompose(
+        self, v: Sequence[Sequence[complex]], eps: float = 1.0e-15
+    ) -> Sequence[float]:
         # if abs(v[0][1]) < eps and abs(v[1][0]) < eps and abs(v[0][0] * v[1][1]) > 0:
         if abs(v[0][1]) < eps or abs(v[1][0]) < eps:
             theta = np.zeros(4)
@@ -52,7 +53,7 @@ class SingleQubitUnitaryMatrixTranspiler(GateDecomposer):
             m[1] = (a - b) / 2
             theta += np.pi * m
 
-            return tuple(map(tuple, theta))
+            return tuple(theta)
         # elif abs(v[0][0]) < eps and abs(v[1][1]) < eps and abs(v[0][1] * v[1][0]) > 0:
         elif abs(v[0][0]) < eps or abs(v[1][1]) < eps:
             theta = np.zeros(4)
@@ -68,7 +69,7 @@ class SingleQubitUnitaryMatrixTranspiler(GateDecomposer):
             m[1] = (a - b) / 2
             theta += np.pi * m
 
-            return tuple(map(tuple, theta))
+            return tuple(theta)
         else:
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(v[0][0] * v[1][1] - v[1][0] * v[0][1])).real
@@ -104,4 +105,4 @@ class SingleQubitUnitaryMatrixTranspiler(GateDecomposer):
             m[3] = (a - b) / 2
             theta += np.pi / 2 * m
 
-            return tuple(map(tuple, theta))
+            return tuple(theta)

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -50,8 +50,6 @@ class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(v[0][0] * v[1][1])).real
             theta[1] = (1j * cmath.log(v[0][0] / v[1][1])).real
-            theta[2] = 0
-            theta[3] = 0
 
             m = np.zeros(4)
             a = (cmath.phase(v[0][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
@@ -67,7 +65,6 @@ class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
             theta[0] = (1j * cmath.log(-v[1][0] * v[0][1])).real
             theta[1] = (1j * cmath.log(-v[1][0] / v[0][1])).real
             theta[2] = np.pi
-            theta[3] = 0
 
             m = np.zeros(4)
             a = (cmath.phase(v[1][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
@@ -82,9 +79,7 @@ class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(v[0][0] * v[1][1] - v[1][0] * v[0][1])).real
             theta[1] = (0.5j * cmath.log(-v[0][0] * v[1][0] / (v[1][1] * v[0][1]))).real
-            if abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]) > 1:
-                theta[2] = 0
-            else:
+            if abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]) <= 1:
                 theta[2] = math.acos(abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]))
             theta[3] = (0.5j * cmath.log(-v[0][0] * v[0][1] / (v[1][1] * v[1][0]))).real
 

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -1,0 +1,107 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Sequence
+
+import numpy as np
+import math
+import cmath
+
+from quri_parts.circuit import QuantumGate, gate_names, gates
+from .transpiler import GateDecomposer
+
+
+class SingleQubitUnitaryMatrixTranspiler(GateDecomposer):
+    def is_target_gate(self, gate: QuantumGate) -> bool:
+        return gate.name == gate_names.UnitaryMatrix and len(gate.target_indices) == 1
+
+    def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
+        theta = self._su2_decompose(gate.unitary_matrix)
+        # phase = math.cos(theta[0] / 2) - 1j * math.sin(theta[0] / 2)
+
+        target = gate.target_indices[0]
+        return [
+            gates.RZ(target, theta[1]),
+            gates.RY(target, theta[2]),
+            gates.RZ(target, theta[3]),
+        ]
+
+    def _su2_decompose(v: Sequence[Sequence[complex]]) -> Sequence[complex]:
+        eps = 1.0e-15
+
+        # if abs(v[0][1]) < eps and abs(v[1][0]) < eps and abs(v[0][0] * v[1][1]) > 0:
+        if abs(v[0][1]) < eps or abs(v[1][0]) < eps:
+            theta = np.zeros(4)
+            theta[0] = (1j * cmath.log(v[0][0] * v[1][1])).real
+            theta[1] = (1j * cmath.log(v[0][0] / v[1][1])).real
+            # theta[1] = (2j * cmath.log(v[0][0] / v[1][1])).real
+            theta[2] = 0
+            theta[3] = 0
+
+            m = np.zeros(4)
+            a = (cmath.phase(v[0][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
+            b = (cmath.phase(v[1][1]) + (theta[0] - theta[1]) / 2) / (-np.pi / 2)
+            m[0] = (a + b) / 2
+            m[1] = (a - b) / 2
+            theta += np.pi * m
+
+            return tuple(map(tuple, theta))
+        # elif abs(v[0][0]) < eps and abs(v[1][1]) < eps and abs(v[0][1] * v[1][0]) > 0:
+        elif abs(v[0][0]) < eps or abs(v[1][1]) < eps:
+            theta = np.zeros(4)
+            theta[0] = (1j * cmath.log(-v[1][0] * v[0][1])).real
+            theta[1] = (1j * cmath.log(-v[1][0] / v[0][1])).real
+            theta[2] = np.pi
+            theta[3] = 0
+
+            m = np.zeros(4)
+            a = (cmath.phase(v[1][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
+            b = (cmath.phase(-v[0][1]) + (theta[0] - theta[1]) / 2) / (-np.pi / 2)
+            m[0] = (a + b) / 2
+            m[1] = (a - b) / 2
+            theta += np.pi * m
+
+            return tuple(map(tuple, theta))
+        else:
+            theta = np.zeros(4)
+            theta[0] = (1j * cmath.log(v[0][0] * v[1][1] - v[1][0] * v[0][1])).real
+            theta[1] = (0.5j * cmath.log(-v[0][0] * v[1][0] / (v[1][1] * v[0][1]))).real
+            if abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]) > 1:
+                theta[2] = 0
+            else:
+                theta[2] = math.acos(abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]))
+            theta[3] = (0.5j * cmath.log(-v[0][0] * v[0][1] / (v[1][1] * v[1][0]))).real
+            # theta[1] = (1j * cmath.log(-v[0][0] * v[1][0] / (v[1][1] * v[0][1]))).real
+            # theta[2] = math.acos(0.5j * abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]))
+            # theta[3] = (1j * cmath.log(-v[0][0] * v[0][1] / (v[1][1] * v[1][0]))).real
+
+            m = np.zeros(4)
+            if abs(abs(v[0][0]) - math.cos(theta[2] / 2)) > abs(
+                abs(v[0][0]) - math.sin(theta[2] / 2)
+            ):
+                theta[2] = np.pi - theta[2]
+            a = (cmath.phase(v[0][0]) + (theta[0] + theta[3] + theta[1]) / 2) / (
+                -np.pi / 4
+            )
+            b = (cmath.phase(v[1][0]) + (theta[0] - theta[3] + theta[1]) / 2) / (
+                -np.pi / 4
+            )
+            c = (cmath.phase(-v[0][1]) + (theta[0] + theta[3] - theta[1]) / 2) / (
+                -np.pi / 4
+            )
+            # d = (cmath.phase(v[1][1]) + (theta[0] - theta[3] - theta[1]) / 2) / (
+            #     -np.pi / 4
+            # )
+            m[0] = (b + c) / 2
+            m[1] = (a - c) / 2
+            m[3] = (a - b) / 2
+            theta += np.pi / 2 * m
+
+            return tuple(map(tuple, theta))

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -36,7 +36,7 @@ def su2_decompose(
         m[1] = (a - b) / 2
         theta += np.pi * m
 
-        return tuple(theta)
+        return theta
 
     elif abs(ut[0][0]) < eps and abs(ut[1][1]) < eps:
         theta = np.zeros(4)
@@ -51,7 +51,7 @@ def su2_decompose(
         m[1] = (a - b) / 2
         theta += np.pi * m
 
-        return tuple(theta)
+        return theta
 
     else:
         theta = np.zeros(4)
@@ -80,7 +80,7 @@ def su2_decompose(
         m[3] = (a - b) / 2
         theta += np.pi / 2 * m
 
-        return tuple(theta)
+        return theta
 
 
 class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -19,7 +19,16 @@ from quri_parts.circuit import QuantumGate, gate_names, gates
 from .transpiler import GateDecomposer
 
 
-class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
+class SingleQubitUnitaryMatrix2RYRZTranspiler(GateDecomposer):
+    """CircuitTranspiler, which decomposes single qubit UnitaryMatrix gates
+    into gate sequences containing RY and RZ gates.
+
+    Ref:
+        [1]: Tomonori Shirakawa, Hiroshi Ueda, and Seiji Yunoki,
+            Automatic quantum circuit encoding of a given arbitrary quantum state,
+            arXiv:2112.14524, (2021).
+    """
+
     def is_target_gate(self, gate: QuantumGate) -> bool:
         return gate.name == gate_names.UnitaryMatrix and len(gate.target_indices) == 1
 

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -13,6 +13,7 @@ import math
 from collections.abc import Sequence
 
 import numpy as np
+import numpy.typing as npt
 
 from quri_parts.circuit import QuantumGate, gate_names, gates
 
@@ -20,32 +21,32 @@ from .transpiler import GateDecomposer
 
 
 def su2_decompose(
-    v: Sequence[Sequence[complex]], eps: float = 1.0e-15
-) -> Sequence[float]:
+    ut: Sequence[Sequence[complex]], eps: float = 1e-15
+) -> npt.NDArray[np.float64]:
 
-    if abs(v[0][1]) < eps and abs(v[1][0]) < eps:
+    if abs(ut[0][1]) < eps and abs(ut[1][0]) < eps:
         theta = np.zeros(4)
-        theta[0] = (1j * cmath.log(v[0][0] * v[1][1])).real
-        theta[1] = (1j * cmath.log(v[0][0] / v[1][1])).real
+        theta[0] = (1j * cmath.log(ut[0][0] * ut[1][1])).real
+        theta[1] = (1j * cmath.log(ut[0][0] / ut[1][1])).real
 
         m = np.zeros(4)
-        a = (cmath.phase(v[0][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
-        b = (cmath.phase(v[1][1]) + (theta[0] - theta[1]) / 2) / (-np.pi / 2)
+        a = (cmath.phase(ut[0][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
+        b = (cmath.phase(ut[1][1]) + (theta[0] - theta[1]) / 2) / (-np.pi / 2)
         m[0] = (a + b) / 2
         m[1] = (a - b) / 2
         theta += np.pi * m
 
         return tuple(theta)
 
-    elif abs(v[0][0]) < eps and abs(v[1][1]) < eps:
+    elif abs(ut[0][0]) < eps and abs(ut[1][1]) < eps:
         theta = np.zeros(4)
-        theta[0] = (1j * cmath.log(-v[1][0] * v[0][1])).real
-        theta[1] = (1j * cmath.log(-v[1][0] / v[0][1])).real
+        theta[0] = (1j * cmath.log(-ut[1][0] * ut[0][1])).real
+        theta[1] = (1j * cmath.log(-ut[1][0] / ut[0][1])).real
         theta[2] = np.pi
 
         m = np.zeros(4)
-        a = (cmath.phase(v[1][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
-        b = (cmath.phase(-v[0][1]) + (theta[0] - theta[1]) / 2) / (-np.pi / 2)
+        a = (cmath.phase(ut[1][0]) + (theta[0] + theta[1]) / 2) / (-np.pi / 2)
+        b = (cmath.phase(-ut[0][1]) + (theta[0] - theta[1]) / 2) / (-np.pi / 2)
         m[0] = (a + b) / 2
         m[1] = (a - b) / 2
         theta += np.pi * m
@@ -54,20 +55,24 @@ def su2_decompose(
 
     else:
         theta = np.zeros(4)
-        theta[0] = (1j * cmath.log(v[0][0] * v[1][1] - v[1][0] * v[0][1])).real
-        theta[1] = (0.5j * cmath.log(-v[0][0] * v[1][0] / (v[1][1] * v[0][1]))).real
-        if abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]) <= 1:
-            theta[2] = math.acos(abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]))
-        theta[3] = (0.5j * cmath.log(-v[0][0] * v[0][1] / (v[1][1] * v[1][0]))).real
+        theta[0] = (1j * cmath.log(ut[0][0] * ut[1][1] - ut[1][0] * ut[0][1])).real
+        theta[1] = (0.5j * cmath.log(-ut[0][0] * ut[1][0] / (ut[1][1] * ut[0][1]))).real
+        if abs(ut[0][0] * ut[1][1] + ut[1][0] * ut[0][1]) <= 1:
+            theta[2] = math.acos(abs(ut[0][0] * ut[1][1] + ut[1][0] * ut[0][1]))
+        theta[3] = (0.5j * cmath.log(-ut[0][0] * ut[0][1] / (ut[1][1] * ut[1][0]))).real
 
         m = np.zeros(4)
-        if abs(abs(v[0][0]) - math.cos(theta[2] / 2)) > abs(
-            abs(v[0][0]) - math.sin(theta[2] / 2)
+        if abs(abs(ut[0][0]) - math.cos(theta[2] / 2)) > abs(
+            abs(ut[0][0]) - math.sin(theta[2] / 2)
         ):
             theta[2] = np.pi - theta[2]
-        a = (cmath.phase(v[0][0]) + (theta[0] + theta[3] + theta[1]) / 2) / (-np.pi / 4)
-        b = (cmath.phase(v[1][0]) + (theta[0] - theta[3] + theta[1]) / 2) / (-np.pi / 4)
-        c = (cmath.phase(-v[0][1]) + (theta[0] + theta[3] - theta[1]) / 2) / (
+        a = (cmath.phase(ut[0][0]) + (theta[0] + theta[3] + theta[1]) / 2) / (
+            -np.pi / 4
+        )
+        b = (cmath.phase(ut[1][0]) + (theta[0] - theta[3] + theta[1]) / 2) / (
+            -np.pi / 4
+        )
+        c = (cmath.phase(-ut[0][1]) + (theta[0] + theta[3] - theta[1]) / 2) / (
             -np.pi / 4
         )
         m[0] = (b + c) / 2

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -24,7 +24,7 @@ def su2_decompose(
     ut: Sequence[Sequence[complex]], eps: float = 1e-15
 ) -> npt.NDArray[np.float64]:
 
-    if abs(ut[0][1]) < eps and abs(ut[1][0]) < eps:
+    if abs(ut[0][1]) < eps or abs(ut[1][0]) < eps:
         theta = np.zeros(4)
         theta[0] = (1j * cmath.log(ut[0][0] * ut[1][1])).real
         theta[1] = (1j * cmath.log(ut[0][0] / ut[1][1])).real
@@ -38,7 +38,7 @@ def su2_decompose(
 
         return theta
 
-    elif abs(ut[0][0]) < eps and abs(ut[1][1]) < eps:
+    elif abs(ut[0][0]) < eps or abs(ut[1][1]) < eps:
         theta = np.zeros(4)
         theta[0] = (1j * cmath.log(-ut[1][0] * ut[0][1])).real
         theta[1] = (1j * cmath.log(-ut[1][0] / ut[0][1])).real

--- a/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/unitary_matrix_decomposer.py
@@ -25,7 +25,6 @@ class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
         theta = self._su2_decompose(gate.unitary_matrix)
-        # phase = math.cos(theta[0] / 2) - 1j * math.sin(theta[0] / 2)
 
         target = gate.target_indices[0]
         return [
@@ -37,12 +36,11 @@ class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
     def _su2_decompose(
         self, v: Sequence[Sequence[complex]], eps: float = 1.0e-15
     ) -> Sequence[float]:
-        # if abs(v[0][1]) < eps and abs(v[1][0]) < eps and abs(v[0][0] * v[1][1]) > 0:
+
         if abs(v[0][1]) < eps or abs(v[1][0]) < eps:
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(v[0][0] * v[1][1])).real
             theta[1] = (1j * cmath.log(v[0][0] / v[1][1])).real
-            # theta[1] = (2j * cmath.log(v[0][0] / v[1][1])).real
             theta[2] = 0
             theta[3] = 0
 
@@ -54,7 +52,7 @@ class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
             theta += np.pi * m
 
             return tuple(theta)
-        # elif abs(v[0][0]) < eps and abs(v[1][1]) < eps and abs(v[0][1] * v[1][0]) > 0:
+
         elif abs(v[0][0]) < eps or abs(v[1][1]) < eps:
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(-v[1][0] * v[0][1])).real
@@ -70,6 +68,7 @@ class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
             theta += np.pi * m
 
             return tuple(theta)
+
         else:
             theta = np.zeros(4)
             theta[0] = (1j * cmath.log(v[0][0] * v[1][1] - v[1][0] * v[0][1])).real
@@ -79,9 +78,6 @@ class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
             else:
                 theta[2] = math.acos(abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]))
             theta[3] = (0.5j * cmath.log(-v[0][0] * v[0][1] / (v[1][1] * v[1][0]))).real
-            # theta[1] = (1j * cmath.log(-v[0][0] * v[1][0] / (v[1][1] * v[0][1]))).real
-            # theta[2] = math.acos(0.5j * abs(v[0][0] * v[1][1] + v[1][0] * v[0][1]))
-            # theta[3] = (1j * cmath.log(-v[0][0] * v[0][1] / (v[1][1] * v[1][0]))).real
 
             m = np.zeros(4)
             if abs(abs(v[0][0]) - math.cos(theta[2] / 2)) > abs(
@@ -97,9 +93,6 @@ class SingleQubitUnitaryMatrix2RYRZ(GateDecomposer):
             c = (cmath.phase(-v[0][1]) + (theta[0] + theta[3] - theta[1]) / 2) / (
                 -np.pi / 4
             )
-            # d = (cmath.phase(v[1][1]) + (theta[0] - theta[3] - theta[1]) / 2) / (
-            #     -np.pi / 4
-            # )
             m[0] = (b + c) / 2
             m[1] = (a - c) / 2
             m[3] = (a - b) / 2

--- a/packages/circuit/tests/circuit/transpile/test_unitary_matrix_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_unitary_matrix_decomposer.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from quri_parts.circuit import RY, RZ, QuantumCircuit, QuantumGate
+from quri_parts.circuit.transpile import SingleQubitUnitaryMatrix2RYRZ
+
+
+def _assert_params_close(x: QuantumGate, y: QuantumGate) -> None:
+    assert (
+        x.name == y.name
+        and x.target_indices == y.target_indices
+        and x.control_indices == y.control_indices
+        and np.allclose(x.params, y.params)
+        and x.pauli_ids == y.pauli_ids
+        and x.unitary_matrix == y.unitary_matrix
+    )
+
+
+class TestSingleQubitDecompose:
+    def test_id_decompose(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_SingleQubitUnitaryMatrix_gate(0, [[1, 0], [0, 1]])
+        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                RZ(0, 0.0),
+                RY(0, 0.0),
+                RZ(0, 0.0),
+            ]
+        )
+
+        assert transpiled == expect
+
+    def test_x_decompose(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_SingleQubitUnitaryMatrix_gate(0, [[0, 1], [1, 0]])
+        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                RZ(0, np.pi),
+                RY(0, np.pi),
+                RZ(0, 0),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            _assert_params_close(t, e)
+
+    def test_h_decompose(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_SingleQubitUnitaryMatrix_gate(
+            0, 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])
+        )
+        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                RZ(0, np.pi),
+                RY(0, np.pi / 2),
+                RZ(0, 0),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            _assert_params_close(t, e)
+
+    def test_fixed_decompose(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_SingleQubitUnitaryMatrix_gate(
+            0,
+            [
+                [-0.74161209 - 0.58511358j, 0.32678536 - 0.02940967j],
+                [-0.14825031 - 0.29270369j, -0.88922216 - 0.31879516j],
+            ],
+        )
+        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                RZ(0, 5.525447921071612),
+                RY(0, 0.6685959371692511),
+                RZ(0, 0.43399113617430446),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            _assert_params_close(t, e)

--- a/packages/circuit/tests/circuit/transpile/test_unitary_matrix_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_unitary_matrix_decomposer.py
@@ -59,6 +59,23 @@ class TestSingleQubitDecompose:
         for t, e in zip(transpiled.gates, expect.gates):
             _assert_params_close(t, e)
 
+    def test_y_decompose(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_SingleQubitUnitaryMatrix_gate(0, [[0, -1j], [1j, 0]])
+        transpiled = SingleQubitUnitaryMatrix2RYRZTranspiler()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                RZ(0, 0),
+                RY(0, np.pi),
+                RZ(0, 0),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            _assert_params_close(t, e)
+
     def test_h_decompose(self) -> None:
         circuit = QuantumCircuit(1)
         circuit.add_SingleQubitUnitaryMatrix_gate(
@@ -71,6 +88,25 @@ class TestSingleQubitDecompose:
             [
                 RZ(0, np.pi),
                 RY(0, np.pi / 2),
+                RZ(0, 0),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            _assert_params_close(t, e)
+
+    def test_t_decompose(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_SingleQubitUnitaryMatrix_gate(
+            0, [[1, 0], [0, np.cos(np.pi / 4) + 1j * np.sin(np.pi / 4)]]
+        )
+        transpiled = SingleQubitUnitaryMatrix2RYRZTranspiler()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                RZ(0, np.pi / 4),
+                RY(0, 0),
                 RZ(0, 0),
             ]
         )

--- a/packages/circuit/tests/circuit/transpile/test_unitary_matrix_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_unitary_matrix_decomposer.py
@@ -11,7 +11,7 @@
 import numpy as np
 
 from quri_parts.circuit import RY, RZ, QuantumCircuit, QuantumGate
-from quri_parts.circuit.transpile import SingleQubitUnitaryMatrix2RYRZ
+from quri_parts.circuit.transpile import SingleQubitUnitaryMatrix2RYRZTranspiler
 
 
 def _assert_params_close(x: QuantumGate, y: QuantumGate) -> None:
@@ -29,7 +29,7 @@ class TestSingleQubitDecompose:
     def test_id_decompose(self) -> None:
         circuit = QuantumCircuit(1)
         circuit.add_SingleQubitUnitaryMatrix_gate(0, [[1, 0], [0, 1]])
-        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+        transpiled = SingleQubitUnitaryMatrix2RYRZTranspiler()(circuit)
 
         expect = QuantumCircuit(1)
         expect.extend(
@@ -45,7 +45,7 @@ class TestSingleQubitDecompose:
     def test_x_decompose(self) -> None:
         circuit = QuantumCircuit(1)
         circuit.add_SingleQubitUnitaryMatrix_gate(0, [[0, 1], [1, 0]])
-        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+        transpiled = SingleQubitUnitaryMatrix2RYRZTranspiler()(circuit)
 
         expect = QuantumCircuit(1)
         expect.extend(
@@ -64,7 +64,7 @@ class TestSingleQubitDecompose:
         circuit.add_SingleQubitUnitaryMatrix_gate(
             0, 1 / np.sqrt(2) * np.array([[1, 1], [1, -1]])
         )
-        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+        transpiled = SingleQubitUnitaryMatrix2RYRZTranspiler()(circuit)
 
         expect = QuantumCircuit(1)
         expect.extend(
@@ -87,7 +87,7 @@ class TestSingleQubitDecompose:
                 [-0.14825031 - 0.29270369j, -0.88922216 - 0.31879516j],
             ],
         )
-        transpiled = SingleQubitUnitaryMatrix2RYRZ()(circuit)
+        transpiled = SingleQubitUnitaryMatrix2RYRZTranspiler()(circuit)
 
         expect = QuantumCircuit(1)
         expect.extend(


### PR DESCRIPTION
- Added a transpiler to decompose single qubit `UntiaryMatrix` gates into gate sequences containing `RY` and `RZ` gates
- Test cases check the parameters after the transformation with `UnitaryMatrix` gates corresponding to I, X, Y, H, T gates and one deterministic numerical gate
  - These gates are selected to cover a wide range of patterns with 0 matrix elements and 0 rotation angles for the resulting RY and RZ gates
- In porting, the matrix representation of circuits before and after the conversion is verified numerically in some random cases

*References*

- The original paper is here and is listed as a reference in the docstring
  - https://arxiv.org/abs/2112.14524v1 (p.22)