### PR TITLE
Rewrite the check of hermiticity in mitigations 

### DIFF
--- a/packages/algo/quri_parts/algo/mitigation/cdr/cdr.py
+++ b/packages/algo/quri_parts/algo/mitigation/cdr/cdr.py
@@ -32,7 +32,7 @@ from quri_parts.core.estimator import (
     Estimate,
     QuantumEstimator,
 )
-from quri_parts.core.operator import Operator
+from quri_parts.core.operator import Operator, is_hermitian
 from quri_parts.core.state import GeneralCircuitQuantumState
 
 
@@ -225,7 +225,7 @@ def cdr(
     """
 
     if isinstance(obs, Operator):
-        if obs != obs.hermitian_conjugated():
+        if not is_hermitian(obs):
             raise NotImplementedError(
                 "Only the case that obs is a Hermitian has been implemented."
             )

--- a/packages/algo/quri_parts/algo/mitigation/zne/zne.py
+++ b/packages/algo/quri_parts/algo/mitigation/zne/zne.py
@@ -26,7 +26,7 @@ from quri_parts.core.estimator import (
     Estimate,
     QuantumEstimator,
 )
-from quri_parts.core.operator import Operator
+from quri_parts.core.operator import Operator, is_hermitian
 from quri_parts.core.state import GeneralCircuitQuantumState
 
 
@@ -268,7 +268,7 @@ def zne(
     """
 
     if isinstance(obs, Operator):
-        if obs != obs.hermitian_conjugated():
+        if not is_hermitian(obs):
             raise NotImplementedError(
                 "Only the case that obs is a Hermitian has been implemented."
             )


### PR DESCRIPTION
Rewrote the check of the hermiticity of operators in mitigations using `is_hermitian()` instead of `.hermitian_conjugated()`.