### PR TITLE
Fix document build: install all sub packages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -38,7 +38,7 @@ jobs:
         yes | sudo dpkg -i pandoc-2.18-1-amd64.deb
 
     - run: |
-        poetry install --only main,doc
+        poetry install --only main,dev,doc
 
     - run: poetry run julia -e 'using Pkg; Pkg.add("PythonCall")'
   


### PR DESCRIPTION
Optional sub packages were not installed in the document build workflow, resulting in missing documentation for them.
Documentation of packages *other than the followings* were missing:

- quri-parts-circuit
- quri-parts-core
- quri-parts-algo
- quri-parts-chem

Example: [quri_parts.qulacs.operator page](https://quri-parts.qunasys.com/quri_parts/qulacs/quri_parts.qulacs.operator.html) is empty now, while [deploy preview](https://deploy-preview-126--quri-parts.netlify.app/quri_parts/qulacs/quri_parts.qulacs.operator.html) of the same page has its content.