### PR TITLE
Support computational basis state for evaluate state to vector

### DIFF
--- a/packages/qulacs/quri_parts/qulacs/simulator.py
+++ b/packages/qulacs/quri_parts/qulacs/simulator.py
@@ -5,14 +5,14 @@ from numpy import cfloat, zeros
 from numpy.typing import NDArray
 
 from quri_parts.circuit import NonParametricQuantumCircuit
-from quri_parts.core.state import GeneralCircuitQuantumState, QuantumStateVector
+from quri_parts.core.state import CircuitQuantumState, QuantumStateVector
 from quri_parts.qulacs.circuit import convert_circuit
 
 from . import cast_to_list
 
 
 def evaluate_state_to_vector(
-    state: Union[GeneralCircuitQuantumState, QuantumStateVector]
+    state: Union[CircuitQuantumState, QuantumStateVector]
 ) -> QuantumStateVector:
     """Convert GeneralCircuitQuantumState or QuantumStateVector to
     QuantumStateVector that only contains the state vector."""
@@ -20,7 +20,7 @@ def evaluate_state_to_vector(
 
     if isinstance(state, QuantumStateVector):
         init_state_vector = state.vector
-    elif isinstance(state, GeneralCircuitQuantumState):
+    elif isinstance(state, CircuitQuantumState):
         init_state_vector = zeros(2**n_qubits, dtype=complex)
         init_state_vector[0] = 1.0
     else:

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -1,7 +1,11 @@
 from numpy import allclose, array, pi
 
 from quri_parts.circuit import QuantumCircuit
-from quri_parts.core.state import GeneralCircuitQuantumState, QuantumStateVector
+from quri_parts.core.state import (
+    ComputationalBasisState,
+    GeneralCircuitQuantumState,
+    QuantumStateVector,
+)
 from quri_parts.qulacs.simulator import evaluate_state_to_vector, run_circuit
 
 
@@ -52,6 +56,16 @@ def test_evaluate_state_to_vector_vec_to_vec() -> None:
             0.676132 - 0.0306967j,
         ]
     )
+
+    assert len(quantum_state_vector.circuit.gates) == 0
+    assert allclose(quantum_state_vector.vector, expect_output_vector)
+
+
+def test_evaluate_state_to_vector_comp_state_to_vec() -> None:
+    circuit_quantum_state = ComputationalBasisState(4, bits=0b0101)
+    quantum_state_vector = evaluate_state_to_vector(circuit_quantum_state)
+
+    expect_output_vector = array([0] * 5 + [1] + [0] * 10)
 
     assert len(quantum_state_vector.circuit.gates) == 0
     assert allclose(quantum_state_vector.vector, expect_output_vector)


### PR DESCRIPTION
Input of `evaluate_state_to_vector` is changed from `Union[QuantumStateVector, GeneralCircuitQuantumState]` to `Union[QuantumStateVector, CircuitQuantumState]` to support evaluating `ComputationalBasisState` to `QuantumStateVector`.