### PR TITLE
AllSinglesDoubles ansatz

### DIFF
--- a/packages/chem/quri_parts/chem/ansatz/__init__.py
+++ b/packages/chem/quri_parts/chem/ansatz/__init__.py
@@ -1,0 +1,3 @@
+from .all_singles_doubles import AllSinglesDoubles
+
+__all__ = ["AllSinglesDoubles"]

--- a/packages/chem/quri_parts/chem/ansatz/all_singles_doubles.py
+++ b/packages/chem/quri_parts/chem/ansatz/all_singles_doubles.py
@@ -1,0 +1,63 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from quri_parts.chem.utils.excitations import (
+    add_double_excitation_circuit,
+    add_single_excitation_circuit,
+    excitations,
+)
+from quri_parts.circuit import (
+    ImmutableLinearMappedUnboundParametricQuantumCircuit,
+    LinearMappedUnboundParametricQuantumCircuit,
+)
+
+
+class AllSinglesDoubles(ImmutableLinearMappedUnboundParametricQuantumCircuit):
+    """Parametric quantum circuit consists of single excitation and double
+    excitation.
+
+    Note that this circuit conserves the particle number and spins
+    only if the state applied to is represented based on the Jordan-Wigner
+    transformation.
+
+    Ref:
+        PennyLane's documentations,
+        `qml.AllSinglesDoubles <https://docs.pennylane.ai/en/stable/code/
+        api/pennylane.AllSinglesDoubles.html>`_
+
+    Args:
+        n_spin_orbitals: Number of spin orbitals.
+        n_fermions: Number of fermions.
+    """
+
+    def __init__(
+        self,
+        n_spin_orbitals: int,
+        n_fermions: int,
+    ):
+        single_excitations, double_excitations = excitations(
+            n_spin_orbitals, n_fermions
+        )
+
+        circuit = LinearMappedUnboundParametricQuantumCircuit(n_spin_orbitals)
+        s_exc_params = circuit.add_parameters(
+            *[f"theta_s_{i}" for i in range(len(single_excitations))]
+        )
+        d_exc_params = circuit.add_parameters(
+            *[f"phi_d_{i}" for i in range(len(double_excitations))]
+        )
+
+        for d_exc, d_exc_param in zip(double_excitations, d_exc_params):
+            add_double_excitation_circuit(circuit, d_exc, d_exc_param)
+
+        for s_exc, s_exc_param in zip(single_excitations, s_exc_params):
+            add_single_excitation_circuit(circuit, s_exc, s_exc_param)
+
+        super().__init__(circuit)

