### PR TITLE
Allow to pass keyword arguments to itensor mps estimator for fast computation.

### DIFF
--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -65,6 +65,7 @@ def _estimate(
 
 
 def create_itensor_mps_estimator(
+    *,
     mindim: Optional[int] = None,
     maxdim: Optional[int] = None,
     cutoff: Optional[float] = None,

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -77,9 +77,8 @@ def create_itensor_mps_estimator(
 ) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
     calculate expectation values. The following parameters including keyword
-    arguments `**kwargs` are passed to `ITensors.apply.
-
-    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+    arguments `**kwargs` are passed to `ITensors.apply
+    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.
 
     Args:
         maxdim: The maximum numer of singular values.

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -77,7 +77,6 @@ def create_itensor_mps_estimator(
 ) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
     calculate expectation values.
-    
     The following parameters including keyword
     arguments `**kwargs` are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -189,7 +189,7 @@ def _sequential_parametric_estimate(
 
 
 def create_itensor_mps_parametric_estimator(
-    **kwargs:Any,
+    **kwargs: Any,
 ) -> ParametricQuantumEstimator[ITensorParametricStateT]:
     return create_parametric_estimator(create_itensor_mps_estimator(**kwargs))
 

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -75,18 +75,20 @@ def create_itensor_mps_estimator(
 
     Args:
         mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
-        maxdim: ...
-        cutoff: ...
+        maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
+        cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
     Keyword arguments are passed to `ITensors.apply
 
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """
 
     def estimator(operator: Estimatable, state: ITensorStateT) -> Estimate[complex]:
-        if mindim:
+        if mindim is not None:
             kwargs["mindim"] = mindim
-        if ...
-        
+        if maxdim is not None:
+            kwargs["maxdim"] = maxdim
+        if cutoff is not None:
+            kwargs["cutoff"] = cutoff
         return _estimate(operator, state, **kwargs)
 
     return estimator

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Callable, NamedTuple, Optional
 import juliacall
 import numpy as np
 from juliacall import Main as jl
+from typing_extensions import TypeAlias
+
 from quri_parts.core.estimator import (
     ConcurrentParametricQuantumEstimator,
     ConcurrentQuantumEstimator,
@@ -16,8 +18,6 @@ from quri_parts.core.estimator import (
 from quri_parts.core.operator import zero
 from quri_parts.core.state import CircuitQuantumState, ParametricCircuitQuantumState
 from quri_parts.core.utils.concurrent import execute_concurrently
-from typing_extensions import TypeAlias
-
 from quri_parts.itensor.load_itensor import ensure_itensor_loaded
 
 from .circuit import convert_circuit
@@ -71,8 +71,9 @@ def create_itensor_mps_estimator(
     **kwargs: Any,
 ) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
-    calculate expectation values. The following parameters including
-    keyword arguments `**kwargs` are passed to `ITensors.apply
+    calculate expectation values. The following parameters including keyword
+    arguments `**kwargs` are passed to `ITensors.apply.
+
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
 
     Args:

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -75,7 +75,6 @@ def create_itensor_mps_estimator(
     calculate expectation values.
 
     Args:
-        mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
         maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
         cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
     Keyword arguments are passed to `ITensors.apply
@@ -83,8 +82,6 @@ def create_itensor_mps_estimator(
     """
 
     def estimator(operator: Estimatable, state: ITensorStateT) -> Estimate[complex]:
-        if mindim is not None:
-            kwargs["mindim"] = mindim
         if maxdim is not None:
             kwargs["maxdim"] = maxdim
         if cutoff is not None:

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -68,9 +68,9 @@ def create_itensor_mps_estimator(**kwargs: Any) -> QuantumEstimator[ITensorState
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
     calculate expectation values.
 
-    Keyword arguments are passed to
-    `ITensors.apply <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.
-    product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+    Keyword arguments are passed to `ITensors.apply
+
+    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """
 
     def estimator(operator: Estimatable, state: ITensorStateT) -> Estimate[complex]:

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -77,6 +77,7 @@ def create_itensor_mps_estimator(
 ) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
     calculate expectation values.
+
     The following parameters including keyword
     arguments `**kwargs` are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -174,7 +174,7 @@ def create_itensor_mps_concurrent_estimator(
 
     The following parameters including
     keyword arguments `**kwargs` are passed to `ITensors.apply
-    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.
 
     Args:
         maxdim: The maximum numer of singular values.

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -66,19 +66,18 @@ def _estimate(
 
 def create_itensor_mps_estimator(
     *,
-    mindim: Optional[int] = None,
     maxdim: Optional[int] = None,
     cutoff: Optional[float] = None,
     **kwargs: Any,
 ) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
-    calculate expectation values.
+    calculate expectation values. The following parameters including
+    keyword arguments `**kwargs` are passed to `ITensors.apply
+    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
 
     Args:
-        maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
-        cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
-    Keyword arguments are passed to `ITensors.apply
-    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+        maxdim: The maximum numer of singular values.
+        cutoff: Singular value truncation cutoff.
     """
 
     def estimator(operator: Estimatable, state: ITensorStateT) -> Estimate[complex]:

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -64,7 +64,12 @@ def _estimate(
     return _Estimate(value=exp, error=0.0)
 
 
-def create_itensor_mps_estimator(**kwargs: Any) -> QuantumEstimator[ITensorStateT]:
+def create_itensor_mps_estimator(
+    mindim: Optional[int] = None,
+    maxdim: Optional[int] = None,
+    cutoff: Optional[float] = None,
+    **kwargs: Any,
+) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
     calculate expectation values.
 

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -73,12 +73,20 @@ def create_itensor_mps_estimator(
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
     calculate expectation values.
 
+    Args:
+        mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
+        maxdim: ...
+        cutoff: ...
     Keyword arguments are passed to `ITensors.apply
 
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """
 
     def estimator(operator: Estimatable, state: ITensorStateT) -> Estimate[complex]:
+        if mindim:
+            kwargs["mindim"] = mindim
+        if ...
+        
         return _estimate(operator, state, **kwargs)
 
     return estimator

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -178,9 +178,10 @@ def create_itensor_mps_concurrent_estimator(
 
     For now, this function works when the executor is defined like below::
 
-    >>> with ProcessPoolExecutor(
-    ...     max_workers=2, mp_context=get_context("spawn")
-    ... ) as executor:
+    Examples:
+        >>> with ProcessPoolExecutor(
+                max_workers=2, mp_context=get_context("spawn")
+            ) as executor:
 
     The following parameters including
     keyword arguments `**kwargs` are passed to `ITensors.apply

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -76,7 +76,9 @@ def create_itensor_mps_estimator(
     **kwargs: Any,
 ) -> QuantumEstimator[ITensorStateT]:
     """Returns a :class:`~QuantumEstimator` that uses ITensor MPS simulator to
-    calculate expectation values. The following parameters including keyword
+    calculate expectation values.
+    
+    The following parameters including keyword
     arguments `**kwargs` are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.
 

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -264,7 +264,7 @@ def create_itensor_mps_concurrent_parametric_estimator(
 
     The following parameters including
     keyword arguments `**kwargs` are passed to `ITensors.apply
-    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.
 
     Args:
         maxdim: The maximum numer of singular values.

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -61,7 +61,12 @@ def _estimate(
     psi = jl.apply(circuit, psi, **kwargs)
     exp: float = jl.expectation(psi, op)
 
-    return _Estimate(value=exp, error=0.0)
+    # See https://github.com/QunaSys/quri-parts/pull/203#discussion_r1329458816
+    error = 0.0
+    if "maxdim" in kwargs or "cutoff" in kwargs:
+        error = np.nan
+
+    return _Estimate(value=exp, error=error)
 
 
 def create_itensor_mps_estimator(
@@ -108,7 +113,13 @@ def _sequential_estimate_single_state(
             results.append(_Estimate(value=0.0, error=0.0))
             continue
         itensor_op = convert_operator(op, s)
-        results.append(_Estimate(value=jl.expectation(psi, itensor_op), error=0.0))
+
+        # See https://github.com/QunaSys/quri-parts/pull/203#discussion_r1329458816
+        error = 0.0
+        if "maxdim" in kwargs or "cutoff" in kwargs:
+            error = np.nan
+
+        results.append(_Estimate(value=jl.expectation(psi, itensor_op), error=error))
     return results
 
 

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -178,7 +178,7 @@ def create_itensor_mps_concurrent_estimator(
     """Returns a :class:`~ConcurrentQuantumEstimator` that uses ITensor MPS
     simulator to calculate expectation values.
 
-    For now, this function works when the executor is defined like below::
+    For now, this function works when the executor is defined like below
 
     Examples:
         >>> with ProcessPoolExecutor(

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -77,7 +77,7 @@ def create_itensor_mps_estimator(
         mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
         maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
         cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
-    Keyword arguments are passed to `ITensors.apply
+    Keyword arguments are passed to `ITensors.apply`
 
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -238,7 +238,7 @@ def create_itensor_mps_parametric_estimator(
 
     The following parameters including
     keyword arguments `**kwargs` are passed to `ITensors.apply
-    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+    <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_.
 
     Args:
         maxdim: The maximum numer of singular values.

--- a/packages/itensor/quri_parts/itensor/estimator.py
+++ b/packages/itensor/quri_parts/itensor/estimator.py
@@ -77,8 +77,7 @@ def create_itensor_mps_estimator(
         mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
         maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
         cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
-    Keyword arguments are passed to `ITensors.apply`
-
+    Keyword arguments are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """
 

--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -39,7 +39,6 @@ def create_itensor_mps_sampler(
     sampling.
 
     Args:
-        mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
         maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
         cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
     Keyword arguments are passed to `ITensors.apply
@@ -47,8 +46,6 @@ def create_itensor_mps_sampler(
     """
 
     def sample(circuit: NonParametricQuantumCircuit, shots: int) -> MeasurementCounts:
-        if mindim is not None:
-            kwargs["mindim"] = mindim
         if maxdim is not None:
             kwargs["maxdim"] = maxdim
         if cutoff is not None:

--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -85,12 +85,6 @@ def create_itensor_mps_concurrent_sampler(
     """Returns a :class:`~ConcurrentSampler` that uses ITensor mps simulator
     for sampling.
 
-    For now, this function works when the executor is defined like below::
-
-    >>> with ProcessPoolExecutor(
-    ...     max_workers=2, mp_context=get_context("spawn")
-    ... ) as executor:
-
     The following parameters including
     keyword arguments `**kwargs` are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
@@ -98,6 +92,17 @@ def create_itensor_mps_concurrent_sampler(
     Args:
         maxdim: The maximum numer of singular values.
         cutoff: Singular value truncation cutoff.
+
+    For now, this function works when the executor is defined like below
+
+    Examples:
+        >>> with ProcessPoolExecutor(
+                max_workers=2, mp_context=get_context("spawn")
+            ) as executor:
+                sampler = create_itensor_mps_concurrent_sampler(
+                    executor, 2, **kwargs
+                )
+                results = list(sampler([(circuit1, 1000), (circuit2, 2000)]))
     """
 
     if maxdim is not None:

--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -41,7 +41,7 @@ def create_itensor_mps_sampler(
         mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
         maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
         cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
-    Keyword arguments are passed to `ITensors.apply
+    Keyword arguments are passed to `ITensors.apply`
 
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """

--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -41,8 +41,7 @@ def create_itensor_mps_sampler(
         mindim: The minimum number of singular values. The value is passed to `ITensors.apply`.
         maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
         cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
-    Keyword arguments are passed to `ITensors.apply`
-
+    Keyword arguments are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
     """
 

--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -29,6 +29,7 @@ def _sample(
 
 
 def create_itensor_mps_sampler(
+    *,
     mindim: Optional[int] = None,
     maxdim: Optional[int] = None,
     cutoff: Optional[float] = None,

--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -30,7 +30,6 @@ def _sample(
 
 def create_itensor_mps_sampler(
     *,
-    mindim: Optional[int] = None,
     maxdim: Optional[int] = None,
     cutoff: Optional[float] = None,
     **kwargs: Any,
@@ -38,11 +37,13 @@ def create_itensor_mps_sampler(
     """Returns a :class:`~Sampler` that uses ITensor mps simulator for
     sampling.
 
-    Args:
-        maxdim: The maximum numer of singular values. The value is passed to `ITensors.apply`.
-        cutoff: Singular value truncation cutoff. The value is passed to `ITensors.apply`.
-    Keyword arguments are passed to `ITensors.apply
+    The following parameters including
+    keyword arguments `**kwargs` are passed to `ITensors.apply
     <https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#ITensors.product-Tuple{ITensor,%20ITensors.AbstractMPS}>`_
+
+    Args:
+        maxdim: The maximum numer of singular values.
+        cutoff: Singular value truncation cutoff.
     """
 
     def sample(circuit: NonParametricQuantumCircuit, shots: int) -> MeasurementCounts:

--- a/packages/itensor/tests/itensor/estimator/test_itensor_estimator.py
+++ b/packages/itensor/tests/itensor/estimator/test_itensor_estimator.py
@@ -44,6 +44,8 @@ class TestITensorEstimator:
         estimate = estimator(operator, state)
         assert estimate.value == -0.25 + 0.5j
 
+        # Note that the results of numerical calculations differ
+        # depending on the presence or absence of keyword arguments.
         estimator_with_kwargs = create_itensor_mps_estimator(
             mindim=1, maxdim=2, cutoff=0.01
         )

--- a/packages/itensor/tests/itensor/estimator/test_itensor_estimator.py
+++ b/packages/itensor/tests/itensor/estimator/test_itensor_estimator.py
@@ -26,9 +26,7 @@ class TestITensorEstimator:
         estimate = estimator(pauli, state)
         assert estimate.value == -1
 
-        estimator_with_kwargs = create_itensor_mps_estimator(
-            mindim=1, maxdim=2, cutoff=0.01
-        )
+        estimator_with_kwargs = create_itensor_mps_estimator(maxdim=2, cutoff=0.01)
         estimate_with_kwargs = estimator_with_kwargs(pauli, state)
         assert estimate_with_kwargs.value == -1
 
@@ -46,9 +44,7 @@ class TestITensorEstimator:
 
         # Note that the results of numerical calculations differ
         # depending on the presence or absence of keyword arguments.
-        estimator_with_kwargs = create_itensor_mps_estimator(
-            mindim=1, maxdim=2, cutoff=0.01
-        )
+        estimator_with_kwargs = create_itensor_mps_estimator(maxdim=2, cutoff=0.01)
         estimate_with_kwargs = estimator_with_kwargs(operator, state)
         assert estimate_with_kwargs.value == -0.25 + 0.5j
 
@@ -230,7 +226,7 @@ class TestITensorParametricEstimator:
         # Note that the results of numerical calculations differ
         # depending on the presence or absence of keyword arguments.
         estimator_with_kwargs = create_itensor_mps_parametric_estimator(
-            mindim=1, maxdim=2, cutoff=0.01
+            maxdim=2, cutoff=0.01
         )
         estimate_with_kwargs = estimator_with_kwargs(operator, state, params)
         assert estimate_with_kwargs.value == pytest.approx(

--- a/packages/itensor/tests/itensor/estimator/test_itensor_estimator.py
+++ b/packages/itensor/tests/itensor/estimator/test_itensor_estimator.py
@@ -87,7 +87,9 @@ class TestITensorConcurrentEstimator:
         with ProcessPoolExecutor(
             max_workers=2, mp_context=get_context("spawn")
         ) as executor:
-            estimator = create_itensor_mps_concurrent_estimator(executor, concurrency=2, **jl_apply_kwargs)
+            estimator = create_itensor_mps_concurrent_estimator(
+                executor, concurrency=2, **jl_apply_kwargs
+            )
             result = list(estimator(operators, states))
         assert result[0].value == -1
         assert result[1].value == -0.25 + 0.5j

--- a/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
+++ b/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
@@ -1,5 +1,6 @@
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import get_context
+from typing import Any
 
 import pytest
 
@@ -22,12 +23,20 @@ def circuit() -> QuantumCircuit:
 class TestITensorMPSSampler:
     @pytest.mark.parametrize("qubits", [4, 12])
     @pytest.mark.parametrize("shots", [800, 1200, 2**12 + 100])
-    def test_sampler(self, qubits: int, shots: int) -> None:
+    @pytest.mark.parametrize(
+        "sampler_kwargs",
+        [
+            {},
+            {"maxdim": 100, "mindim": 10, "cutoff": 0.1},
+            {"apply_dag": False, "move_sites_back": True},
+        ],
+    )
+    def test_sampler(self, qubits: int, shots: int, sampler_kwargs: Any) -> None:
         circuit = QuantumCircuit(qubits)
         for i in range(qubits):
             circuit.add_H_gate(i)
 
-        sampler = create_itensor_mps_sampler()
+        sampler = create_itensor_mps_sampler(**sampler_kwargs)
         counts = sampler(circuit, shots)
 
         assert set(counts.keys()).issubset(range(2**qubits))

--- a/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
+++ b/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
@@ -46,14 +46,22 @@ class TestITensorMPSSampler:
 
 class TestITensorMPSConcurrentSampler:
     @pytest.mark.skip(reason="This test is too slow.")
-    def test_concurrent_sampler(self) -> None:
+    @pytest.mark.parametrize(
+        "sampler_kwargs",
+        [
+            {},
+            {"maxdim": 100, "cutoff": 0.1},
+            {"apply_dag": False, "move_sites_back": True},
+        ],
+    )
+    def test_concurrent_sampler(self,  sampler_kwargs: Any) -> None:
         circuit1 = circuit()
         circuit2 = circuit()
         circuit2.add_X_gate(3)
         with ProcessPoolExecutor(
             max_workers=2, mp_context=get_context("spawn")
         ) as executor:
-            sampler = create_itensor_mps_concurrent_sampler(executor, 2)
+            sampler = create_itensor_mps_concurrent_sampler(executor, 2, **sampler_kwargs)
             results = list(sampler([(circuit1, 1000), (circuit2, 2000)]))
         assert set(results[0]) == {0b1001, 0b1011}
         assert all(c >= 0 for c in results[0].values())

--- a/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
+++ b/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
@@ -27,7 +27,7 @@ class TestITensorMPSSampler:
         "sampler_kwargs",
         [
             {},
-            {"maxdim": 100, "mindim": 10, "cutoff": 0.1},
+            {"maxdim": 100, "cutoff": 0.1},
             {"apply_dag": False, "move_sites_back": True},
         ],
     )

--- a/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
+++ b/packages/itensor/tests/itensor/sampler/test_itensor_sampler.py
@@ -54,14 +54,16 @@ class TestITensorMPSConcurrentSampler:
             {"apply_dag": False, "move_sites_back": True},
         ],
     )
-    def test_concurrent_sampler(self,  sampler_kwargs: Any) -> None:
+    def test_concurrent_sampler(self, sampler_kwargs: Any) -> None:
         circuit1 = circuit()
         circuit2 = circuit()
         circuit2.add_X_gate(3)
         with ProcessPoolExecutor(
             max_workers=2, mp_context=get_context("spawn")
         ) as executor:
-            sampler = create_itensor_mps_concurrent_sampler(executor, 2, **sampler_kwargs)
+            sampler = create_itensor_mps_concurrent_sampler(
+                executor, 2, **sampler_kwargs
+            )
             results = list(sampler([(circuit1, 1000), (circuit2, 2000)]))
         assert set(results[0]) == {0b1001, 0b1011}
         assert all(c >= 0 for c in results[0].values())


### PR DESCRIPTION
# Description

This PR allows users to pass keyword arguments to `jl.apply` in [the auxiliary function _estimate](https://github.com/QunaSys/quri-parts/blob/8e370584aeb0d3eb4b0ef3e7049ab9f98e01a48c/packages/itensor/quri_parts/itensor/estimator.py#L44-L62). Note that `jl.apply` Julia function [ITensors.apply](https://itensor.github.io/ITensors.jl/dev/MPSandMPO.html#Gate-evolution). By passing `maxdim`, it enables us to calculate the expectation value at high speed by obtaining the Truncated SVD in [ITensors.factorize](https://github.com/ITensor/ITensors.jl/blob/73bc07eded9bd5f88da1a1562986ac5fb6e42a10/src/tensor_operations/matrix_decomposition.jl#L580-L694) and [svd](https://github.com/ITensor/ITensors.jl/blob/73bc07eded9bd5f88da1a1562986ac5fb6e42a10/NDTensors/src/linearalgebra/linearalgebra.jl#L93C1-L258). These functions are called from the `ITensors.apply`.

- [x] I have added tests that verify the behavior of the changes I made.
