### PR TITLE
Replacing unhashable defaults with factories

### DIFF
--- a/packages/algo/quri_parts/algo/optimizer/adam.py
+++ b/packages/algo/quri_parts/algo/optimizer/adam.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Optional
 
 import numpy as np
@@ -26,15 +26,17 @@ from .interface import (
 )
 from .tolerance import ftol as create_ftol
 
-_const_zero_array: Params = readonly_array(np.zeros(0, dtype=float))
+
+def _const_zero_array_factory() -> Params:
+    return readonly_array(np.zeros(0, dtype=float))
 
 
 @dataclass(frozen=True)
 class OptimizerStateAdam(OptimizerState):
     """Optimizer state for Adam."""
 
-    m: Params = _const_zero_array
-    v: Params = _const_zero_array
+    m: Params = field(default_factory=_const_zero_array_factory)
+    v: Params = field(default_factory=_const_zero_array_factory)
 
 
 def _adam_grad_square_moving_average(

--- a/packages/algo/quri_parts/algo/optimizer/lbfgs.py
+++ b/packages/algo/quri_parts/algo/optimizer/lbfgs.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 import warnings
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, replace, field
 from typing import TYPE_CHECKING, Callable, Optional, cast
 
 import numpy as np
@@ -35,23 +35,25 @@ from .interface import (
 )
 from .tolerance import gtol as create_gtol
 
-_const_zero_array: Params = readonly_array(np.zeros(0, dtype=float))
+
+def _const_zero_array_factory() -> Params:
+    return readonly_array(np.zeros(0, dtype=float))
 
 
 @dataclass(frozen=True)
 class OptimizerStateLBFGS(OptimizerState):
     """Optimizer state for LBFGS."""
 
-    grad: Params = _const_zero_array
+    grad: Params = field(default_factory=_const_zero_array_factory)
 
-    p: Params = _const_zero_array
-    s: Params = _const_zero_array
-    y: Params = _const_zero_array
-    rho: Params = _const_zero_array
+    p: Params = field(default_factory=_const_zero_array_factory)
+    s: Params = field(default_factory=_const_zero_array_factory)
+    y: Params = field(default_factory=_const_zero_array_factory)
+    rho: Params = field(default_factory=_const_zero_array_factory)
 
     cost_prev: float = 0.0
     ind: int = 0
-    a: Params = _const_zero_array
+    a: Params = field(default_factory=_const_zero_array_factory)
 
 
 class LBFGS(Optimizer):

--- a/packages/algo/quri_parts/algo/optimizer/lbfgs.py
+++ b/packages/algo/quri_parts/algo/optimizer/lbfgs.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 import warnings
-from dataclasses import dataclass, replace, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Callable, Optional, cast
 
 import numpy as np


### PR DESCRIPTION
Resolves issue #169

I've checked all instances of frozen dataclasses in the library and think they should all work now, at least I couldn't generate an error while using Python 3.11.