### PR TITLE
add comma to OpenQASM's two-qubit gate instructions

### DIFF
--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -143,7 +143,7 @@ def convert_gate_to_qasm_line(gate: "QuantumGate") -> str:
                 _ref_q_str(i)
                 for i in tuple(gate.control_indices) + tuple(gate.target_indices)
             ]
-            return f"{gate_str} {c_q_str} {t_q_str};"
+            return f"{gate_str} {c_q_str}, {t_q_str};"
 
     elif is_parametric_gate_name(gate.name):
         raise ValueError("Parametric gates are not supported.")

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
@@ -72,17 +72,17 @@ class TestConvertGate:
 
     def test_cnot_gate(self) -> None:
         g = gates.CNOT(123, 456)
-        qasm_expected = "cx q[123] q[456];"
+        qasm_expected = "cx q[123], q[456];"
         assert convert_gate_to_qasm_line(g) == qasm_expected
 
     def test_cz_gate(self) -> None:
         g = gates.CZ(123, 456)
-        qasm_expected = "cz q[123] q[456];"
+        qasm_expected = "cz q[123], q[456];"
         assert convert_gate_to_qasm_line(g) == qasm_expected
 
     def test_swap_gate(self) -> None:
         g = gates.SWAP(123, 456)
-        qasm_expected = "swap q[123] q[456];"
+        qasm_expected = "swap q[123], q[456];"
         assert convert_gate_to_qasm_line(g) == qasm_expected
 
     def test_u1_gate(self) -> None:


### PR DESCRIPTION
I fix  #22
Please review and merge this. 