### PR TITLE
Include UnitaryMatrix gate decomposers in fixed gate set decomposers

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -79,10 +79,13 @@ from .unitary_matrix_decomposer import (
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only X, SqrtX, CNOT, and RZ.
+#: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
 RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
     [
         ParallelDecomposer(
             [
+                SingleQubitUnitaryMatrix2RYRZTranspiler,
+                TwoQubitUnitaryMatrixKAKTranspiler,
                 CZ2CNOTHTranspiler(),
                 PauliDecomposeTranspiler(),
                 PauliRotationDecomposeTranspiler(),
@@ -116,10 +119,13 @@ RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only RX, RY, RZ, and CNOT.
+#: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
 RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
     [
         ParallelDecomposer(
             [
+                SingleQubitUnitaryMatrix2RYRZTranspiler,
+                TwoQubitUnitaryMatrixKAKTranspiler,
                 PauliDecomposeTranspiler(),
                 PauliRotationDecomposeTranspiler(),
                 TOFFOLI2HTTdagCNOTTranspiler(),

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -170,6 +170,8 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
     def __init__(self, epsilon: float = 1.0e-9):
         super().__init__(
             [
+                SingleQubitUnitaryMatrix2RYRZTranspiler(),
+                TwoQubitUnitaryMatrixKAKTranspiler(),
                 ParallelDecomposer(
                     [
                         CZ2CNOTHTranspiler(),

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -82,10 +82,10 @@ from .unitary_matrix_decomposer import (
 #: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
 RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
     [
+        SingleQubitUnitaryMatrix2RYRZTranspiler(),
+        TwoQubitUnitaryMatrixKAKTranspiler(),
         ParallelDecomposer(
             [
-                SingleQubitUnitaryMatrix2RYRZTranspiler,
-                TwoQubitUnitaryMatrixKAKTranspiler,
                 CZ2CNOTHTranspiler(),
                 PauliDecomposeTranspiler(),
                 PauliRotationDecomposeTranspiler(),
@@ -122,10 +122,10 @@ RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
 #: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
 RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
     [
+        SingleQubitUnitaryMatrix2RYRZTranspiler,
+        TwoQubitUnitaryMatrixKAKTranspiler,
         ParallelDecomposer(
             [
-                SingleQubitUnitaryMatrix2RYRZTranspiler,
-                TwoQubitUnitaryMatrixKAKTranspiler,
                 PauliDecomposeTranspiler(),
                 PauliRotationDecomposeTranspiler(),
                 TOFFOLI2HTTdagCNOTTranspiler(),

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -122,8 +122,8 @@ RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
 #: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
 RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
     [
-        SingleQubitUnitaryMatrix2RYRZTranspiler,
-        TwoQubitUnitaryMatrixKAKTranspiler,
+        SingleQubitUnitaryMatrix2RYRZTranspiler(),
+        TwoQubitUnitaryMatrixKAKTranspiler(),
         ParallelDecomposer(
             [
                 PauliDecomposeTranspiler(),


### PR DESCRIPTION
- UnitaryMatrix gates of 2 qubits or less are decomposed by RZSetTranspiler / RotationSetTranspiler / CliffordRZSetTranspiler.