--- a/packages/chem/quri_parts/chem/utils/excitations.py
+++ b/packages/chem/quri_parts/chem/utils/excitations.py
@@ -59,7 +59,7 @@ def add_single_excitation_circuit(
     param_fn: ParameterOrLinearFunction,
 ) -> LinearMappedUnboundParametricQuantumCircuit:
     r"""Add a particle-conserving single excitation circuit to the given
-    :attr:`circuit` implemented as a givens rotation :math:`G(\theta)`
+    :attr:`circuit` implemented as a Givens rotation :math:`G(\theta)`
 
     .. math::
         \begin{align}

--- a/packages/chem/quri_parts/chem/utils/excitations.py
+++ b/packages/chem/quri_parts/chem/utils/excitations.py
@@ -19,14 +19,14 @@ from quri_parts.circuit import (
     ParameterOrLinearFunction,
 )
 
-#: Represents the set of orbital indices involved in excitation. The first element is
-#: the index of an occupied orbital and the second element is the index of an
-#: unoccupied index.
+#: Alias of ``tuple[int, int]`` which represents the set of orbital indices involved in
+#: excitation. The first element is the index of an occupied orbital and the second
+#: element is the index of an unoccupied index.
 SingleExcitation: TypeAlias = tuple[int, int]
 
-#: Represents the set of orbital indices involved in excitation. The first and second
-#: element is the indices of occupied orbitals and the third and fourth element is the
-#: indices of unoccupied orbitals.
+#: Alias of ``tuple[int, int, int, int]`` which represents the set of orbital indices
+#: involved in excitation. The first and second element is the indices of occupied
+#: orbitals and the third and fourth element is the indices of unoccupied orbitals.
 DoubleExcitation: TypeAlias = tuple[int, int, int, int]
 
 

--- a/packages/chem/quri_parts/chem/utils/excitations.py
+++ b/packages/chem/quri_parts/chem/utils/excitations.py
@@ -77,7 +77,7 @@ def add_single_excitation_circuit(
         p_fn = {param: 0.5 * val for param, val in param_fn.items()}
 
     circuit.add_CNOT_gate(*excitation_indices)
-    _add_controlled_Y_gate(circuit, excitation_indices[1], excitation_indices[0], p_fn)
+    _add_controlled_RY_gate(circuit, excitation_indices[1], excitation_indices[0], p_fn)
     circuit.add_CNOT_gate(*excitation_indices)
     return circuit
 
@@ -149,7 +149,7 @@ def add_double_excitation_circuit(
     return circuit
 
 
-def _add_controlled_Y_gate(
+def _add_controlled_RY_gate(
     circuit: LinearMappedUnboundParametricQuantumCircuit,
     control_index: int,
     target_index: int,

--- a/packages/chem/quri_parts/chem/utils/excitations.py
+++ b/packages/chem/quri_parts/chem/utils/excitations.py
@@ -1,0 +1,164 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Sequence
+
+from typing_extensions import TypeAlias
+
+from quri_parts.circuit import (
+    LinearMappedUnboundParametricQuantumCircuit,
+    LinearParameterFunction,
+    Parameter,
+    ParameterOrLinearFunction,
+)
+
+#: Represents the set of orbital indices involved in excitation. The first element is
+#: the index of an occupied orbital and the second element is the index of an
+#: unoccupied index.
+SingleExcitation: TypeAlias = tuple[int, int]
+
+#: Represents the set of orbital indices involved in excitation. The first and second
+#: element is the indices of occupied orbitals and the third and fourth element is the
+#: indices of unoccupied orbitals.
+DoubleExcitation: TypeAlias = tuple[int, int, int, int]
+
+
+def excitations(
+    n_spin_orbitals: int, n_fermions: int, delta_sz: float = 0
+) -> tuple[Sequence[SingleExcitation], Sequence[DoubleExcitation]]:
+    """Returns the list of excitation indices for :attr:`n_spin_orbitals` and
+    :attr:`n_fermions` with :attr:`delta_sz` as a tuple of
+    :attr:`SingleExcitation` and :class:`DoubleExcitation`."""
+    sz = [0.5 if (i % 2 == 0) else -0.5 for i in range(n_spin_orbitals)]
+    singles = []
+    doubles = []
+    for r in range(n_fermions):
+        for p in range(n_fermions, n_spin_orbitals):
+            if sz[p] - sz[r] == delta_sz:
+                singles.append((r, p))
+    for s in range(n_fermions - 1):
+        for r in range(s + 1, n_fermions):
+            for q in range(n_fermions, n_spin_orbitals - 1):
+                for p in range(q + 1, n_spin_orbitals):
+                    if sz[p] + sz[q] - sz[r] - sz[s] == delta_sz:
+                        doubles.append((s, r, q, p))
+
+    return singles, doubles
+
+
+def add_single_excitation_circuit(
+    circuit: LinearMappedUnboundParametricQuantumCircuit,
+    excitation_indices: SingleExcitation,
+    param_fn: ParameterOrLinearFunction,
+) -> LinearMappedUnboundParametricQuantumCircuit:
+    r"""Add a particle-conserving single excitation circuit to the given
+    :attr:`circuit` implemented as a givens rotation :math:`G(\theta)`
+
+    .. math::
+        \begin{align}
+            G(\theta)|01\rangle &= \cos(\theta /2)|01\rangle + \sin(\theta /2)|10
+            \rangle \\
+            G(\theta)|10\rangle &= \cos(\theta /2)|10\rangle - \sin(\theta /2)|01
+            \rangle \\
+        \end{align}
+
+    applied to the :attr:`excitation_indices`.
+    """
+    if isinstance(param_fn, Parameter):
+        p_fn = {param_fn: 0.5}
+    else:
+        p_fn = {param: 0.5 * val for param, val in param_fn.items()}
+
+    circuit.add_CNOT_gate(*excitation_indices)
+    _add_controlled_Y_gate(circuit, excitation_indices[1], excitation_indices[0], p_fn)
+    circuit.add_CNOT_gate(*excitation_indices)
+    return circuit
+
+
+def add_double_excitation_circuit(
+    circuit: LinearMappedUnboundParametricQuantumCircuit,
+    excitation_indices: DoubleExcitation,
+    param_fn: ParameterOrLinearFunction,
+) -> LinearMappedUnboundParametricQuantumCircuit:
+    r"""Add a particle-conserving double excitation circuit to the given
+    :attr:`circuit` implemented as a extended givens rotation :math:`G^2(\theta)` which
+    acts on the space of 4 qubits and performs the :math:`U(2)` rotation on the
+    subspace spanned by two states, e.g. :math:`|0011\rangle` and :math:`|1100\rangle`
+
+    .. math::
+        \begin{align}
+            G^2(\theta)|0011\rangle &= \cos(\theta /2)|0011\rangle + \sin(\theta /2)
+            |1100\rangle \\
+            G^2(\theta)|1100\rangle &= \cos(\theta /2)|1100\rangle - \sin(\theta /2)
+            |0011\rangle \\
+        \end{align}
+
+    applied to the :attr:`excitation_indices`.
+    """
+    if isinstance(param_fn, Parameter):
+        p_fn = {param_fn: 0.125}
+        inv_sign_p_fn = {param_fn: -0.125}
+    else:
+        p_fn = {param: 0.125 * val for param, val in param_fn.items()}
+        inv_sign_p_fn = {param: -0.125 * val for param, val in param_fn.items()}
+
+    circuit.add_CNOT_gate(excitation_indices[2], excitation_indices[3])
+    circuit.add_CNOT_gate(excitation_indices[0], excitation_indices[2])
+    circuit.add_H_gate(excitation_indices[3])
+    circuit.add_H_gate(excitation_indices[0])
+    circuit.add_CNOT_gate(excitation_indices[2], excitation_indices[3])
+    circuit.add_CNOT_gate(excitation_indices[0], excitation_indices[1])
+
+    circuit.add_ParametricRY_gate(excitation_indices[1], p_fn)
+    circuit.add_ParametricRY_gate(excitation_indices[0], inv_sign_p_fn)
+
+    circuit.add_CNOT_gate(excitation_indices[0], excitation_indices[3])
+    circuit.add_H_gate(excitation_indices[3])
+    circuit.add_CNOT_gate(excitation_indices[3], excitation_indices[1])
+
+    circuit.add_ParametricRY_gate(excitation_indices[1], p_fn)
+    circuit.add_ParametricRY_gate(excitation_indices[0], inv_sign_p_fn)
+
+    circuit.add_CNOT_gate(excitation_indices[2], excitation_indices[1])
+    circuit.add_CNOT_gate(excitation_indices[2], excitation_indices[0])
+
+    circuit.add_ParametricRY_gate(excitation_indices[1], inv_sign_p_fn)
+    circuit.add_ParametricRY_gate(excitation_indices[0], p_fn)
+
+    circuit.add_CNOT_gate(excitation_indices[3], excitation_indices[1])
+    circuit.add_H_gate(excitation_indices[3])
+    circuit.add_CNOT_gate(excitation_indices[0], excitation_indices[3])
+
+    circuit.add_ParametricRY_gate(excitation_indices[1], inv_sign_p_fn)
+    circuit.add_ParametricRY_gate(excitation_indices[0], p_fn)
+
+    circuit.add_CNOT_gate(excitation_indices[0], excitation_indices[1])
+    circuit.add_CNOT_gate(excitation_indices[2], excitation_indices[0])
+    circuit.add_H_gate(excitation_indices[0])
+    circuit.add_H_gate(excitation_indices[3])
+    circuit.add_CNOT_gate(excitation_indices[0], excitation_indices[2])
+    circuit.add_CNOT_gate(excitation_indices[2], excitation_indices[3])
+
+    return circuit
+
+
+def _add_controlled_Y_gate(
+    circuit: LinearMappedUnboundParametricQuantumCircuit,
+    control_index: int,
+    target_index: int,
+    param_fn: LinearParameterFunction,
+) -> LinearMappedUnboundParametricQuantumCircuit:
+    inv_sign_param_fn = {param: -1.0 * val for param, val in param_fn.items()}
+    circuit.add_ParametricRY_gate(target_index, param_fn)
+    circuit.add_CNOT_gate(control_index, target_index)
+    circuit.add_ParametricRY_gate(target_index, inv_sign_param_fn)
+    circuit.add_CNOT_gate(control_index, target_index)
+
+    return circuit

--- a/packages/chem/quri_parts/chem/utils/excitations.py
+++ b/packages/chem/quri_parts/chem/utils/excitations.py
@@ -88,7 +88,7 @@ def add_double_excitation_circuit(
     param_fn: ParameterOrLinearFunction,
 ) -> LinearMappedUnboundParametricQuantumCircuit:
     r"""Add a particle-conserving double excitation circuit to the given
