### PR TITLE
Bug fix in convert empty circuit with noise model to qulacs

### DIFF
--- a/packages/qulacs/quri_parts/qulacs/circuit/noise/circuit_converter.py
+++ b/packages/qulacs/quri_parts/qulacs/circuit/noise/circuit_converter.py
@@ -146,7 +146,7 @@ def convert_circuit_with_noise_model(
 
     # Circuit noises for depth at the end of the circuit.
     depth_noises = []
-    max_depth = max(depths.values())
+    max_depth = max(depths.values()) if depths else 0
     for q in range(circuit.qubit_count):
         for ci in resolvers:
             depth_noises.extend(

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -276,3 +276,15 @@ def test_convert_kraus_cptp() -> None:
     # We need to disable type check due to an error in qulacs type annotation
     # https://github.com/qulacs/qulacs/issues/537
     assert np.allclose(cptp, matrix.get_matrix())  # type: ignore
+
+
+def test_convert_empty_circuit() -> None:
+    circuit = QuantumCircuit(1)
+
+    noise_model_empty = NoiseModel([])
+    converted_empty = convert_circuit_with_noise_model(circuit, noise_model_empty)
+    assert converted_empty.get_gate_count() == 0
+
+    noise_model_readout = NoiseModel([MeasurementNoise([BitFlipNoise(1.0)])])
+    converted_readout = convert_circuit_with_noise_model(circuit, noise_model_readout)
+    assert converted_readout.get_gate_count() == 1


### PR DESCRIPTION
- Fixed an error when converting an empty circuit to a Qulacs circuit with a noise model.
- Add test cases.