### PR TITLE
Reduce execution time of GitHub Actions

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,6 +2,11 @@ name: Document
 
 on:
   pull_request:
+    paths:
+      - packages/**/*.py
+      - docs
+      - poetry.lock
+      - .github/workflows/doc.yml
   push:
     branches: [main]
 
@@ -22,7 +27,6 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-        cache: 'poetry'
 
     - name: Download pandoc
       if: steps.cache-pandoc.outputs.cache-hit != 'true'
@@ -34,7 +38,7 @@ jobs:
         yes | sudo dpkg -i pandoc-2.18-1-amd64.deb
 
     - run: |
-        poetry install -vvv
+        poetry install --only main,doc
 
     - run: poetry run julia -e 'using Pkg; Pkg.add("PythonCall")'
   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Lint
 
 on:
   pull_request:
+    paths:
+      - packages/**/*.py
+      - pyproject.toml
+      - .flake8
+      - .github/workflows/lint.yml
   push:
     branches: [main]
 
@@ -22,22 +27,18 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-        cache: 'poetry'
 
     - run: |
-        poetry install -vvv
+        poetry install --only lint
 
-    - run: poetry run isort . --check --diff
+    - run: poetry run isort packages --check --diff
       if: success() || failure()
 
-    - run: poetry run black . --check
+    - run: poetry run black packages --check
       if: success() || failure()
 
-    - run: poetry run flake8
+    - run: poetry run flake8 packages
       if: success() || failure()
 
-    - run: poetry run mypy .
-      if: success() || failure()
-
-    - run: poetry run docformatter -c -r .
+    - run: poetry run docformatter -c -r packages
       if: success() || failure()

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,16 +1,17 @@
-name: Test
+name: Type check
 
 on:
   pull_request:
     paths:
       - packages/**/*.py
       - poetry.lock
-      - .github/workflows/test.yml
+      - mypy.ini
+      - .github/workflows/typecheck.yml
   push:
     branches: [main]
 
 jobs:
-  test:
+  typecheck:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,8 +29,10 @@ jobs:
         python-version: '3.9'
 
     - run: |
-        poetry install --only main,dev
+        poetry install --only main,dev,typecheck
 
-    - run: poetry run julia -e 'using Pkg; Pkg.add("PythonCall")'
+    - name: Cache mypy cache
+      uses: AustinScola/mypy-cache-github-action@v1.0.0
 
-    - run: poetry run pytest
+    - run: poetry run mypy .
+      if: success() || failure()

--- a/poetry.lock
+++ b/poetry.lock
@@ -4803,4 +4803,4 @@ tket = ["quri-parts-tket"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.8,<3.12"
-content-hash = "12b98a0a50f7997a3f0ce8efa55af093abdab8510885f7440c4b479cefc7868f"
+content-hash = "b57dd089b6fd57cc212efd6bf28d363439e0b5b3b3707040bea63e09581f6331"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,23 @@ quri-parts-itensor = {path = "packages/itensor", develop = true}
 quri-parts-pyscf = {path = "packages/pyscf", develop = true}
 quri-parts-tket = {path = "packages/tket", develop = true}
 
+# To avoid poetry downloading hundreds versions of botocore
+# https://github.com/python-poetry/poetry/issues/7858
+botocore = ">=1.29.115"
+
 pytest = "^7.0.1"
+
+[tool.poetry.group.lint.dependencies]
+black = "^23.1.0"
 flake8 = ">=4.0.1,<7.0.0"
-mypy = ">=0.950"
 # Exclude docformatter 1.6.0 to avoid this issue: https://github.com/PyCQA/docformatter/issues/161
 docformatter = "^1.4,!=1.6.0"
 isort = "^5.10.1"
 
+[tool.poetry.group.typecheck.dependencies]
+mypy = ">=0.950"
+
+[tool.poetry.group.doc.dependencies]
 Sphinx = ">=4.4,<7.0"
 furo = ">=2022.2.23,<2024.0.0"
 sphinx-autobuild = "^2021.3.14"
@@ -90,7 +100,6 @@ nbsphinx = ">=0.8.9,<0.10.0"
 ipython = "^8.4.0"
 notebook = "^6.4.12"
 myst-parser = ">=0.18.1,<1.1.0"
-black = "^23.1.0"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
- Grouped dev depedencies into groups: `dev`, `lint`, `typecheck` and `doc`
- Split `lint.yml` workflow into two: `typecheck.yml` and `lint.yml`
- In each workflow (`lint`, `typecheck`, `test` and `doc`), only necessary dependencies are installed with `poetry install --only [groups]`
  - Since installed dependecies change depending on the workflow, I disabled caching of poetry virtualenv. (It may be safe to keep it enabled, but it is not likely that the caching provides much improvement on the execution time)
- Introduced caching of mypy cache files.
- Each of the above workflows are now configured as executed only when relevant files are modified by a pull request.