### PR TITLE
Add Qiskit transpiler

### DIFF
--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -1,8 +1,6 @@
 from typing import Optional
 
 from qiskit import transpile
-
-# from qiskit.compiler import transpile
 from qiskit.providers import Backend
 
 from quri_parts.circuit import NonParametricQuantumCircuit

--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -1,3 +1,13 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 
 from qiskit import transpile
@@ -8,7 +18,7 @@ from quri_parts.circuit.transpile import CircuitTranspilerProtocol
 from quri_parts.qiskit.circuit import circuit_from_qiskit, convert_circuit
 
 
-class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
+class QiskitTranspiler(CircuitTranspilerProtocol):
     """A CircuitTranspiler that uses Qiskit's transpiler to convert circuits to
     backend-compatible circuits, convert gate sets, perform circuit
     optimization, etc.
@@ -19,8 +29,8 @@ class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
 
     Args:
         backend: Qiskit's Backend instance.
-        basis_gates: Specify the gate set after decomposition as a string of gates.
-            The gate name notation follows Qiskit.
+        basis_gates: Specify the gate set after decomposition as a list of gate name
+            strings. The gate name notation follows Qiskit.
         optimization_level: Specifies the optimization level of the circuit.
     """
 
@@ -48,5 +58,5 @@ class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
 
 
 __all__ = [
-    "QiskitOptimizationTranspiler",
+    "QiskitTranspiler",
 ]

--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -1,10 +1,11 @@
-from qiskit.providers import Backend
-from qiskit.compiler import transpile
 from typing import Optional
+
+from qiskit.compiler import transpile
+from qiskit.providers import Backend
 
 from quri_parts.circuit import NonParametricQuantumCircuit
 from quri_parts.circuit.transpile import CircuitTranspilerProtocol
-from quri_parts.qiskit.circuit import convert_circuit, circuit_from_qiskit
+from quri_parts.qiskit.circuit import circuit_from_qiskit, convert_circuit
 
 
 class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):

--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
-from qiskit.compiler import transpile
+from qiskit import transpile
+
+# from qiskit.compiler import transpile
 from qiskit.providers import Backend
 
 from quri_parts.circuit import NonParametricQuantumCircuit
@@ -9,8 +11,14 @@ from quri_parts.qiskit.circuit import circuit_from_qiskit, convert_circuit
 
 
 class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
-    def __init__(self, backend: Backend, optimization_level: Optional[int] = None):
+    def __init__(
+        self,
+        backend: Optional[Backend] = None,
+        basis_gates: Optional[list[str]] = None,
+        optimization_level: Optional[int] = None,
+    ):
         self._backend = backend
