### PR TITLE
Fix typos on OepnQASM gate name

### DIFF
--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -43,9 +43,9 @@ _single_qubit_gate_stdgates_symbol: Mapping["SingleQubitGateNameType", str] = {
     gate_names.Z: "z",
     gate_names.H: "h",
     gate_names.S: "s",
-    gate_names.Sdag: "sdag",
+    gate_names.Sdag: "sdg",
     gate_names.T: "t",
-    gate_names.Tdag: "tdag",
+    gate_names.Tdag: "tdg",
 }
 
 _single_qubit_rotation_gate_stdgates_symbol: Mapping["SingleQubitGateNameType", str] = {

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
@@ -42,7 +42,7 @@ class TestConvertGate:
 
     def test_sdag_gate(self) -> None:
         g = gates.Sdag(123)
-        qasm_expected = "sdag q[123];"
+        qasm_expected = "sdg q[123];"
         assert convert_gate_to_qasm_line(g) == qasm_expected
 
     def test_t_gate(self) -> None:
@@ -52,7 +52,7 @@ class TestConvertGate:
 
     def test_tdag_gate(self) -> None:
         g = gates.Tdag(123)
-        qasm_expected = "tdag q[123];"
+        qasm_expected = "tdg q[123];"
         assert convert_gate_to_qasm_line(g) == qasm_expected
 
     def test_rx_gate(self) -> None:


### PR DESCRIPTION
Gate names for Sdag and Tdag gates converted to OepnQASM 3.0 by quri-parts-openqasm are different from the description in stdgates.inc.

stdgates.inc
https://github.com/openqasm/openqasm/blob/main/examples/stdgates.inc

sdag -> sdg
tdag -> tdg