-    :attr:`circuit` implemented as a extended givens rotation :math:`G^2(\theta)` which
+    :attr:`circuit` implemented as a extended Givens rotation :math:`G^2(\theta)` which
     acts on the space of 4 qubits and performs the :math:`U(2)` rotation on the
     subspace spanned by two states, e.g. :math:`|0011\rangle` and :math:`|1100\rangle`
 

--- a/packages/chem/tests/chem/ansatz/test_all_singles_doubles.py
+++ b/packages/chem/tests/chem/ansatz/test_all_singles_doubles.py
@@ -1,0 +1,63 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from quri_parts.chem.ansatz.all_singles_doubles import AllSinglesDoubles
+from quri_parts.chem.utils.excitations import (
+    add_double_excitation_circuit,
+    add_single_excitation_circuit,
+    excitations,
+)
+from quri_parts.circuit import LinearMappedUnboundParametricQuantumCircuit
+
+
+def test_all_singles_doubles() -> None:
+    qubit_count = 4
+    n_electrons = 2
+    circuit = AllSinglesDoubles(qubit_count, n_electrons)
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    s_exc_indices, d_exc_indices = excitations(qubit_count, n_electrons)
+    s_exc_params = expected_circuit.add_parameters(
+        *[f"theta_s_{i}" for i in range(len(s_exc_indices))]
+    )
+    d_exc_params = expected_circuit.add_parameters(
+        *[f"phi_d_{i}" for i in range(len(d_exc_indices))]
+    )
+    for d_exc, d_exc_param in zip(d_exc_indices, d_exc_params):
+        add_double_excitation_circuit(expected_circuit, d_exc, d_exc_param)
+    for s_exc, s_exc_param in zip(s_exc_indices, s_exc_params):
+        add_single_excitation_circuit(expected_circuit, s_exc, s_exc_param)
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit
+
+    qubit_count = 8
+    n_electrons = 4
+    circuit = AllSinglesDoubles(qubit_count, n_electrons)
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    s_exc_indices, d_exc_indices = excitations(qubit_count, n_electrons)
+    s_exc_params = expected_circuit.add_parameters(
+        *[f"theta_s_{i}" for i in range(len(s_exc_indices))]
+    )
+    d_exc_params = expected_circuit.add_parameters(
+        *[f"phi_d_{i}" for i in range(len(d_exc_indices))]
+    )
+    for d_exc, d_exc_param in zip(d_exc_indices, d_exc_params):
+        add_double_excitation_circuit(expected_circuit, d_exc, d_exc_param)
+    for s_exc, s_exc_param in zip(s_exc_indices, s_exc_params):
+        add_single_excitation_circuit(expected_circuit, s_exc, s_exc_param)
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit

