### PR TITLE
Fix CliffordRZSetTranspiler

### DIFF
--- a/packages/circuit/quri_parts/circuit/gates.py
+++ b/packages/circuit/quri_parts/circuit/gates.py
@@ -190,7 +190,7 @@ class RXFactory:
 
 
 RX = RXFactory()
-r"""RX gate equivalant to :math:`\exp(-i\theta X/2)` represented by matrix.
+r"""RX gate equivalant to :math:`\exp(-i\theta X/2)` represented by matrix
 :math:`\begin{pmatrix} \cos\frac{\theta}{2} & -i\sin\frac{\theta}{2} \\
 -i\sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{pmatrix}`
 """

--- a/packages/circuit/quri_parts/circuit/gates.py
+++ b/packages/circuit/quri_parts/circuit/gates.py
@@ -191,7 +191,6 @@ class RXFactory:
 
 RX = RXFactory()
 r"""RX gate equivalant to :math:`\exp(-i\theta X/2)` represented by matrix.
-
 :math:`\begin{pmatrix} \cos\frac{\theta}{2} & -i\sin\frac{\theta}{2} \\
 -i\sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{pmatrix}`
 """

--- a/packages/circuit/quri_parts/circuit/gates.py
+++ b/packages/circuit/quri_parts/circuit/gates.py
@@ -190,7 +190,8 @@ class RXFactory:
 
 
 RX = RXFactory()
-r"""RX gate equivalant to :math:`\exp(-i\theta X/2)` represented by matrix
+r"""RX gate equivalant to :math:`\exp(-i\theta X/2)` represented by matrix.
+
 :math:`\begin{pmatrix} \cos\frac{\theta}{2} & -i\sin\frac{\theta}{2} \\
 -i\sin\frac{\theta}{2} & \cos\frac{\theta}{2} \end{pmatrix}`
 """

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -159,8 +159,8 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 
 class CliffordRZSetTranspiler(SequentialTranspiler):
     """CircuitTranspiler to transpile a QuntumCircuit into another
-    QuantumCircuit containing only H, X, Y, Z, SqrtX, SqrtXdag, SqrtY, SqrtYdag,
-    S, Sdg, RZ, CZ, and CNOT.
+    QuantumCircuit containing only H, X, Y, Z, SqrtX, SqrtXdag, SqrtY,
+    SqrtYdag, S, Sdg, RZ, CZ, and CNOT.
 
     Since this transpiler involves fusing rotation gates, converting
     rotation gates to named gates with a certain precision, and removing

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -159,7 +159,8 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
 
 class CliffordRZSetTranspiler(SequentialTranspiler):
     """CircuitTranspiler to transpile a QuntumCircuit into another
-    QuantumCircuit containing only H, X, Y, Z, S, Sdg, RZ, and CNOT.
+    QuantumCircuit containing only H, X, Y, Z, SqrtX, SqrtXdag, SqrtY, SqrtYdag,
+    S, Sdg, RZ, CZ, and CNOT.
 
     Since this transpiler involves fusing rotation gates, converting
     rotation gates to named gates with a certain precision, and removing
@@ -174,7 +175,6 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
                 TwoQubitUnitaryMatrixKAKTranspiler(),
                 ParallelDecomposer(
                     [
-                        CZ2CNOTHTranspiler(),
                         PauliDecomposeTranspiler(),
                         PauliRotationDecomposeTranspiler(),
                         TOFFOLI2HTTdagCNOTTranspiler(),
@@ -182,10 +182,6 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
                 ),
                 ParallelDecomposer(
                     [
-                        SqrtXdag2RZSqrtXTranspiler(),
-                        SqrtY2RZSqrtXTranspiler(),
-                        SqrtYdag2RZSqrtXTranspiler(),
-                        Sdag2RZTranspiler(),
                         T2RZTranspiler(),
                         Tdag2RZTranspiler(),
                         RX2RZSqrtXTranspiler(),
@@ -196,7 +192,6 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
                         SWAP2CNOTTranspiler(),
                     ]
                 ),
-                SqrtX2RZHTranspiler(),
                 FuseRotationTranspiler(),
                 RX2NamedTranspiler(epsilon),
                 RY2NamedTranspiler(epsilon),

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -640,11 +640,6 @@ class TestCliffordRZSetTranspile:
         circuit = QuantumCircuit(1)
         circuit.extend(
             [
-                SqrtX(0),
-                SqrtXdag(0),
-                SqrtY(0),
-                SqrtYdag(0),
-                Sdag(0),
                 T(0),
                 Tdag(0),
                 RX(0, theta),
@@ -659,16 +654,7 @@ class TestCliffordRZSetTranspile:
         expect = QuantumCircuit(3)
         expect.extend(
             [
-                Sdag(0),  # SqrtX
-                H(0),
-                # RZ(0, 0.0),  # SqrtX, SqrtXdag
-                H(0),
-                Sdag(0),  # SqrtXdag, SqrtY
-                H(0),
-                # RZ(0, 0.0),  # SqrtY, SqrtYdag
-                H(0),
-                S(0),  # SqrtYdag, T, Tdag
-                H(0),  # RX
+                H(0),  # T, Tdag, RX
                 RZ(0, theta),
                 H(0),
                 Sdag(0),  # RY

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -654,20 +654,21 @@ class TestCliffordRZSetTranspile:
         expect = QuantumCircuit(3)
         expect.extend(
             [
-                H(0),  # T, Tdag, RX
-                RZ(0, theta),
-                H(0),
-                Sdag(0),  # RY
-                H(0),
-                RZ(0, theta),
-                H(0),
-                RZ(0, (-np.pi / 2.0 + 2.0 * lam) % (2.0 * np.pi)),  # RY, U1, U2
-                H(0),
-                RZ(0, (phi + lam - np.pi / 2.0) % (2.0 * np.pi)),  # U2, U3
-                H(0),
-                RZ(0, theta),
-                H(0),
-                RZ(0, (phi + np.pi / 2.0) % (2.0 * np.pi)),
+                S(0),  # T, Tdag, RX
+                SqrtX(0),
+                RZ(0, theta + np.pi),
+                SqrtX(0),
+                S(0),
+                SqrtX(0),  # RY
+                RZ(0, theta + np.pi),
+                SqrtX(0),
+                RZ(0, np.pi / 2.0 + 2.0 * lam),  # U1, U2
+                SqrtX(0),
+                RZ(0, phi + lam + np.pi / 2.0),  # U2, U3
+                SqrtX(0),
+                RZ(0, theta + np.pi),
+                SqrtX(0),
+                RZ(0, phi + 3.0 * np.pi),
             ]
         )
 


### PR DESCRIPTION
- CliffordRZSetTranspiler now does not decompose SqrtX, SqrtXdag, SqrtY, SqrtYdag, and CZ gates.