### PR TITLE
Bug fix for single sampling job

### DIFF
--- a/packages/qiskit/quri_parts/qiskit/backend/sampling.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/sampling.py
@@ -167,7 +167,7 @@ class QiskitSamplingBackend(SamplingBackend):
         qubit_mapped_jobs = [self._job_mapper(job) for job in jobs]
         return (
             qubit_mapped_jobs[0]
-            if len(qubit_mapped_jobs) == 0
+            if len(qubit_mapped_jobs) == 1
             else CompositeSamplingJob(qubit_mapped_jobs)
         )
 

--- a/packages/qiskit/quri_parts/qiskit/backend/saved_sampling.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/saved_sampling.py
@@ -215,7 +215,7 @@ class QiskitSavedDataSamplingBackend(SamplingBackend):
                 raise KeyError("This experiment is not in the saved data.")
 
         jobs = [self._job_mapper(job) for job in jobs]
-        return jobs[0] if len(jobs) == 0 else CompositeSamplingJob(jobs)
+        return jobs[0] if len(jobs) == 1 else CompositeSamplingJob(jobs)
 
     def _load_data(self, json_str: str) -> SavedDataType:
         saved_data = defaultdict(list)

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_backend.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_backend.py
@@ -22,6 +22,7 @@ from quri_parts.circuit import NonParametricQuantumCircuit, QuantumCircuit
 from quri_parts.circuit.transpile import CircuitTranspiler
 from quri_parts.qiskit.backend import (
     QiskitSamplingBackend,
+    QiskitSamplingJob,
     QiskitSavedDataSamplingJob,
     QiskitSavedDataSamplingResult,
 )
@@ -55,6 +56,7 @@ class TestQiskitSamplingBackend:
         job = backend.sample(QuantumCircuit(4), 1000)
         counts = job.result().counts
 
+        assert isinstance(job, QiskitSamplingJob)
         assert set(counts.keys()) == {0b0000, 0b0001, 0b0100, 0b0101}
         assert all(c >= 0 for c in counts.values())
         assert sum(counts.values()) == 1000
@@ -70,6 +72,7 @@ class TestQiskitSamplingBackend:
         job = backend.sample(circuit, 1000)
         counts = job.result().counts
 
+        assert isinstance(job, QiskitSamplingJob)
         assert set(counts.keys()) == {0b001, 0b011}
         assert all(c >= 0 for c in counts.values())
         assert sum(counts.values()) == 1000
@@ -83,6 +86,7 @@ class TestQiskitSamplingBackend:
         job = backend.sample(circuit, 1000)
         counts = job.result().counts
 
+        assert isinstance(job, QiskitSamplingJob)
         assert set(counts.keys()) == {0b1001, 0b1011}
         assert all(c >= 0 for c in counts.values())
         assert sum(counts.values()) == 1000
@@ -95,6 +99,7 @@ class TestQiskitSamplingBackend:
         job = backend.sample(QuantumCircuit(4), 50)
         counts = job.result().counts
 
+        assert isinstance(job, QiskitSamplingJob)
         assert set(counts.keys()) == {0b0000, 0b0001, 0b0100, 0b0101}
         assert all(c >= 0 for c in counts.values())
         assert sum(counts.values()) == 1000


### PR DESCRIPTION
Bug fix: Return `QiskitSamplingJob` (`QiskitSaveDataSamplingJob`) for single sampling job instead of `CompositeSamplingJob`