### PR TITLE
Add Identity to RZ transpiler

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -17,6 +17,7 @@ from .gate_kind_decomposer import (
     CZ2RXRYCNOTTranspiler,
     H2RXRYTranspiler,
     H2RZSqrtXTranspiler,
+    Identity2RZTranspiler,
     RX2RZSqrtXTranspiler,
     RY2RZSqrtXTranspiler,
     S2RZTranspiler,
@@ -79,6 +80,7 @@ RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
         ),
         ParallelDecomposer(
             [
+                Identity2RZTranspiler(),
                 Y2RZXTranspiler(),
                 Z2RZTranspiler(),
                 H2RZSqrtXTranspiler(),
@@ -114,6 +116,7 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
         ),
         ParallelDecomposer(
             [
+                Identity2RZTranspiler(),
                 H2RXRYTranspiler(),
                 X2RXTranspiler(),
                 Y2RYTranspiler(),
@@ -148,6 +151,7 @@ __all__ = [
     "RotationSetTranspiler",
     "CliffordApproximationTranspiler",
     "IdentityInsertionTranspiler",
+    "Identity2RZTranspiler",
     "PauliDecomposeTranspiler",
     "PauliRotationDecomposeTranspiler",
     "CNOT2CZHTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/gate_kind_decomposer.py
+++ b/packages/circuit/quri_parts/circuit/transpile/gate_kind_decomposer.py
@@ -103,6 +103,18 @@ class H2RXRYTranspiler(GateKindDecomposer):
         ]
 
 
+class Identity2RZTranspiler(GateKindDecomposer):
+    """CircuitTranspiler, which converts Identity gates into RZ gates."""
+
+    @property
+    def target_gate_names(self) -> Sequence[str]:
+        return [gate_names.Identity]
+
+    def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
+        target = gate.target_indices[0]
+        return [gates.RZ(target, 0.0)]
+
+
 class RX2RZSqrtXTranspiler(GateKindDecomposer):
     """CircuitTranspiler, which decomposes RX gates into sequences of RZ and
     SqrtX gates."""

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -13,6 +13,7 @@ import numpy as np
 from quri_parts.circuit import (
     CNOT,
     CZ,
+    Identity,
     RX,
     RY,
     RZ,
@@ -42,6 +43,7 @@ from quri_parts.circuit.transpile import (
     CZ2RXRYCNOTTranspiler,
     H2RXRYTranspiler,
     H2RZSqrtXTranspiler,
+    Identity2RZTranspiler,
     RX2RZSqrtXTranspiler,
     RY2RZSqrtXTranspiler,
     RZSetTranspiler,
@@ -137,6 +139,16 @@ class TestFTQCSetTranspile:
 
 
 class TestRZSetTranspile:
+    def test_identity2rz_transpile(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.add_gate(Identity(0))
+        transpiled = Identity2RZTranspiler()(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend([RZ(0, 0.0)])
+
+        assert transpiled.gates == expect.gates
+
     def test_h2rzsqrtx_transpile(self) -> None:
         circuit = QuantumCircuit(1)
         circuit.add_gate(H(0))
@@ -358,6 +370,7 @@ class TestRZSetTranspile:
         circuit = QuantumCircuit(3)
         circuit.extend(
             [
+                Identity(2),
                 X(0),
                 Y(1),
                 Z(2),
@@ -385,6 +398,7 @@ class TestRZSetTranspile:
         expect = QuantumCircuit(3)
         expect.extend(
             [
+                RZ(2, 0.0),  # Idenitty
                 X(0),  # X
                 RZ(1, -np.pi),  # Y
                 X(1),

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -13,7 +13,6 @@ import numpy as np
 from quri_parts.circuit import (
     CNOT,
     CZ,
-    Identity,
     RX,
     RY,
     RZ,
@@ -23,6 +22,7 @@ from quri_parts.circuit import (
     U2,
     U3,
     H,
+    Identity,
     Pauli,
     PauliRotation,
     QuantumCircuit,


### PR DESCRIPTION
- Add `Identity2RZTranspiler`, which converts `Identity` gates into `RZ` gates
- Add `Identity2RZTranspiler` to `RZSetTranspiler` and `RotationSetTranspiler`
  - This change effects `IonQSetTranspiler` and `HoneywellSetTranspiler` too via `RotationSetTranspiler`