+        self._basis_gates = basis_gates
         self._optimization_level = optimization_level
 
     def __call__(
@@ -20,6 +28,12 @@ class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
         optimized_qiskit_circ = transpile(
             qiskit_circ,
             backend=self._backend,
+            basis_gates=self._basis_gates,
             optimization_level=self._optimization_level,
         )
         return circuit_from_qiskit(optimized_qiskit_circ)
+
+
+__all__ = [
+    "QiskitOptimizationTranspiler",
+]

--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -1,0 +1,24 @@
+from qiskit.providers import Backend
+from qiskit.compiler import transpile
+from typing import Optional
+
+from quri_parts.circuit import NonParametricQuantumCircuit
+from quri_parts.circuit.transpile import CircuitTranspilerProtocol
+from quri_parts.qiskit.circuit import convert_circuit, circuit_from_qiskit
+
+
+class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
+    def __init__(self, backend: Backend, optimization_level: Optional[int] = None):
+        self._backend = backend
+        self._optimization_level = optimization_level
+
+    def __call__(
+        self, circuit: NonParametricQuantumCircuit
+    ) -> NonParametricQuantumCircuit:
+        qiskit_circ = convert_circuit(circuit)
+        optimized_qiskit_circ = transpile(
+            qiskit_circ,
+            backend=self._backend,
+            optimization_level=self._optimization_level,
+        )
+        return circuit_from_qiskit(optimized_qiskit_circ)

--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -9,6 +9,21 @@ from quri_parts.qiskit.circuit import circuit_from_qiskit, convert_circuit
 
 
 class QiskitOptimizationTranspiler(CircuitTranspilerProtocol):
+    """A CircuitTranspiler that uses Qiskit's transpiler to convert circuits to
+    backend-compatible circuits, convert gate sets, perform circuit
+    optimization, etc.
+
+    This transpiler converts NonParametricQuantumCircuit to NonParametricQuantumCircuit
+    just like other transpilers in QURI Parts though the conversion of the circuit to
+    Qiskit and vice versa is performed internally.
+
+    Args:
+        backend: Qiskit's Backend instance.
+        basis_gates: Specify the gate set after decomposition as a string of gates.
+            The gate name notation follows Qiskit.
+        optimization_level: Specifies the optimization level of the circuit.
+    """
+
     def __init__(
         self,
         backend: Optional[Backend] = None,

--- a/packages/qiskit/tests/qiskit/circuit/transpile/test_transpile_qiskit.py
+++ b/packages/qiskit/tests/qiskit/circuit/transpile/test_transpile_qiskit.py
@@ -1,0 +1,82 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+from qiskit.providers.fake_provider import FakeBelemV2
+
+from quri_parts.circuit import QuantumCircuit, gate_names, gates
+from quri_parts.qiskit.circuit.transpile import QiskitOptimizationTranspiler
+
+
+def test_basis_gates() -> None:
+    circuit = QuantumCircuit(3)
+    circuit.extend(
+        [
+            gates.H(0),
+            gates.X(1),
+            gates.S(2),
+        ]
+    )
+    target = QiskitOptimizationTranspiler(basis_gates=["x", "sx", "rz", "cx"])(circuit)
+
+    expect = QuantumCircuit(3)
+    expect.extend(
+        [
+            gates.RZ(0, np.pi / 2.0),
+            gates.SqrtX(0),
+            gates.RZ(0, np.pi / 2.0),
+            gates.X(1),
+            gates.RZ(2, np.pi / 2.0),
+        ]
+    )
+    assert target == expect
+
+
+def test_optimization() -> None:
+    circuit = QuantumCircuit(1)
+    circuit.extend(
+        [
+            gates.H(0),
+            gates.H(0),
+            gates.T(0),
+            gates.X(0),
+            gates.X(0),
+        ]
+    )
+    target = QiskitOptimizationTranspiler(
+        basis_gates=["h", "x", "t"], optimization_level=2
+    )(circuit)
+
+    expect = QuantumCircuit(1)
+    expect.add_T_gate(0)
+    assert target == expect
+
+
+def test_backend() -> None:
+    backend = FakeBelemV2()
+
+    circuit = QuantumCircuit(3)
+    circuit.extend(
+        [
+            gates.H(0),
+            gates.CNOT(0, 1),
+            gates.H(1),
+            gates.CNOT(1, 2),
+            gates.H(2),
+            gates.CNOT(2, 0),
+        ]
+    )
+    target = QiskitOptimizationTranspiler(backend=backend)(circuit)
+
+    for gate in target.gates:
+        if gate.name == gate_names.CNOT:
+            assert (
+                gate.control_indices[0],
+                gate.target_indices[0],
+            ) in backend.coupling_map

--- a/packages/qiskit/tests/qiskit/circuit/transpile/test_transpile_qiskit.py
+++ b/packages/qiskit/tests/qiskit/circuit/transpile/test_transpile_qiskit.py
@@ -74,9 +74,7 @@ def test_backend() -> None:
     )
     target = QiskitOptimizationTranspiler(backend=backend)(circuit)
 
+    coupling_map = backend.coupling_map.get_edges()
     for gate in target.gates:
         if gate.name == gate_names.CNOT:
-            assert (
-                gate.control_indices[0],
-                gate.target_indices[0],
-            ) in backend.coupling_map
+            assert (gate.control_indices[0], gate.target_indices[0]) in coupling_map

--- a/packages/qiskit/tests/qiskit/circuit/transpile/test_transpile_qiskit.py
+++ b/packages/qiskit/tests/qiskit/circuit/transpile/test_transpile_qiskit.py
@@ -7,11 +7,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 from qiskit.providers.fake_provider import FakeBelemV2
 
 from quri_parts.circuit import QuantumCircuit, gate_names, gates
-from quri_parts.qiskit.circuit.transpile import QiskitOptimizationTranspiler
+from quri_parts.qiskit.circuit.transpile import QiskitTranspiler
 
 
 def test_basis_gates() -> None:
@@ -23,7 +24,7 @@ def test_basis_gates() -> None:
             gates.S(2),
         ]
     )
-    target = QiskitOptimizationTranspiler(basis_gates=["x", "sx", "rz", "cx"])(circuit)
+    target = QiskitTranspiler(basis_gates=["x", "sx", "rz", "cx"])(circuit)
 
     expect = QuantumCircuit(3)
     expect.extend(
@@ -49,9 +50,9 @@ def test_optimization() -> None:
             gates.X(0),
         ]
     )
-    target = QiskitOptimizationTranspiler(
-        basis_gates=["h", "x", "t"], optimization_level=2
-    )(circuit)
+    target = QiskitTranspiler(basis_gates=["h", "x", "t"], optimization_level=2)(
+        circuit
+    )
 
     expect = QuantumCircuit(1)
     expect.add_T_gate(0)
@@ -72,7 +73,7 @@ def test_backend() -> None:
             gates.CNOT(2, 0),
         ]
     )
-    target = QiskitOptimizationTranspiler(backend=backend)(circuit)
+    target = QiskitTranspiler(backend=backend)(circuit)
 
     coupling_map = backend.coupling_map.get_edges()
     for gate in target.gates:


### PR DESCRIPTION
- Add a QURI Parts transpiler that wraps the Qiskit transpiler.
- Users can convert QURI Parts circuits to QURI Parts circuits, just like any other QURI Parts transpiler.
- Expected applications are as follows.
  1. Conversion of gate sets and qubits for the actual IBM Quantum equipment.
  2. Gate set conversion.
  3. Circuit optimization.