### PR TITLE
Fix location of NOTICE file in wheel packages

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -32,12 +32,14 @@ jobs:
     - run: |
         mkdir -p dist
         poetry build
-        for pkg in packages/*
+        cd packages
+        for pkg in *
         do
           cd $pkg
+          cp -f NOTICE quri_parts/$pkg/
           poetry build
           mv dist/* ../../dist
-          cd ../..
+          cd ..
         done
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,6 +31,7 @@ jobs:
 
     - run: |
         mkdir -p dist
+        cp -f NOTICE quri_parts/
         poetry build
         cd packages
         for pkg in *

--- a/packages/algo/pyproject.toml
+++ b/packages/algo/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/braket/pyproject.toml
+++ b/packages/braket/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/chem/pyproject.toml
+++ b/packages/chem/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/circuit/pyproject.toml
+++ b/packages/circuit/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/cirq/pyproject.toml
+++ b/packages/cirq/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/honeywell/pyproject.toml
+++ b/packages/honeywell/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/ionq/pyproject.toml
+++ b/packages/ionq/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/itensor/NOTICE
+++ b/packages/itensor/NOTICE
@@ -1,0 +1,1 @@
+Copyright 2022 QURI Parts Authors

--- a/packages/itensor/pyproject.toml
+++ b/packages/itensor/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/openfermion/pyproject.toml
+++ b/packages/openfermion/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/openqasm/pyproject.toml
+++ b/packages/openqasm/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/pyscf/pyproject.toml
+++ b/packages/pyscf/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/qiskit/pyproject.toml
+++ b/packages/qiskit/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/qulacs/pyproject.toml
+++ b/packages/qulacs/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/packages/stim/pyproject.toml
+++ b/packages/stim/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 packages = [
     { include = "quri_parts" }
 ]
-include = ["NOTICE"]
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Workaround for https://github.com/python-poetry/poetry/issues/7153
Since `NOTICE` file from multiple sub packages are placed in the same location (just under `site-packages`), uninstallation of the packages fails (`pip` complains that it cannot find `NOTICE` file, which was removed by uninstallation of other packages).