### PR TITLE
Add CircuitTranspiler to normalize rotation gate parameters

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -13,6 +13,7 @@ from typing import Callable
 from .clifford_approximation import CliffordApproximationTranspiler
 from .fuse import (
     FuseRotationTranspiler,
+    NormalizeRotationTranspiler,
     RX2NamedTranspiler,
     RY2NamedTranspiler,
     RZ2NamedTranspiler,
@@ -221,6 +222,7 @@ __all__ = [
     "CZ2CNOTHTranspiler",
     "CZ2RXRYCNOTTranspiler",
     "FuseRotationTranspiler",
+    "NormalizeRotationTranspiler",
     "H2RXRYTranspiler",
     "H2RZSqrtXTranspiler",
     "QubitRemappingTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -79,8 +79,8 @@ class FuseRotationTranspiler(TwoGateFuser):
 
 
 class RX2NamedTranspiler(GateKindDecomposer):
-    """Convert RX gate to Identity or X gate if it is equivalent to Identity or
-    X gate."""
+    """Convert RX gate to Identity or X gate if it is equivalent to Identity,
+    X, SqrtX, or SqrtXdag gate."""
 
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon
@@ -109,8 +109,8 @@ class RX2NamedTranspiler(GateKindDecomposer):
 
 
 class RY2NamedTranspiler(GateKindDecomposer):
-    """Convert RY gate to Identity or Y gate if it is equivalent to Identity or
-    Y gate."""
+    """Convert RY gate to Identity or Y gate if it is equivalent to Identity,
+    Y, SqrtY, or SqrtYdag gate."""
 
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon
@@ -140,7 +140,7 @@ class RY2NamedTranspiler(GateKindDecomposer):
 
 class RZ2NamedTranspiler(GateKindDecomposer):
     """Convert RZ gate to Identity, Z, S, Sdag, T, or Tdag gate if it is
-    equivalent to one of these gates."""
+    equivalent to a sequence of these gates."""
 
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -150,14 +150,18 @@ class RZ2NamedTranspiler(GateKindDecomposer):
 
         if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
-        elif self._is_close(theta, np.pi):
-            return [gates.Z(target)]
-        elif self._is_close(theta, np.pi / 2.0):
-            return [gates.S(target)]
-        elif self._is_close(theta, 3.0 * np.pi / 2.0):
-            return [gates.Sdag(target)]
         elif self._is_close(theta, np.pi / 4.0):
             return [gates.T(target)]
+        elif self._is_close(theta, np.pi / 2.0):
+            return [gates.S(target)]
+        elif self._is_close(theta, 3.0 * np.pi / 4.0):
+            return [gates.S(target), gates.T(target)]
+        elif self._is_close(theta, np.pi):
+            return [gates.Z(target)]
+        elif self._is_close(theta, 5.0 * np.pi / 4.0):
+            return [gates.Z(target), gates.T(target)]
+        elif self._is_close(theta, 3.0 * np.pi / 2.0):
+            return [gates.Sdag(target)]
         elif self._is_close(theta, 7.0 * np.pi / 4.0):
             return [gates.Tdag(target)]
         else:

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -84,13 +84,18 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
 
     Args:
         cycle_range: Specify a range of width 2PI in the form of (lower limit,
-        upper limit).
+        upper limit). Lower limit is inclusive and upper limit is exclusive.
     """
 
-    def __init__(self, cycle_range: tuple[float, float] = (0.0, np.pi * 2.0)):
+    def __init__(
+        self,
+        cycle_range: tuple[float, float] = (0.0, np.pi * 2.0),
+        epsilon: float = 1.0e-9,
+    ):
         if not cycle_range[1] > cycle_range[0]:  # Do not accept 0 width.
             raise ValueError("Specify (lower limit, upper limit) for cycle_range.")
-        self._width = cycle_range[1] - cycle_range[0]
+        if abs(cycle_range[1] - cycle_range[0] - np.pi * 2.0) > epsilon:
+            raise ValueError("The width of the cycle range must be 2PI.")
         self._upper = cycle_range[1]
 
     @property
@@ -98,7 +103,7 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
         return [gate_names.RX, gate_names.RY, gate_names.RZ]
 
     def _normalize(self, theta: float) -> float:
-        t = theta % self._width
+        t = theta % (2.0 * np.pi)
         # For boundary, take lower limit.
         t = t - self._width if not t < self._upper else t
         return t

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -103,7 +103,7 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
         return [gate_names.RX, gate_names.RY, gate_names.RZ]
 
     def _normalize(self, theta: float) -> float:
-        t = theta % (2.0 * np.pi)
+        t = theta % (np.pi * 2.0)
         # For boundary, take lower limit.
         t = t - self._width if not t < self._upper else t
         return t

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -105,7 +105,7 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
     def _normalize(self, theta: float) -> float:
         t = theta % (np.pi * 2.0)
         # For boundary, take lower limit.
-        t = t - self._width if not t < self._upper else t
+        t = t - (np.pi * 2.0) if not t < self._upper else t
         return t
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -8,7 +8,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -83,7 +83,7 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
     they are in the specified range (0 to 2PI by default)."""
 
     def __init__(self, cycle_range: tuple[float, float] = (0.0, np.pi * 2.0)):
-        if not cycle_range[1] > cycle_range[0]:
+        if not cycle_range[1] > cycle_range[0]:  # Do not accept 0 width.
             raise ValueError("Specify (lower limit, upper limit) for cycle_range.")
         self._width = cycle_range[1] - cycle_range[0]
         self._upper = cycle_range[1]
@@ -94,7 +94,8 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
 
     def _normalize(self, theta: float) -> float:
         t = theta % self._width
-        t = t - self._width if t > self._upper else t
+        # For boundary, take lower limit.
+        t = t - self._width if not t < self._upper else t
         return t
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -98,8 +98,12 @@ class RX2NamedTranspiler(GateKindDecomposer):
 
         if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
+        elif self._is_close(theta, np.pi / 2.0):
+            return [gates.SqrtX(target)]
         elif self._is_close(theta, np.pi):
             return [gates.X(target)]
+        elif self._is_close(theta, np.pi * 3.0 / 2.0):
+            return [gates.SqrtXdag(target)]
         else:
             return [gate]
 
@@ -124,8 +128,12 @@ class RY2NamedTranspiler(GateKindDecomposer):
 
         if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
+        elif self._is_close(theta, np.pi / 2.0):
+            return [gates.SqrtY(target)]
         elif self._is_close(theta, np.pi):
             return [gates.Y(target)]
+        elif self._is_close(theta, np.pi * 3.0 / 2.0):
+            return [gates.SqrtYdag(target)]
         else:
             return [gate]
 

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -80,7 +80,12 @@ class FuseRotationTranspiler(TwoGateFuser):
 
 class NormalizeRotationTranspiler(GateKindDecomposer):
     """Normalize the parameters of the rotation gates (RX, RY, and RZ) so that
-    they are in the specified range (0 to 2PI by default)."""
+    they are in the specified range (0 to 2PI by default).
+
+    Args:
+        cycle_range: Specify a range of width 2PI in the form of (lower limit,
+        upper limit).
+    """
 
     def __init__(self, cycle_range: tuple[float, float] = (0.0, np.pi * 2.0)):
         if not cycle_range[1] > cycle_range[0]:  # Do not accept 0 width.

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -104,10 +104,7 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
         return [gate_names.RX, gate_names.RY, gate_names.RZ]
 
     def _normalize(self, theta: float) -> float:
-        t = theta % (np.pi * 2.0)
-        n = math.ceil((self._lower - t) / (2.0 * np.pi))
-        t += 2.0 * np.pi * n
-        return t
+        return ((theta - self._lower) % (np.pi * 2.0)) + self._lower
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
         theta = self._normalize(gate.params[0])

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -8,6 +8,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
@@ -96,7 +97,7 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
             raise ValueError("Specify (lower limit, upper limit) for cycle_range.")
         if abs(cycle_range[1] - cycle_range[0] - np.pi * 2.0) > epsilon:
             raise ValueError("The width of the cycle range must be 2PI.")
-        self._upper = cycle_range[1]
+        self._lower, self._upper = cycle_range
 
     @property
     def target_gate_names(self) -> Sequence[str]:
@@ -104,8 +105,8 @@ class NormalizeRotationTranspiler(GateKindDecomposer):
 
     def _normalize(self, theta: float) -> float:
         t = theta % (np.pi * 2.0)
-        # For boundary, take lower limit.
-        t = t - (np.pi * 2.0) if not t < self._upper else t
+        n = math.ceil((self._lower - t) / (2.0 * np.pi))
+        t += 2.0 * np.pi * n
         return t
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -131,6 +131,8 @@ class TestNormalizeRotation:
         circuit = QuantumCircuit(1)
         circuit.extend(
             [
+                gates.RZ(0, -2.0 * np.pi),
+                gates.RY(0, -np.pi),
                 gates.RX(0, 0.0),
                 gates.RY(0, np.pi),
                 gates.RZ(0, 2.0 * np.pi),
@@ -141,6 +143,8 @@ class TestNormalizeRotation:
         expect = QuantumCircuit(1)
         expect.extend(
             [
+                gates.RZ(0, 4.0 * np.pi),
+                gates.RY(0, 3.0 * np.pi),
                 gates.RX(0, 4.0 * np.pi),
                 gates.RY(0, 3.0 * np.pi),
                 gates.RZ(0, 4.0 * np.pi),
@@ -154,6 +158,8 @@ class TestNormalizeRotation:
         circuit = QuantumCircuit(1)
         circuit.extend(
             [
+                gates.RZ(0, -2.0 * np.pi),
+                gates.RY(0, -np.pi),
                 gates.RX(0, 0.0),
                 gates.RY(0, np.pi),
                 gates.RZ(0, 2.0 * np.pi),
@@ -164,6 +170,8 @@ class TestNormalizeRotation:
         expect = QuantumCircuit(1)
         expect.extend(
             [
+                gates.RZ(0, -4.0 * np.pi),
+                gates.RY(0, -5.0 * np.pi),
                 gates.RX(0, -4.0 * np.pi),
                 gates.RY(0, -5.0 * np.pi),
                 gates.RZ(0, -4.0 * np.pi),

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -118,8 +118,8 @@ class TestNormalizeRotation:
                 gates.RX(0, -np.pi / 2.0),
                 gates.RY(0, -3.0 / 4.0 * np.pi),
                 gates.RZ(0, -np.pi / 2.0),
-                gates.RX(0, np.pi),
-                gates.RY(0, np.pi),
+                gates.RX(0, -np.pi),
+                gates.RY(0, -np.pi),
                 gates.RZ(0, 0.0),
             ]
         )

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -115,11 +115,16 @@ class TestRotation2Named:
         circuit.extend(
             [
                 gates.RZ(0, 0.0),
-                gates.RZ(0, np.pi),
-                gates.RZ(0, -np.pi),
-                gates.RZ(0, np.pi / 2.0),
-                gates.RZ(0, -np.pi / 2.0),
                 gates.RZ(0, np.pi / 4.0),
+                gates.RZ(0, np.pi / 2.0),
+                gates.RZ(0, np.pi * 3.0 / 4.0),
+                gates.RZ(0, np.pi),
+                gates.RZ(0, np.pi * 5.0 / 4.0),
+                gates.RZ(0, np.pi * 3.0 / 2.0),
+                gates.RZ(0, np.pi * 7.0 / 4.0),
+                gates.RZ(0, np.pi * 2.0),
+                gates.RZ(0, -np.pi),
+                gates.RZ(0, -np.pi / 2.0),
                 gates.RZ(0, -np.pi / 4.0),
             ]
         )
@@ -129,11 +134,18 @@ class TestRotation2Named:
         expect.extend(
             [
                 gates.Identity(0),
-                gates.Z(0),
-                gates.Z(0),
-                gates.S(0),
-                gates.Sdag(0),
                 gates.T(0),
+                gates.S(0),
+                gates.S(0),
+                gates.T(0),
+                gates.Z(0),
+                gates.Z(0),
+                gates.T(0),
+                gates.Sdag(0),
+                gates.Tdag(0),
+                gates.Identity(0),
+                gates.Z(0),
+                gates.Sdag(0),
                 gates.Tdag(0),
             ]
         )

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -127,6 +127,52 @@ class TestNormalizeRotation:
         for t, e in zip(transpiled.gates, expect.gates):
             assert _gates_close(t, e)
 
+    def test_normalize_5pi(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.extend(
+            [
+                gates.RX(0, 0.0),
+                gates.RY(0, np.pi),
+                gates.RZ(0, 2.0 * np.pi),
+            ]
+        )
+        transpiled = NormalizeRotationTranspiler((3.0 * np.pi, 5.0 * np.pi))(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                gates.RX(0, 4.0 * np.pi),
+                gates.RY(0, 3.0 * np.pi),
+                gates.RZ(0, 4.0 * np.pi),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            assert _gates_close(t, e)
+
+    def test_normalize_minus3pi(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.extend(
+            [
+                gates.RX(0, 0.0),
+                gates.RY(0, np.pi),
+                gates.RZ(0, 2.0 * np.pi),
+            ]
+        )
+        transpiled = NormalizeRotationTranspiler((-5.0 * np.pi, -3.0 * np.pi))(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                gates.RX(0, -4.0 * np.pi),
+                gates.RY(0, -5.0 * np.pi),
+                gates.RZ(0, -4.0 * np.pi),
+            ]
+        )
+
+        for t, e in zip(transpiled.gates, expect.gates):
+            assert _gates_close(t, e)
+
 
 class TestRotation2Named:
     def test_rx2named(self) -> None:

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -73,7 +73,9 @@ class TestRotation2Named:
         circuit.extend(
             [
                 gates.RX(0, 0.0),
+                gates.RX(0, np.pi / 2.0),
                 gates.RX(0, np.pi),
+                gates.RX(0, np.pi * 3.0 / 2.0),
             ]
         )
         transpiled = RX2NamedTranspiler()(circuit)
@@ -82,7 +84,9 @@ class TestRotation2Named:
         expect.extend(
             [
                 gates.Identity(0),
+                gates.SqrtX(0),
                 gates.X(0),
+                gates.SqrtXdag(0),
             ]
         )
 
@@ -94,7 +98,9 @@ class TestRotation2Named:
         circuit.extend(
             [
                 gates.RY(0, 0.0),
+                gates.RY(0, np.pi / 2.0),
                 gates.RY(0, np.pi),
+                gates.RY(0, np.pi * 3.0 / 2.0),
             ]
         )
         transpiled = RY2NamedTranspiler()(circuit)
@@ -103,7 +109,9 @@ class TestRotation2Named:
         expect.extend(
             [
                 gates.Identity(0),
+                gates.SqrtY(0),
                 gates.Y(0),
+                gates.SqrtYdag(0),
             ]
         )
 


### PR DESCRIPTION
- Added a `CircuitTranspiler` to normalize RX, RY, and RZ gate parameters to the specified range.
  - By default, it normalizes to 0 to 2pi, but It can be normalized to any range of width 2pi (such as -pi to pi) by specifying it on creation.
- Rotation to named transpiler support more angles.
  - Support SqrtX, SqrtXdag, SqrtY, SqrtYdag angles.
  - Support one cycle of pi/4 units for Z rotation.