### PR TITLE
Python 3 11 fix

### DIFF
--- a/packages/chem/tests/chem/mol/test_active_space_error_message.py
+++ b/packages/chem/tests/chem/mol/test_active_space_error_message.py
@@ -26,7 +26,6 @@ class MolecularOrbitalsInfo(MolecularOrbitals):
     _n_electron: int
     _n_spatial_orb: int
     _spin: int = 0
-    _mo_coeff: npt.NDArray[np.complex128] = np.zeros((1,), dtype=np.complex128)
     charge: int = 0
 
     @property
@@ -42,8 +41,8 @@ class MolecularOrbitalsInfo(MolecularOrbitals):
         return self._n_spatial_orb
 
     @property
-    def mo_coeff(self) -> "npt.NDArray[np.complex128]":
-        return self._mo_coeff
+    def mo_coeff(self) -> npt.NDArray[np.complex128]:
+        return np.zeros((1,), dtype=np.complex128)
 
 
 h2o = MolecularOrbitalsInfo(_n_electron=10, _n_spatial_orb=7)

--- a/packages/chem/tests/chem/mol/test_ao_eint_set.py
+++ b/packages/chem/tests/chem/mol/test_ao_eint_set.py
@@ -30,9 +30,6 @@ from quri_parts.chem.mol import (
 
 @dataclass
 class MolecularOrbitalsInfo(MolecularOrbitals):
-    class Config:
-        arbitrary_types_allowed = True
-
     _n_electron: int
     _n_spatial_orb: int
     _mo_coeff: npt.NDArray[np.complex128]

--- a/packages/chem/tests/chem/mol/test_ao_eint_set.py
+++ b/packages/chem/tests/chem/mol/test_ao_eint_set.py
@@ -30,10 +30,13 @@ from quri_parts.chem.mol import (
 
 @dataclass
 class MolecularOrbitalsInfo(MolecularOrbitals):
+    class Config:
+        arbitrary_types_allowed = True
+
     _n_electron: int
     _n_spatial_orb: int
+    _mo_coeff: npt.NDArray[np.complex128]
     _spin: int = 0
-    _mo_coeff: npt.NDArray[np.complex128] = np.zeros((1,), dtype=np.complex128)
 
     @property
     def n_electron(self) -> int:

--- a/packages/chem/tests/chem/mol/test_effective_eints.py
+++ b/packages/chem/tests/chem/mol/test_effective_eints.py
@@ -34,9 +34,6 @@ from quri_parts.chem.mol import (
 
 @dataclass
 class MolecularOrbitalsInfo(MolecularOrbitals):
-    class Config:
-        arbitrary_types_allowed = True
-
     _n_electron: int
     _n_spatial_orb: int
     _mo_coeff: npt.NDArray[np.complex128]

--- a/packages/chem/tests/chem/mol/test_effective_eints.py
+++ b/packages/chem/tests/chem/mol/test_effective_eints.py
@@ -34,10 +34,13 @@ from quri_parts.chem.mol import (
 
 @dataclass
 class MolecularOrbitalsInfo(MolecularOrbitals):
+    class Config:
+        arbitrary_types_allowed = True
+
     _n_electron: int
     _n_spatial_orb: int
+    _mo_coeff: npt.NDArray[np.complex128]
     _spin: int = 0
-    _mo_coeff: npt.NDArray[np.complex128] = np.zeros((1,), dtype=np.complex128)
 
     @property
     def n_electron(self) -> int:


### PR DESCRIPTION
Fix pytest error of not allowing mutable default as dataclass fields for python 3.11