### PR TITLE
Change python version invariant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ enable = true
 style = "pep440"
 
 [tool.poetry.dependencies]
-python = "^3.9.8,<3.12"
+python = "^3.9.8,<3.11"
 quri-parts-core = "*"
 quri-parts-circuit = "*"
 quri-parts-algo = "*"


### PR DESCRIPTION
Using python=3.11 causes some error:

```
ERROR packages/algo/tests/algo/optimizer/test_adam.py - ValueError: mutable default <class 'numpy.ndarray'> for field m is not allowed: use default_factory
ERROR packages/algo/tests/algo/optimizer/test_lbfgs.py - ValueError: mutable default <class 'numpy.ndarray'> for field m is not allowed: use default_factory
ERROR packages/algo/tests/algo/optimizer/test_nft.py - ValueError: mutable default <class 'numpy.ndarray'> for field m is not allowed: use default_factory
ERROR packages/algo/tests/algo/optimizer/test_spsa.py - ValueError: mutable default <class 'numpy.ndarray'> for field m is not allowed: use default_factory
ERROR packages/chem/tests/chem/mol/test_active_space_error_message.py - ValueError: mutable default <class 'numpy.ndarray'> for field _mo_coeff is not allowed: use default_factory
ERROR packages/chem/tests/chem/mol/test_ao_eint_set.py - ValueError: mutable default <class 'numpy.ndarray'> for field _mo_coeff is not allowed: use default_factory
ERROR packages/chem/tests/chem/mol/test_effective_eints.py - ValueError: mutable default <class 'numpy.ndarray'> for field _mo_coeff is not allowed: use default_factory
```

This is simple fix to prevent it.