### PR TITLE
Fix dtype for ndarray in Optimizers

### DIFF
--- a/packages/algo/quri_parts/algo/optimizer/adam.py
+++ b/packages/algo/quri_parts/algo/optimizer/adam.py
@@ -96,7 +96,7 @@ class Adam(Optimizer):
 
     def get_init_state(self, init_params: Params) -> OptimizerStateAdam:
         # Defensively copy init_params by np.array
-        params = readonly_array(np.array(init_params))
+        params = readonly_array(np.array(init_params, dtype=float))
         zeros = readonly_array(np.zeros(len(params), dtype=float))
         return OptimizerStateAdam(
             params=params,

--- a/packages/algo/quri_parts/algo/optimizer/lbfgs.py
+++ b/packages/algo/quri_parts/algo/optimizer/lbfgs.py
@@ -49,7 +49,7 @@ class OptimizerStateLBFGS(OptimizerState):
     y: Params = _const_zero_array
     rho: Params = _const_zero_array
 
-    cost_prev: float = 0
+    cost_prev: float = 0.0
     ind: int = 0
     a: Params = _const_zero_array
 
@@ -125,7 +125,7 @@ class LBFGS(Optimizer):
             self._gtol = create_gtol(gtol)
 
     def get_init_state(self, init_params: Params) -> OptimizerStateLBFGS:
-        params = readonly_array(np.array(init_params))
+        params = readonly_array(np.array(init_params, dtype=float))
         zeros2d = readonly_array(np.zeros((self._m, len(params)), dtype=float))
         zeros = readonly_array(np.zeros(self._m, dtype=float))
         return OptimizerStateLBFGS(
@@ -135,7 +135,7 @@ class LBFGS(Optimizer):
             s=zeros2d,
             y=zeros2d,
             rho=zeros,
-            cost_prev=0,
+            cost_prev=0.0,
             ind=0,
             a=zeros,
         )
@@ -168,7 +168,7 @@ class LBFGS(Optimizer):
 
             grad = grad_function(params)
             gradcalls += 1
-            cost_prev = cost + cast(float, np.linalg.norm(grad)) / 2
+            cost_prev = cost + cast(float, np.linalg.norm(grad)) / 2.0
 
             p = -grad
 
@@ -227,7 +227,7 @@ class LBFGS(Optimizer):
         y[ind] = grad_next - grad
 
         rho_inv = np.dot(s[ind], y[ind])
-        rho[ind] = self._rho_const if rho_inv == 0.0 else 1 / rho_inv
+        rho[ind] = self._rho_const if rho_inv == 0.0 else 1.0 / rho_inv
 
         grad = grad_next
 

--- a/packages/algo/quri_parts/algo/optimizer/nft.py
+++ b/packages/algo/quri_parts/algo/optimizer/nft.py
@@ -50,7 +50,7 @@ class NFTBase(Optimizer):
             self._ftol = create_ftol(ftol)
 
     def get_init_state(self, init_params: Params) -> OptimizerStateNFT:
-        params = readonly_array(np.array(init_params))
+        params = readonly_array(np.array(init_params, dtype=float))
         return OptimizerStateNFT(
             params=params,
         )
@@ -174,18 +174,18 @@ class NFT(NFTBase):
                 z0 = cost
 
             p = params.copy()
-            p[idx] = params[idx] + np.pi / 2
+            p[idx] = params[idx] + np.pi / 2.0
             z1 = cost_function(p)
             funcalls += 1
 
             p = params.copy()
-            p[idx] = params[idx] - np.pi / 2
+            p[idx] = params[idx] - np.pi / 2.0
             z3 = cost_function(p)
             funcalls += 1
 
             z2 = z1 + z3 - z0
-            c = (z1 + z3) / 2
-            a = np.sqrt((z0 - z2) ** 2 + (z1 - z3) ** 2) / 2
+            c = (z1 + z3) / 2.0
+            a = np.sqrt((z0 - z2) ** 2 + (z1 - z3) ** 2) / 2.0
             b = (
                 np.arctan((z1 - z3) / ((z0 - z2) + self._eps * (z0 == z2)))
                 + params[idx]
@@ -251,7 +251,7 @@ class NFTfit(NFTBase):
             # while if `A < 0` minimum at `x=b`
             fit_result, _ = curve_fit(_fit_func, x_data, y_data)
             a, b, _ = fit_result
-            params[idx] = b + np.pi if a > 0 else b
+            params[idx] = b + np.pi if a > 0.0 else b
 
         cost = cost_function(params)
         funcalls += 1

--- a/packages/algo/quri_parts/algo/optimizer/spsa.py
+++ b/packages/algo/quri_parts/algo/optimizer/spsa.py
@@ -78,7 +78,7 @@ class SPSA(Optimizer):
 
     def __init__(
         self,
-        a: float = 2 * np.pi / 10,
+        a: float = 2.0 * np.pi / 10.0,
         c: float = 0.1,
         alpha: float = 0.602,
         gamma: float = 0.101,
@@ -108,7 +108,7 @@ class SPSA(Optimizer):
             self._ftol = create_ftol(ftol)
 
     def get_init_state(self, init_params: Params) -> OptimizerStateSPSA:
-        params = readonly_array(np.array(init_params))
+        params = readonly_array(np.array(init_params, dtype=float))
         rng = np.random.default_rng(seed=self._rng_seed)
         return OptimizerStateSPSA(
             params=params,


### PR DESCRIPTION
- For optimziers, explicitly state dtype=float when creating ndarray for parameters and fix literals for float variables.