### PR TITLE
SqrtX gate support in quri-parts-openqasm

### DIFF
--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -43,6 +43,7 @@ _single_qubit_gate_stdgates_symbol: Mapping["SingleQubitGateNameType", str] = {
     gate_names.Z: "z",
     gate_names.H: "h",
     gate_names.S: "s",
+    gate_names.SqrtX: "sx",
     gate_names.Sdag: "sdag",
     gate_names.T: "t",
     gate_names.Tdag: "tdag",
@@ -77,7 +78,6 @@ _U_gate_stdgates_symbol: Mapping["SingleQubitGateNameType", str] = {
 }
 
 _not_implemented_gates: set["SingleQubitGateNameType"] = {
-    gate_names.SqrtX,
     gate_names.SqrtXdag,
     gate_names.SqrtY,
     gate_names.SqrtYdag,

--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -44,9 +44,9 @@ _single_qubit_gate_stdgates_symbol: Mapping["SingleQubitGateNameType", str] = {
     gate_names.H: "h",
     gate_names.S: "s",
     gate_names.SqrtX: "sx",
-    gate_names.Sdag: "sdag",
+    gate_names.Sdag: "sdg",
     gate_names.T: "t",
-    gate_names.Tdag: "tdag",
+    gate_names.Tdag: "tdg",
 }
 
 _single_qubit_rotation_gate_stdgates_symbol: Mapping["SingleQubitGateNameType", str] = {

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
@@ -40,6 +40,11 @@ class TestConvertGate:
         qasm_expected = "s q[123];"
         assert convert_gate_to_qasm_line(g) == qasm_expected
 
+    def test_sqrtx_gate(self) -> None:
+        g = gates.SqrtX(123)
+        qasm_expected = "sx q[123];"
+        assert convert_gate_to_qasm_line(g) == qasm_expected
+
     def test_sdag_gate(self) -> None:
         g = gates.Sdag(123)
         qasm_expected = "sdag q[123];"


### PR DESCRIPTION
SqrtX(sx) is available in both QURI Parts and OpenQASM 3.0, so quri-parts-openqasm supports it.

stdgates.inc
https://github.com/openqasm/openqasm/blob/main/examples/stdgates.inc#L26

Sorry. I made a mistake and closed #50 , so I will pull request again.