### PR TITLE
Clifford + RZ decomposer

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -149,9 +149,11 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 )
 
 
-#: CircuitTranspiler to transpile a QuntumCircuit into another
-#: QuantumCircuit containing only H, X, Y, Z, S, RZ, and CNOT.
 class CliffordRZSetTranspiler(SequentialTranspiler):
+    """CircuitTranspiler to transpile a QuntumCircuit into another
+    QuantumCircuit containing only H, X, Y, Z, S, Sdg, RZ, and CNOT.
+    """
+
     def __init__(self, epsilon: float = 1.0e-9):
         super().__init__(
             [

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -11,6 +11,7 @@
 from typing import Callable
 
 from .clifford_approximation import CliffordApproximationTranspiler
+from .fuse import FuseRotationTranspiler
 from .gate_kind_decomposer import (
     CNOT2CZHTranspiler,
     CZ2CNOTHTranspiler,
@@ -143,6 +144,41 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 )
 
 
+#: CircuitTranspiler to transpile a QuntumCircuit into another
+#: QuantumCircuit containing only H, X, Y, Z, S, RZ, and CNOT.
+CliffordRZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
+    [
+        ParallelDecomposer(
+            [
+                CZ2CNOTHTranspiler(),
+                PauliDecomposeTranspiler(),
+                PauliRotationDecomposeTranspiler(),
+                TOFFOLI2HTTdagCNOTTranspiler(),
+            ]
+        ),
+        ParallelDecomposer(
+            [
+                Identity2RZTranspiler(),
+                SqrtXdag2RZSqrtXTranspiler(),
+                SqrtY2RZSqrtXTranspiler(),
+                SqrtYdag2RZSqrtXTranspiler(),
+                Sdag2RZTranspiler(),
+                T2RZTranspiler(),
+                Tdag2RZTranspiler(),
+                RX2RZSqrtXTranspiler(),
+                RY2RZSqrtXTranspiler(),
+                U1ToRZTranspiler(),
+                U2ToRZSqrtXTranspiler(),
+                U3ToRZSqrtXTranspiler(),
+                SWAP2CNOTTranspiler(),
+            ]
+        ),
+        SqrtX2RZHTranspiler(),
+        FuseRotationTranspiler(),
+    ]
+)
+
+
 __all__ = [
     "CircuitTranspiler",
     "CircuitTranspilerProtocol",
@@ -152,6 +188,7 @@ __all__ = [
     "SequentialTranspiler",
     "RZSetTranspiler",
     "RotationSetTranspiler",
+    "CliffordRZSetTranspiler",
     "CliffordApproximationTranspiler",
     "IdentityEliminationTranspiler",
     "IdentityInsertionTranspiler",
@@ -161,6 +198,7 @@ __all__ = [
     "CNOT2CZHTranspiler",
     "CZ2CNOTHTranspiler",
     "CZ2RXRYCNOTTranspiler",
+    "FuseRotationTranspiler",
     "H2RXRYTranspiler",
     "H2RZSqrtXTranspiler",
     "QubitRemappingTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -151,42 +151,42 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only H, X, Y, Z, S, RZ, and CNOT.
-CliffordRZSetTranspiler: Callable[
-    [float], CircuitTranspiler
-] = lambda epsilon=1.0e-9: SequentialTranspiler(
-    [
-        ParallelDecomposer(
+class CliffordRZSetTranspiler(SequentialTranspiler):
+    def __init__(self, epsilon: float = 1.0e-9):
+        super().__init__(
             [
-                CZ2CNOTHTranspiler(),
-                PauliDecomposeTranspiler(),
-                PauliRotationDecomposeTranspiler(),
-                TOFFOLI2HTTdagCNOTTranspiler(),
+                ParallelDecomposer(
+                    [
+                        CZ2CNOTHTranspiler(),
+                        PauliDecomposeTranspiler(),
+                        PauliRotationDecomposeTranspiler(),
+                        TOFFOLI2HTTdagCNOTTranspiler(),
+                    ]
+                ),
+                ParallelDecomposer(
+                    [
+                        SqrtXdag2RZSqrtXTranspiler(),
+                        SqrtY2RZSqrtXTranspiler(),
+                        SqrtYdag2RZSqrtXTranspiler(),
+                        Sdag2RZTranspiler(),
+                        T2RZTranspiler(),
+                        Tdag2RZTranspiler(),
+                        RX2RZSqrtXTranspiler(),
+                        RY2RZSqrtXTranspiler(),
+                        U1ToRZTranspiler(),
+                        U2ToRZSqrtXTranspiler(),
+                        U3ToRZSqrtXTranspiler(),
+                        SWAP2CNOTTranspiler(),
+                    ]
+                ),
+                SqrtX2RZHTranspiler(),
+                FuseRotationTranspiler(),
+                RX2NamedTranspiler(epsilon),
+                RY2NamedTranspiler(epsilon),
+                RZ2NamedTranspiler(epsilon),
+                IdentityEliminationTranspiler(),
             ]
-        ),
-        ParallelDecomposer(
-            [
-                SqrtXdag2RZSqrtXTranspiler(),
-                SqrtY2RZSqrtXTranspiler(),
-                SqrtYdag2RZSqrtXTranspiler(),
-                Sdag2RZTranspiler(),
-                T2RZTranspiler(),
-                Tdag2RZTranspiler(),
-                RX2RZSqrtXTranspiler(),
-                RY2RZSqrtXTranspiler(),
-                U1ToRZTranspiler(),
-                U2ToRZSqrtXTranspiler(),
-                U3ToRZSqrtXTranspiler(),
-                SWAP2CNOTTranspiler(),
-            ]
-        ),
-        SqrtX2RZHTranspiler(),
-        FuseRotationTranspiler(),
-        RX2NamedTranspiler(epsilon),
-        RY2NamedTranspiler(epsilon),
-        RZ2NamedTranspiler(epsilon),
-        IdentityEliminationTranspiler(),
-    ]
-)
+        )
 
 
 __all__ = [

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -11,7 +11,12 @@
 from typing import Callable
 
 from .clifford_approximation import CliffordApproximationTranspiler
-from .fuse import FuseRotationTranspiler
+from .fuse import (
+    FuseRotationTranspiler,
+    RX2NamedTranspiler,
+    RY2NamedTranspiler,
+    RZ2NamedTranspiler,
+)
 from .gate_kind_decomposer import (
     CNOT2CZHTranspiler,
     CZ2CNOTHTranspiler,
@@ -146,7 +151,9 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only H, X, Y, Z, S, RZ, and CNOT.
-CliffordRZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
+CliffordRZSetTranspiler: Callable[
+    [float], CircuitTranspiler
+] = lambda epsilon=1.0e-9: SequentialTranspiler(
     [
         ParallelDecomposer(
             [
@@ -158,7 +165,6 @@ CliffordRZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTra
         ),
         ParallelDecomposer(
             [
-                Identity2RZTranspiler(),
                 SqrtXdag2RZSqrtXTranspiler(),
                 SqrtY2RZSqrtXTranspiler(),
                 SqrtYdag2RZSqrtXTranspiler(),
@@ -175,6 +181,10 @@ CliffordRZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTra
         ),
         SqrtX2RZHTranspiler(),
         FuseRotationTranspiler(),
+        RX2NamedTranspiler(epsilon),
+        RY2NamedTranspiler(epsilon),
+        RZ2NamedTranspiler(epsilon),
+        IdentityEliminationTranspiler(),
     ]
 )
 
@@ -204,6 +214,9 @@ __all__ = [
     "QubitRemappingTranspiler",
     "RX2RZSqrtXTranspiler",
     "RY2RZSqrtXTranspiler",
+    "RX2NamedTranspiler",
+    "RY2NamedTranspiler",
+    "RZ2NamedTranspiler",
     "S2RZTranspiler",
     "Sdag2RZTranspiler",
     "SingleQubitUnitaryMatrix2RYRZTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -152,6 +152,11 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 class CliffordRZSetTranspiler(SequentialTranspiler):
     """CircuitTranspiler to transpile a QuntumCircuit into another
     QuantumCircuit containing only H, X, Y, Z, S, Sdg, RZ, and CNOT.
+
+    Since this transpiler involves fusing rotation gates, converting
+    rotation gates to named gates with a certain precision, and removing
+    Identity gates, the action of the circuit before and after the
+    conversion may not be completely equivalent.
     """
 
     def __init__(self, epsilon: float = 1.0e-9):

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from quri_parts.circuit import (
+    NonParametricQuantumCircuit,
+    QuantumCircuit,
+    QuantumGate,
+    gate_names,
+)
+
+from .transpiler import CircuitTranspilerProtocol
+
+
+class FuseRotationTranspiler(CircuitTranspilerProtocol):
+    def __call__(
+        self, circuit: NonParametricQuantumCircuit
+    ) -> NonParametricQuantumCircuit:
+        xs = circuit.gates
+        ys = []
+
+        while xs:
+            x = xs.pop(0)
+            if not ys:
+                ys.append(x)
+                continue
+            y = ys.pop(-1)
+
+            if (
+                x.name in [gate_names.RX, gate_names.RY, gate_names.RZ]
+                and x.name == y.name
+                and x.target_indices == y.target_indices
+            ):
+                theta = (x.params[0] + y.params[0]) % (2 * np.pi)
+                ys.append(
+                    QuantumGate(
+                        name=x.name, target_indices=x.target_indices, params=theta
+                    )
+                )
+            else:
+                ys.extend([y, x])
+
+        ret = QuantumCircuit(circuit.qubit_count)
+        ret.extend(ys)
+        return ret

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -25,6 +25,8 @@ from .transpiler import CircuitTranspilerProtocol, GateKindDecomposer
 
 
 class TwoGateFuser(CircuitTranspilerProtocol, ABC):
+    """Abstract base class of adjacent gates fusing transpilers."""
+
     @abstractmethod
     def is_target_pair(self, left: QuantumGate, right: QuantumGate) -> bool:
         ...
@@ -57,6 +59,9 @@ class TwoGateFuser(CircuitTranspilerProtocol, ABC):
 
 
 class FuseRotationTranspiler(TwoGateFuser):
+    """CircuitTranspiler, which fuses consecutive rotation gates of the same
+    kind acting on the same qubit."""
+
     def is_target_pair(self, left: QuantumGate, right: QuantumGate) -> bool:
         return (
             left.name in [gate_names.RX, gate_names.RY, gate_names.RZ]
@@ -74,6 +79,9 @@ class FuseRotationTranspiler(TwoGateFuser):
 
 
 class RX2NamedTranspiler(GateKindDecomposer):
+    """Convert RX gate to Identity or X gate if it is equivalent to Identity or
+    X gate."""
+
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon
 
@@ -97,6 +105,9 @@ class RX2NamedTranspiler(GateKindDecomposer):
 
 
 class RY2NamedTranspiler(GateKindDecomposer):
+    """Convert RY gate to Identity or Y gate if it is equivalent to Identity or
+    Y gate."""
+
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon
 
@@ -120,6 +131,9 @@ class RY2NamedTranspiler(GateKindDecomposer):
 
 
 class RZ2NamedTranspiler(GateKindDecomposer):
+    """Convert RZ gate to Identity, Z, S, Sdag, T, or Tdag gate if it is
+    equivalent to one of these gates."""
+
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon
 

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -42,7 +42,9 @@ class FuseRotationTranspiler(CircuitTranspilerProtocol):
                 theta = (x.params[0] + y.params[0]) % (2 * np.pi)
                 ys.append(
                     QuantumGate(
-                        name=x.name, target_indices=x.target_indices, params=theta
+                        name=x.name,
+                        target_indices=x.target_indices,
+                        params=[theta],
                     )
                 )
             else:

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -25,7 +25,7 @@ class FuseRotationTranspiler(CircuitTranspilerProtocol):
         self, circuit: NonParametricQuantumCircuit
     ) -> NonParametricQuantumCircuit:
         xs = circuit.gates
-        ys = []
+        ys: list[QuantumGate] = []
 
         while xs:
             x = xs.pop(0)

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -44,7 +44,7 @@ class FuseRotationTranspiler(CircuitTranspilerProtocol):
                     QuantumGate(
                         name=x.name,
                         target_indices=x.target_indices,
-                        params=[theta],
+                        params=(theta,),
                     )
                 )
             else:

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -96,7 +96,7 @@ class RX2NamedTranspiler(GateKindDecomposer):
         target = gate.target_indices[0]
         theta = gate.params[0] % (2.0 * np.pi)
 
-        if self._is_close(theta, 0.0):
+        if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
         elif self._is_close(theta, np.pi):
             return [gates.X(target)]
@@ -122,7 +122,7 @@ class RY2NamedTranspiler(GateKindDecomposer):
         target = gate.target_indices[0]
         theta = gate.params[0] % (2.0 * np.pi)
 
-        if self._is_close(theta, 0.0):
+        if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
         elif self._is_close(theta, np.pi):
             return [gates.Y(target)]
@@ -148,7 +148,7 @@ class RZ2NamedTranspiler(GateKindDecomposer):
         target = gate.target_indices[0]
         theta = gate.params[0] % (2.0 * np.pi)
 
-        if self._is_close(theta, 0.0):
+        if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
         elif self._is_close(theta, np.pi):
             return [gates.Z(target)]

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -24,7 +24,7 @@ class FuseRotationTranspiler(CircuitTranspilerProtocol):
     def __call__(
         self, circuit: NonParametricQuantumCircuit
     ) -> NonParametricQuantumCircuit:
-        xs = circuit.gates
+        xs = list(circuit.gates)
         ys: list[QuantumGate] = []
 
         while xs:

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -1,0 +1,77 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from quri_parts.circuit import CNOT, RX, RY, RZ, SWAP, H, QuantumCircuit, QuantumGate, X
+from quri_parts.circuit.transpile import FuseRotationTranspiler
+
+
+def _gates_close(x: QuantumGate, y: QuantumGate) -> bool:
+    return (
+        x.name == y.name
+        and x.target_indices == y.target_indices
+        and x.control_indices == y.control_indices
+        and np.allclose(x.params, y.params)
+        and x.pauli_ids == y.pauli_ids
+        and np.allclose(x.unitary_matrix, y.unitary_matrix)
+    )
+
+
+class TestFuseRotation:
+    def test_fuse(self) -> None:
+        circuit = QuantumCircuit(3)
+        circuit.extend(
+            [
+                H(0),
+                RX(1, np.pi / 2),
+                RX(1, np.pi / 2),
+                RX(2, np.pi / 2),
+                RY(0, np.pi / 2),
+                RY(0, np.pi / 2),
+                RY(0, np.pi / 2),
+                CNOT(0, 2),
+                X(2),
+                RZ(2, np.pi / 2),
+                RZ(2, np.pi / 2),
+            ]
+        )
+        transpiled = FuseRotationTranspiler()(circuit)
+
+        expect = QuantumCircuit(3)
+        expect.extend(
+            [
+                H(0),
+                RX(1, np.pi),
+                RX(2, np.pi / 2),
+                RY(0, np.pi * 3 / 2),
+                CNOT(0, 2),
+                X(2),
+                RZ(2, np.pi),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            assert _gates_close(t, e)
+
+    def test_no_change(self) -> None:
+        circuit = QuantumCircuit(2)
+        circuit.extend(
+            [RZ(0, np.pi), RZ(1, np.pi), H(0), RX(0, np.pi), RY(0, np.pi), SWAP(1, 0)]
+        )
+        transpiled = FuseRotationTranspiler()(circuit)
+
+        expect = QuantumCircuit(2)
+        expect.extend(
+            [RZ(0, np.pi), RZ(1, np.pi), H(0), RX(0, np.pi), RY(0, np.pi), SWAP(1, 0)]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            assert _gates_close(t, e)

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -26,6 +26,7 @@ from quri_parts.circuit import (
     Pauli,
     PauliRotation,
     QuantumCircuit,
+    QuantumGate,
     S,
     Sdag,
     SqrtX,
@@ -39,6 +40,7 @@ from quri_parts.circuit import (
     Z,
 )
 from quri_parts.circuit.transpile import (
+    CliffordRZSetTranspiler,
     CZ2CNOTHTranspiler,
     CZ2RXRYCNOTTranspiler,
     H2RXRYTranspiler,
@@ -74,6 +76,17 @@ from quri_parts.circuit.transpile import (
     Z2HXTranspiler,
     Z2RZTranspiler,
 )
+
+
+def _gates_close(x: QuantumGate, y: QuantumGate) -> bool:
+    return (
+        x.name == y.name
+        and x.target_indices == y.target_indices
+        and x.control_indices == y.control_indices
+        and np.allclose(x.params, y.params)
+        and x.pauli_ids == y.pauli_ids
+        and np.allclose(x.unitary_matrix, y.unitary_matrix)
+    )
 
 
 class TestFTQCSetTranspile:
@@ -618,3 +631,61 @@ class TestRotationSetTranspile:
         )
 
         assert transpiled.gates == expect.gates
+
+
+class TestCliffordRZSetTranspile:
+    def test_cliffordrzset_transpile(self) -> None:
+        theta = np.random.rand() * 2.0 * np.pi
+        phi = np.random.rand() * 2.0 * np.pi
+        lam = np.random.rand() * 2.0 * np.pi
+
+        circuit = QuantumCircuit(1)
+        circuit.extend(
+            [
+                SqrtX(0),
+                SqrtXdag(0),
+                SqrtY(0),
+                SqrtYdag(0),
+                Sdag(0),
+                T(0),
+                Tdag(0),
+                RX(0, theta),
+                RY(0, theta),
+                U1(0, lam),
+                U2(0, phi, lam),
+                U3(0, theta, phi, lam),
+            ]
+        )
+        transpiled = CliffordRZSetTranspiler()(circuit)
+
+        expect = QuantumCircuit(3)
+        expect.extend(
+            [
+                RZ(0, -np.pi / 2.0),  # SqrtX
+                H(0),
+                RZ(0, 0.0),  # SqrtX, SqrtXdag
+                H(0),
+                RZ(0, 3.0 * np.pi / 2.0),  # SqrtXdag, SqrtY
+                H(0),
+                RZ(0, 0.0),  # SqrtY, SqrtYdag
+                H(0),
+                RZ(0, np.pi / 2.0),  # SqrtYdag, T, Tdag
+                H(0),  # RX
+                RZ(0, theta),
+                H(0),
+                RZ(0, 3.0 * np.pi / 2.0),  # RY
+                H(0),
+                RZ(0, theta),
+                H(0),
+                RZ(0, (-np.pi / 2.0 + 2.0 * lam) % (2.0 * np.pi)),  # RY, U1, U2
+                H(0),
+                RZ(0, (phi + lam - np.pi / 2.0) % (2.0 * np.pi)),  # U2, U3
+                H(0),
+                RZ(0, theta),
+                H(0),
+                RZ(0, (phi + np.pi / 2.0) % (2.0 * np.pi)),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            assert _gates_close(t, e)

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -635,9 +635,7 @@ class TestRotationSetTranspile:
 
 class TestCliffordRZSetTranspile:
     def test_cliffordrzset_transpile(self) -> None:
-        theta = np.random.rand() * 2.0 * np.pi
-        phi = np.random.rand() * 2.0 * np.pi
-        lam = np.random.rand() * 2.0 * np.pi
+        theta, phi, lam = np.pi / 3.0, np.pi / 5.0, np.pi / 7.0
 
         circuit = QuantumCircuit(1)
         circuit.extend(
@@ -661,19 +659,19 @@ class TestCliffordRZSetTranspile:
         expect = QuantumCircuit(3)
         expect.extend(
             [
-                RZ(0, -np.pi / 2.0),  # SqrtX
+                Sdag(0),  # SqrtX
                 H(0),
-                RZ(0, 0.0),  # SqrtX, SqrtXdag
+                # RZ(0, 0.0),  # SqrtX, SqrtXdag
                 H(0),
-                RZ(0, 3.0 * np.pi / 2.0),  # SqrtXdag, SqrtY
+                Sdag(0),  # SqrtXdag, SqrtY
                 H(0),
-                RZ(0, 0.0),  # SqrtY, SqrtYdag
+                # RZ(0, 0.0),  # SqrtY, SqrtYdag
                 H(0),
-                RZ(0, np.pi / 2.0),  # SqrtYdag, T, Tdag
+                S(0),  # SqrtYdag, T, Tdag
                 H(0),  # RX
                 RZ(0, theta),
                 H(0),
-                RZ(0, 3.0 * np.pi / 2.0),  # RY
+                Sdag(0),  # RY
                 H(0),
                 RZ(0, theta),
                 H(0),


### PR DESCRIPTION
## Overview

- Added `CliffordRZSetTranspiler` to convert the gate set of a quantum circuit to Clifford + RZ {H, X, Y, Z, S, Sdag, RZ, CX}.
- Simple rotation gate fusing transpiler and rotation gate to named gate conversion transpiler are added for efficiency of the converted circuit.
- By adding RZ -> HST decomposer after this transpiler, conversion path to Clifford + T can also be provided.