--- a/packages/chem/tests/chem/utils/test_excitations.py
+++ b/packages/chem/tests/chem/utils/test_excitations.py
@@ -1,0 +1,197 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from quri_parts.chem.utils.excitations import (
+    _add_controlled_Y_gate,
+    add_double_excitation_circuit,
+    add_single_excitation_circuit,
+    excitations,
+)
+from quri_parts.circuit import LinearMappedUnboundParametricQuantumCircuit
+
+
+def test_excitations() -> None:
+    assert excitations(2, 2) == ([], [])
+    assert excitations(3, 2) == ([(0, 2)], [])
+    assert excitations(4, 2) == ([(0, 2), (1, 3)], [(0, 1, 2, 3)])
+    assert excitations(4, 2, delta_sz=-1.0) == ([(0, 3)], [])
+    assert excitations(6, 2) == (
+        [(0, 2), (0, 4), (1, 3), (1, 5)],
+        [(0, 1, 2, 3), (0, 1, 2, 5), (0, 1, 3, 4), (0, 1, 4, 5)],
+    )
+    assert excitations(6, 2, delta_sz=1.0) == ([(1, 2), (1, 4)], [(0, 1, 2, 4)])
+    assert excitations(6, 4) == (
+        [(0, 4), (1, 5), (2, 4), (3, 5)],
+        [(0, 1, 4, 5), (0, 3, 4, 5), (1, 2, 4, 5), (2, 3, 4, 5)],
+    )
+
+
+def test_add_single_excitation_circuit() -> None:
+    qubit_count = 4
+    excitation = (0, 2)
+    circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    theta = circuit.add_parameter("theta")
+    add_single_excitation_circuit(circuit, excitation, theta)
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    _theta = expected_circuit.add_parameter("theta")
+    expected_circuit.add_CNOT_gate(*excitation)
+    _add_controlled_Y_gate(
+        expected_circuit, excitation[1], excitation[0], {_theta: 0.5}
+    )
+    expected_circuit.add_CNOT_gate(*excitation)
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit
+
+    qubit_count = 6
+    excitation = (1, 3)
+    circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    theta = circuit.add_parameter("theta")
+    add_single_excitation_circuit(circuit, excitation, theta)
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    _theta = expected_circuit.add_parameter("theta")
+    expected_circuit.add_CNOT_gate(*excitation)
+    _add_controlled_Y_gate(
+        expected_circuit, excitation[1], excitation[0], {_theta: 0.5}
+    )
+    expected_circuit.add_CNOT_gate(*excitation)
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit
+
+
+def test_add_double_excitation_circuit() -> None:
+    qubit_count = 6
+    excitation = (0, 1, 2, 3)
+    circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    phi = circuit.add_parameter("phi")
+    add_double_excitation_circuit(circuit, excitation, phi)
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    _phi = expected_circuit.add_parameter("phi")
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[2])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_H_gate(excitation[0])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[1])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: 0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: -0.125})
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[3])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[3], excitation[1])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: 0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: -0.125})
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[1])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[0])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: -0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: 0.125})
+    expected_circuit.add_CNOT_gate(excitation[3], excitation[1])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[3])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: -0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: 0.125})
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[1])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[0])
+    expected_circuit.add_H_gate(excitation[0])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[2])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[3])
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit
+
+    qubit_count = 6
+    excitation = (0, 1, 4, 5)
+    circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    phi = circuit.add_parameter("phi")
+    add_double_excitation_circuit(circuit, excitation, phi)
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    _phi = expected_circuit.add_parameter("phi")
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[2])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_H_gate(excitation[0])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[1])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: 0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: -0.125})
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[3])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[3], excitation[1])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: 0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: -0.125})
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[1])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[0])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: -0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: 0.125})
+    expected_circuit.add_CNOT_gate(excitation[3], excitation[1])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[3])
+    expected_circuit.add_ParametricRY_gate(excitation[1], {_phi: -0.125})
+    expected_circuit.add_ParametricRY_gate(excitation[0], {_phi: 0.125})
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[1])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[0])
+    expected_circuit.add_H_gate(excitation[0])
+    expected_circuit.add_H_gate(excitation[3])
+    expected_circuit.add_CNOT_gate(excitation[0], excitation[2])
+    expected_circuit.add_CNOT_gate(excitation[2], excitation[3])
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit
+
+
+def test_add_controlled_Y_gate() -> None:
+    qubit_count = 4
+    excitation = (0, 2)
+    circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    theta = circuit.add_parameter("theta")
+    _add_controlled_Y_gate(circuit, excitation[1], excitation[0], {theta: 0.5})
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    exp_theta = expected_circuit.add_parameter("theta")
+    expected_circuit.add_ParametricRY_gate(excitation[0], {exp_theta: 0.5})
+    expected_circuit.add_CNOT_gate(excitation[1], excitation[0])
+    expected_circuit.add_ParametricRY_gate(excitation[0], {exp_theta: -0.5})
+    expected_circuit.add_CNOT_gate(excitation[1], excitation[0])
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit
+
+    qubit_count = 6
+    excitation = (1, 3)
+    circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    theta = circuit.add_parameter("theta")
+    _add_controlled_Y_gate(circuit, excitation[1], excitation[0], {theta: 0.5})
+    expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
+    exp_theta = expected_circuit.add_parameter("theta")
+    expected_circuit.add_ParametricRY_gate(excitation[0], {exp_theta: 0.5})
+    expected_circuit.add_CNOT_gate(excitation[1], excitation[0])
+    expected_circuit.add_ParametricRY_gate(excitation[0], {exp_theta: -0.5})
+    expected_circuit.add_CNOT_gate(excitation[1], excitation[0])
+    assert circuit.parameter_count == expected_circuit.parameter_count
+    assert circuit._circuit.gates == expected_circuit._circuit.gates
+    params = [0.1 * (i + 1) for i in range(circuit.parameter_count)]
+    bound_circuit = circuit.bind_parameters(params)
+    expected_bound_circuit = expected_circuit.bind_parameters(params)
+    assert bound_circuit == expected_bound_circuit

