### PR TITLE
Transpiler for OpenQASM decomposing multi-Pauli (rotation) gates

### DIFF
--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 import io
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Callable, Mapping
 
 from quri_parts.circuit import gate_names
 from quri_parts.circuit.gate_names import (
@@ -21,6 +21,7 @@ from quri_parts.circuit.gate_names import (
     is_two_qubit_gate_name,
 )
 from quri_parts.circuit.transpile import (
+    CircuitTranspiler,
     PauliDecomposeTranspiler,
     PauliRotationDecomposeTranspiler,
     SequentialTranspiler,
@@ -36,16 +37,9 @@ if TYPE_CHECKING:
     )
 
 
-class OpenQASMTranspiler(SequentialTranspiler):
-    """CircuitTranspiler which transpiles gates not supported by OpenQASM to
-    supported ones."""
-
-    def __init__(self) -> None:
-        transpilers = [
-            PauliDecomposeTranspiler(),
-            PauliRotationDecomposeTranspiler(),
-        ]
-        super().__init__(transpilers)
+OpenQASMTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
+    [PauliDecomposeTranspiler(), PauliRotationDecomposeTranspiler()]
+)
 
 
 _HEADER = """OPENQASM 3;

--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -20,6 +20,11 @@ from quri_parts.circuit.gate_names import (
     is_three_qubit_gate_name,
     is_two_qubit_gate_name,
 )
+from quri_parts.circuit.transpile import (
+    PauliDecomposeTranspiler,
+    PauliRotationDecomposeTranspiler,
+    SequentialTranspiler,
+)
 
 if TYPE_CHECKING:
     from quri_parts.circuit import NonParametricQuantumCircuit, QuantumGate
@@ -29,6 +34,19 @@ if TYPE_CHECKING:
         ThreeQubitGateNameType,
         TwoQubitGateNameType,
     )
+
+
+class OpenQASMTranspiler(SequentialTranspiler):
+    """CircuitTranspiler which transpiles gates not supported by OpenQASM to
+    supported ones."""
+
+    def __init__(self) -> None:
+        transpilers = [
+            PauliDecomposeTranspiler(),
+            PauliRotationDecomposeTranspiler(),
+        ]
+        super().__init__(transpilers)
+
 
 _HEADER = """OPENQASM 3;
 include "stdgates.inc";"""

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_transpile.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_transpile.py
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from quri_parts.circuit.transpile import (
+    PauliDecomposeTranspiler,
+    PauliRotationDecomposeTranspiler,
+    SequentialTranspiler,
+)
+from quri_parts.openqasm.circuit import OpenQASMTranspiler
+
+
+def test_openqasm_transpiler() -> None:
+    transpiler = OpenQASMTranspiler()
+    assert isinstance(transpiler, SequentialTranspiler)
+    assert [type(x) for x in transpiler._transpilers] == [
+        PauliDecomposeTranspiler,
+        PauliRotationDecomposeTranspiler,
+    ]


### PR DESCRIPTION
Since multi-Pauli (rotation) gates are not defined in [stdgates.inc](https://github.com/openqasm/openqasm/blob/4ad00941a8d863fd462d2c1757e282b8429bfe32/examples/stdgates.inc), it should be decomposed before converted to OpenQASM.