### PR TITLE
Add fusing rotation gates to the preset gate set decomposition paths

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -113,6 +113,7 @@ RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
                 SWAP2CNOTTranspiler(),
             ]
         ),
+        FuseRotationTranspiler(),
     ]
 )
 
@@ -153,6 +154,7 @@ RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTrans
                 SWAP2CNOTTranspiler(),
             ]
         ),
+        FuseRotationTranspiler(),
     ]
 )
 

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -461,8 +461,8 @@ class TestRZSetTranspile:
                 CNOT(1, 2),
                 RZ(2, -np.pi / 4.0),  # Tdag
                 CNOT(0, 2),
-                RZ(1, np.pi / 4.0),  # T, H
-                RZ(2, np.pi * 3.0 / 4.0),
+                RZ(1, np.pi / 4.0),  # T
+                RZ(2, np.pi * 3.0 / 4.0),  # T, H
                 SqrtX(2),
                 RZ(2, np.pi / 2.0),
                 CNOT(0, 1),

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -461,9 +461,8 @@ class TestRZSetTranspile:
                 CNOT(1, 2),
                 RZ(2, -np.pi / 4.0),  # Tdag
                 CNOT(0, 2),
-                RZ(1, np.pi / 4.0),  # T
-                RZ(2, np.pi / 4.0),  # T
-                RZ(2, np.pi / 2.0),  # H
+                RZ(1, np.pi / 4.0),  # T, H
+                RZ(2, np.pi * 3.0 / 4.0),
                 SqrtX(2),
                 RZ(2, np.pi / 2.0),
                 CNOT(0, 1),


### PR DESCRIPTION
- Since the decomposition paths to prefix gate sets only transforms individual gates, it often yields a series of rotation gates. As a minimal optimization, added a path that fuses these rotation gates.
- No further optimizations were included in the decomposition paths so that the optimization can be controlled by the user.