### PR TITLE
Ignore patch version updates of botocore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
       - dependency-name: "quri-parts-*"
       - dependency-name: "botocore"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "boto3"
+        update-types: ["version-update:semver-patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
     target-branch: "main"
     ignore:
       - dependency-name: "quri-parts-*"
+      - dependency-name: "botocore"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Since botocore and boto3 are updated almost every day with patch version change, I want to ignore those updates to reduce number of dependabot pull requests.

cf. https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/