--- a/packages/chem/tests/chem/utils/test_excitations.py
+++ b/packages/chem/tests/chem/utils/test_excitations.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 from quri_parts.chem.utils.excitations import (
-    _add_controlled_Y_gate,
+    _add_controlled_RY_gate,
     add_double_excitation_circuit,
     add_single_excitation_circuit,
     excitations,
@@ -42,7 +42,7 @@ def test_add_single_excitation_circuit() -> None:
     expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
     _theta = expected_circuit.add_parameter("theta")
     expected_circuit.add_CNOT_gate(*excitation)
-    _add_controlled_Y_gate(
+    _add_controlled_RY_gate(
         expected_circuit, excitation[1], excitation[0], {_theta: 0.5}
     )
     expected_circuit.add_CNOT_gate(*excitation)
@@ -61,7 +61,7 @@ def test_add_single_excitation_circuit() -> None:
     expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
     _theta = expected_circuit.add_parameter("theta")
     expected_circuit.add_CNOT_gate(*excitation)
-    _add_controlled_Y_gate(
+    _add_controlled_RY_gate(
         expected_circuit, excitation[1], excitation[0], {_theta: 0.5}
     )
     expected_circuit.add_CNOT_gate(*excitation)
@@ -164,7 +164,7 @@ def test_add_controlled_Y_gate() -> None:
     excitation = (0, 2)
     circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
     theta = circuit.add_parameter("theta")
-    _add_controlled_Y_gate(circuit, excitation[1], excitation[0], {theta: 0.5})
+    _add_controlled_RY_gate(circuit, excitation[1], excitation[0], {theta: 0.5})
     expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
     exp_theta = expected_circuit.add_parameter("theta")
     expected_circuit.add_ParametricRY_gate(excitation[0], {exp_theta: 0.5})
@@ -182,7 +182,7 @@ def test_add_controlled_Y_gate() -> None:
     excitation = (1, 3)
     circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
     theta = circuit.add_parameter("theta")
-    _add_controlled_Y_gate(circuit, excitation[1], excitation[0], {theta: 0.5})
+    _add_controlled_RY_gate(circuit, excitation[1], excitation[0], {theta: 0.5})
     expected_circuit = LinearMappedUnboundParametricQuantumCircuit(qubit_count)
     exp_theta = expected_circuit.add_parameter("theta")
     expected_circuit.add_ParametricRY_gate(excitation[0], {exp_theta: 0.5})


### PR DESCRIPTION
Added AllSinglesDoubles ansatz, a parametric quantum circuit consists of single excitation and double excitation.

The implementation is based on PennyLane's AllSinglesDoubles. See the document https://docs.pennylane.ai/en/stable/code/api/pennylane.AllSinglesDoubles.html