### PR TITLE
Trigger lint CI when poetry.lock is updated

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - packages/**/*.py
       - pyproject.toml
+      - poetry.lock
       - .flake8
       - .github/workflows/lint.yml
   push:


### PR DESCRIPTION
Lint CI should be triggered when versions of lint tools are updated in `poetry.lock`.