### PR TITLE
Limit execution time

### DIFF
--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -307,16 +307,19 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
             single_batch_execution_time,
             single_batch_time_left,
         ) = self._get_batch_execution_time_and_time_left(shot_dist)
-        if single_batch_time_left is not None and single_batch_time_left < 300:
+        if (
+            single_batch_execution_time is not None
+            and single_batch_execution_time < 300
+        ):
             if self._strict:
                 raise BackendError(
-                    f"Time left: {single_batch_time_left} seconds."
-                    "The time limit cannot be followed strictly."
+                    f"Max execution time limit of: {single_batch_execution_time}"
+                    "seconds cannot be followed strictly."
                 )
             else:
                 warnings.warn(
-                    f"The time limit of {single_batch_time_left} seconds for this job"
-                    "is likely going to be exceeded."
+                    f"The time limit of {single_batch_execution_time} seconds for"
+                    "this job is likely going to be exceeded."
                 )
 
         qiskit_sampler_options = self._get_sampler_option_with_time_limit(

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -226,7 +226,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
                 "are also aborted."
             )
 
-    def _get_time_limit_with_sampler_option(
+    def _get_sampler_option_with_time_limit(
         self, batch_time: Optional[float]
     ) -> Options:
         options = (
@@ -289,7 +289,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
             n_shots, self._min_shots, self._max_shots, self._enable_shots_roundup
         )
         single_batch_execution_time = self._get_batch_execution_time(shot_dist)
-        qiskit_sampler_options = self._get_time_limit_with_sampler_option(
+        qiskit_sampler_options = self._get_sampler_option_with_time_limit(
             single_batch_execution_time
         )
 

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -238,11 +238,11 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
         if batch_time is not None and self.tracker is not None:
             time_left = self._time_limit - self.tracker.total_run_time
             options.max_execution_time = max(
-                300, self._single_job_max_execution_time, time_left
+                300, batch_time, time_left
             )
 
         elif batch_time is not None and self.tracker is None:
-            options.max_execution_time = max(300, self._single_job_max_execution_time)
+            options.max_execution_time = max(300, batch_time)
 
         elif batch_time is None and self.tracker is not None:
             time_left = self._time_limit - self.tracker.total_run_time

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -237,7 +237,10 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
 
         if batch_time is not None and self.tracker is not None:
             time_left = self._time_limit - self.tracker.total_run_time
-            options.max_execution_time = max(300, batch_time, time_left)
+            if time_left > batch_time:
+                options.max_execution_time = max(300, batch_time)
+            else:
+                options.max_execution_time = max(300, time_left)
 
         elif batch_time is not None and self.tracker is None:
             options.max_execution_time = max(300, batch_time)

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -232,6 +232,30 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
     def _get_sampler_option_with_time_limit(
         self, batch_exe_time: Optional[float], batch_time_left: Optional[float]
     ) -> Options:
+        if batch_exe_time is not None and batch_exe_time < 300:
+            if self._strict:
+                raise BackendError(
+                    f"Max execution time limit of: {batch_exe_time}"
+                    "seconds cannot be followed strictly."
+                )
+            else:
+                warnings.warn(
+                    f"The time limit of {batch_exe_time} seconds for"
+                    "this job is likely going to be exceeded."
+                )
+
+        if batch_time_left is not None and batch_time_left < 300:
+            if self._strict:
+                raise BackendError(
+                    f"Max execution time limit of: {batch_time_left}"
+                    "seconds cannot be followed strictly."
+                )
+            else:
+                warnings.warn(
+                    f"The time limit of {batch_time_left} seconds for"
+                    "this job is likely going to be exceeded."
+                )
+
         options = (
             deepcopy(self._qiskit_sampler_options)
             if self._qiskit_sampler_options is not None
@@ -307,20 +331,6 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
             single_batch_execution_time,
             single_batch_time_left,
         ) = self._get_batch_execution_time_and_time_left(shot_dist)
-        if (
-            single_batch_execution_time is not None
-            and single_batch_execution_time < 300
-        ):
-            if self._strict:
-                raise BackendError(
-                    f"Max execution time limit of: {single_batch_execution_time}"
-                    "seconds cannot be followed strictly."
-                )
-            else:
-                warnings.warn(
-                    f"The time limit of {single_batch_execution_time} seconds for"
-                    "this job is likely going to be exceeded."
-                )
 
         qiskit_sampler_options = self._get_sampler_option_with_time_limit(
             single_batch_execution_time, single_batch_time_left

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -237,9 +237,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
 
         if batch_time is not None and self.tracker is not None:
             time_left = self._time_limit - self.tracker.total_run_time
-            options.max_execution_time = max(
-                300, batch_time, time_left
-            )
+            options.max_execution_time = max(300, batch_time, time_left)
 
         elif batch_time is not None and self.tracker is None:
             options.max_execution_time = max(300, batch_time)

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -239,6 +239,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
         )
 
         if batch_exe_time is not None and self.tracker is not None:
+            assert batch_time_left is not None
             if batch_time_left > batch_exe_time:
                 options.max_execution_time = max(300, batch_exe_time)
             else:
@@ -248,6 +249,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
             options.max_execution_time = max(300, batch_exe_time)
 
         elif batch_exe_time is None and self.tracker is not None:
+            assert batch_time_left is not None
             options.max_execution_time = max(300, batch_time_left)
 
         return options
@@ -305,7 +307,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
             single_batch_execution_time,
             single_batch_time_left,
         ) = self._get_batch_execution_time_and_time_left(shot_dist)
-        if single_batch_time_left < 300:
+        if single_batch_time_left is not None and single_batch_time_left < 300:
             if self._strict:
                 raise BackendError(
                     f"Time left: {single_batch_time_left} seconds."

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -595,145 +595,194 @@ class TestQiskitPrimitive:
         job2 = sampling_backend.sample(QuantumCircuit(2), 100)
         assert sampling_backend.tracker.running_jobs == [job1, job2]
 
-    # def test_get_batch_execution_time(self) -> None:
-    #     runtime_service = mock_get_backend("FakeVigo")
-    #     service = runtime_service()
-    #     backend = service.backend()
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend, service=service, single_job_max_execution_time=500
-    #     )
-    #     assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) == 500 / 4
-    #     assert sampling_backend._get_batch_execution_time([50, 50, 50, 1]) == 500 / 4
-    #     assert sampling_backend._get_batch_execution_time([50]) == 500
+    def test_get_batch_execution_time(self) -> None:
+        runtime_service = mock_get_backend("FakeVigo")
+        service = runtime_service()
+        backend = service.backend()
 
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend, service=service
-    #     )
-    #     assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) is None
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend,
+            service=service,
+            single_job_max_execution_time=500,
+            total_time_limit=1000,
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 50]
+        ) == (500 / 4, 1000 / 4)
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 1]
+        ) == (500 / 4, 1000 / 4)
+        assert sampling_backend._get_batch_execution_time_and_time_left([50]) == (
+            500,
+            1000,
+        )
 
-    # def test_get_sampler_option_with_time_limit(self) -> None:
-    #     runtime_service = mock_get_backend("FakeVigo")
-    #     service = runtime_service()
-    #     service.run = fake_dynamic_run
-    #     backend = service.backend()
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, total_time_limit=1000
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 50]
+        ) == (None, 1000 / 4)
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 1]
+        ) == (None, 1000 / 4)
+        assert sampling_backend._get_batch_execution_time_and_time_left([50]) == (
+            None,
+            1000,
+        )
 
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend, service=service, single_job_max_execution_time=500
-    #     )
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(30).max_execution_time
-    #         == 300
-    #     )
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(400).max_execution_time
-    #         == 400
-    #     )
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, single_job_max_execution_time=500
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 50]
+        ) == (500 / 4, None)
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 1]
+        ) == (500 / 4, None)
+        assert sampling_backend._get_batch_execution_time_and_time_left([50]) == (
+            500,
+            None,
+        )
 
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend, service=service, total_time_limit=3000
-    #     )
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             None
-    #         ).max_execution_time
-    #         == 3000
-    #     )
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 50]
+        ) == (None, None)
 
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend, service=service, total_time_limit=30
-    #     )
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             None
-    #         ).max_execution_time
-    #         == 300
-    #     )
+    def test_get_sampler_option_with_time_limit(self) -> None:
+        runtime_service = mock_get_backend("FakeVigo")
+        service = runtime_service()
+        service.run = fake_dynamic_run
+        backend = service.backend()
 
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend,
-    #         service=service,
-    #         total_time_limit=800,
-    #         single_job_max_execution_time=700,
-    #     )
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(350).max_execution_time
-    #         == 350
-    #     )
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(70).max_execution_time
-    #         == 300
-    #     )
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, single_job_max_execution_time=500
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                30, None
+            ).max_execution_time
+            == 300
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                400, None
+            ).max_execution_time
+            == 400
+        )
 
-    #     # Test sampling backend with both total_time_limit and
-    #     # single_job_max_execution_time settings.
-    #     sampling_backend = QiskitRuntimeSamplingBackend(
-    #         backend=backend,
-    #         service=service,
-    #         total_time_limit=800,
-    #         single_job_max_execution_time=700,
-    #     )
-    #     assert isinstance(sampling_backend.tracker, Tracker)
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, total_time_limit=3000
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                None, 3000
+            ).max_execution_time
+            == 3000
+        )
 
-    #     # tl > tb > 300
-    #     time_batch = 700
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             time_batch
-    #         ).max_execution_time
-    #         == 700
-    #     )
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, total_time_limit=30
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                None, 30
+            ).max_execution_time
+            == 300
+        )
 
-    #     # tb > tl > 300
-    #     for _ in range(20):
-    #         job = sampling_backend.sample(QuantumCircuit(4), 100)
-    #         assert isinstance(job, QiskitRuntimeSamplingJob)
-    #         job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend,
+            service=service,
+            total_time_limit=800,
+            single_job_max_execution_time=700,
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                350, 800
+            ).max_execution_time
+            == 350
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                70, 800
+            ).max_execution_time
+            == 300
+        )
 
-    #     time_batch = 700
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             time_batch
-    #         ).max_execution_time
-    #         == 600
-    #     )
+        # Test sampling backend with both total_time_limit and
+        # single_job_max_execution_time settings.
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend,
+            service=service,
+            total_time_limit=800,
+            single_job_max_execution_time=700,
+        )
+        assert isinstance(sampling_backend.tracker, Tracker)
 
-    #     # tl  > 300 > tb
-    #     time_batch = 70
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             time_batch
-    #         ).max_execution_time
-    #         == 300
-    #     )
+        # tl > tb > 300
+        time_batch = 700
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch, 800
+            ).max_execution_time
+            == 700
+        )
 
-    #     # tb > 300 > tl
-    #     for _ in range(50):
-    #         job = sampling_backend.sample(QuantumCircuit(4), 100)
-    #         assert isinstance(job, QiskitRuntimeSamplingJob)
-    #         job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+        # tb > tl > 300
+        for _ in range(20):
+            job = sampling_backend.sample(QuantumCircuit(4), 100)
+            assert isinstance(job, QiskitRuntimeSamplingJob)
+            job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
 
-    #     time_batch = 350
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             time_batch
-    #         ).max_execution_time
-    #         == 300
-    #     )
+        time_batch = 700
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch, 600
+            ).max_execution_time
+            == 600
+        )
 
-    #     # 300 > tb > tl
-    #     time_batch = 140
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             time_batch
-    #         ).max_execution_time
-    #         == 300
-    #     )
+        # tl  > 300 > tb
+        time_batch = 70
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch, 600
+            ).max_execution_time
+            == 300
+        )
 
-    #     # 300 > tl > tb
-    #     time_batch = 10
-    #     assert (
-    #         sampling_backend._get_sampler_option_with_time_limit(
-    #             time_batch
-    #         ).max_execution_time
-    #         == 300
-    #     )
+        # tb > 300 > tl
+        for _ in range(50):
+            job = sampling_backend.sample(QuantumCircuit(4), 100)
+            assert isinstance(job, QiskitRuntimeSamplingJob)
+            job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+
+        time_batch = 350
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch, 100
+            ).max_execution_time
+            == 300
+        )
+
+        # 300 > tb > tl
+        time_batch = 140
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch, 100
+            ).max_execution_time
+            == 300
+        )
+
+        # 300 > tl > tb
+        time_batch = 10
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch, 100
+            ).max_execution_time
+            == 300
+        )

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -16,6 +16,7 @@ from collections import Counter
 from functools import partial
 from typing import Any
 from unittest.mock import MagicMock
+import warnings
 
 import pytest
 import qiskit
@@ -858,26 +859,10 @@ class TestQiskitPrimitive:
             )
 
         # test no warnings raised
-        no_warning_funcs = map(
-            lambda t: partial(
-                sampling_backend._check_execution_time_limitability,
-                batch_exe_time=t[0],
-                batch_time_left=t[1],
-            ),
-            [
-                (300, 300),
-                (800, 500),
-                (800, None),
-                (None, 500),
-                (None, None),
-            ],
-        )
-
-        for f in no_warning_funcs:
-            try:
-                with pytest.warns(UserWarning):
-                    f()
-            except:  # noqa: E722
-                assert True
-            else:
-                assert False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            sampling_backend._check_execution_time_limitability(300, 300)
+            sampling_backend._check_execution_time_limitability(800, 500)
+            sampling_backend._check_execution_time_limitability(800, None)
+            sampling_backend._check_execution_time_limitability(None, 500)
+            sampling_backend._check_execution_time_limitability(None, None)

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -594,3 +594,146 @@ class TestQiskitPrimitive:
 
         job2 = sampling_backend.sample(QuantumCircuit(2), 100)
         assert sampling_backend.tracker.running_jobs == [job1, job2]
+
+    def test_get_batch_execution_time(self) -> None:
+        runtime_service = mock_get_backend("FakeVigo")
+        service = runtime_service()
+        backend = service.backend()
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, single_job_max_execution_time=500
+        )
+        assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) == 500 / 4
+        assert sampling_backend._get_batch_execution_time([50, 50, 50, 1]) == 500 / 4
+        assert sampling_backend._get_batch_execution_time([50]) == 500
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service
+        )
+        assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) is None
+
+    def test_get_sampler_option_with_time_limit(self) -> None:
+        runtime_service = mock_get_backend("FakeVigo")
+        service = runtime_service()
+        service.run = fake_dynamic_run
+        backend = service.backend()
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, single_job_max_execution_time=500
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(30).max_execution_time
+            == 300
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(400).max_execution_time
+            == 400
+        )
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, total_time_limit=3000
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                None
+            ).max_execution_time
+            == 3000
+        )
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, total_time_limit=30
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                None
+            ).max_execution_time
+            == 300
+        )
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend,
+            service=service,
+            total_time_limit=800,
+            single_job_max_execution_time=700,
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(350).max_execution_time
+            == 350
+        )
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(70).max_execution_time
+            == 300
+        )
+
+        # Test sampling backend with both total_time_limit and
+        # single_job_max_execution_time settings.
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend,
+            service=service,
+            total_time_limit=800,
+            single_job_max_execution_time=700,
+        )
+        assert isinstance(sampling_backend.tracker, Tracker)
+
+        # tl > tb > 300
+        time_batch = 700
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch
+            ).max_execution_time
+            == 700
+        )
+
+        # tb > tl > 300
+        for _ in range(20):
+            job = sampling_backend.sample(QuantumCircuit(4), 100)
+            assert isinstance(job, QiskitRuntimeSamplingJob)
+            job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+
+        time_batch = 700
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch
+            ).max_execution_time
+            == 600
+        )
+
+        # tl  > 300 > tb
+        time_batch = 70
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch
+            ).max_execution_time
+            == 300
+        )
+
+        # tb > 300 > tl
+        for _ in range(50):
+            job = sampling_backend.sample(QuantumCircuit(4), 100)
+            assert isinstance(job, QiskitRuntimeSamplingJob)
+            job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+
+        time_batch = 350
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch
+            ).max_execution_time
+            == 300
+        )
+
+        # 300 > tb > tl
+        time_batch = 140
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch
+            ).max_execution_time
+            == 300
+        )
+
+        # 300 > tl > tb
+        time_batch = 10
+        assert (
+            sampling_backend._get_sampler_option_with_time_limit(
+                time_batch
+            ).max_execution_time
+            == 300
+        )

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -595,145 +595,145 @@ class TestQiskitPrimitive:
         job2 = sampling_backend.sample(QuantumCircuit(2), 100)
         assert sampling_backend.tracker.running_jobs == [job1, job2]
 
-    def test_get_batch_execution_time(self) -> None:
-        runtime_service = mock_get_backend("FakeVigo")
-        service = runtime_service()
-        backend = service.backend()
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend, service=service, single_job_max_execution_time=500
-        )
-        assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) == 500 / 4
-        assert sampling_backend._get_batch_execution_time([50, 50, 50, 1]) == 500 / 4
-        assert sampling_backend._get_batch_execution_time([50]) == 500
+    # def test_get_batch_execution_time(self) -> None:
+    #     runtime_service = mock_get_backend("FakeVigo")
+    #     service = runtime_service()
+    #     backend = service.backend()
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend, service=service, single_job_max_execution_time=500
+    #     )
+    #     assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) == 500 / 4
+    #     assert sampling_backend._get_batch_execution_time([50, 50, 50, 1]) == 500 / 4
+    #     assert sampling_backend._get_batch_execution_time([50]) == 500
 
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend, service=service
-        )
-        assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) is None
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend, service=service
+    #     )
+    #     assert sampling_backend._get_batch_execution_time([50, 50, 50, 50]) is None
 
-    def test_get_sampler_option_with_time_limit(self) -> None:
-        runtime_service = mock_get_backend("FakeVigo")
-        service = runtime_service()
-        service.run = fake_dynamic_run
-        backend = service.backend()
+    # def test_get_sampler_option_with_time_limit(self) -> None:
+    #     runtime_service = mock_get_backend("FakeVigo")
+    #     service = runtime_service()
+    #     service.run = fake_dynamic_run
+    #     backend = service.backend()
 
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend, service=service, single_job_max_execution_time=500
-        )
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(30).max_execution_time
-            == 300
-        )
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(400).max_execution_time
-            == 400
-        )
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend, service=service, single_job_max_execution_time=500
+    #     )
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(30).max_execution_time
+    #         == 300
+    #     )
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(400).max_execution_time
+    #         == 400
+    #     )
 
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend, service=service, total_time_limit=3000
-        )
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                None
-            ).max_execution_time
-            == 3000
-        )
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend, service=service, total_time_limit=3000
+    #     )
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             None
+    #         ).max_execution_time
+    #         == 3000
+    #     )
 
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend, service=service, total_time_limit=30
-        )
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                None
-            ).max_execution_time
-            == 300
-        )
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend, service=service, total_time_limit=30
+    #     )
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             None
+    #         ).max_execution_time
+    #         == 300
+    #     )
 
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend,
-            service=service,
-            total_time_limit=800,
-            single_job_max_execution_time=700,
-        )
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(350).max_execution_time
-            == 350
-        )
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(70).max_execution_time
-            == 300
-        )
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend,
+    #         service=service,
+    #         total_time_limit=800,
+    #         single_job_max_execution_time=700,
+    #     )
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(350).max_execution_time
+    #         == 350
+    #     )
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(70).max_execution_time
+    #         == 300
+    #     )
 
-        # Test sampling backend with both total_time_limit and
-        # single_job_max_execution_time settings.
-        sampling_backend = QiskitRuntimeSamplingBackend(
-            backend=backend,
-            service=service,
-            total_time_limit=800,
-            single_job_max_execution_time=700,
-        )
-        assert isinstance(sampling_backend.tracker, Tracker)
+    #     # Test sampling backend with both total_time_limit and
+    #     # single_job_max_execution_time settings.
+    #     sampling_backend = QiskitRuntimeSamplingBackend(
+    #         backend=backend,
+    #         service=service,
+    #         total_time_limit=800,
+    #         single_job_max_execution_time=700,
+    #     )
+    #     assert isinstance(sampling_backend.tracker, Tracker)
 
-        # tl > tb > 300
-        time_batch = 700
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                time_batch
-            ).max_execution_time
-            == 700
-        )
+    #     # tl > tb > 300
+    #     time_batch = 700
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             time_batch
+    #         ).max_execution_time
+    #         == 700
+    #     )
 
-        # tb > tl > 300
-        for _ in range(20):
-            job = sampling_backend.sample(QuantumCircuit(4), 100)
-            assert isinstance(job, QiskitRuntimeSamplingJob)
-            job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+    #     # tb > tl > 300
+    #     for _ in range(20):
+    #         job = sampling_backend.sample(QuantumCircuit(4), 100)
+    #         assert isinstance(job, QiskitRuntimeSamplingJob)
+    #         job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
 
-        time_batch = 700
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                time_batch
-            ).max_execution_time
-            == 600
-        )
+    #     time_batch = 700
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             time_batch
+    #         ).max_execution_time
+    #         == 600
+    #     )
 
-        # tl  > 300 > tb
-        time_batch = 70
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                time_batch
-            ).max_execution_time
-            == 300
-        )
+    #     # tl  > 300 > tb
+    #     time_batch = 70
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             time_batch
+    #         ).max_execution_time
+    #         == 300
+    #     )
 
-        # tb > 300 > tl
-        for _ in range(50):
-            job = sampling_backend.sample(QuantumCircuit(4), 100)
-            assert isinstance(job, QiskitRuntimeSamplingJob)
-            job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
+    #     # tb > 300 > tl
+    #     for _ in range(50):
+    #         job = sampling_backend.sample(QuantumCircuit(4), 100)
+    #         assert isinstance(job, QiskitRuntimeSamplingJob)
+    #         job._qiskit_job._set_status({"new_job_status": JobStatus.DONE})
 
-        time_batch = 350
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                time_batch
-            ).max_execution_time
-            == 300
-        )
+    #     time_batch = 350
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             time_batch
+    #         ).max_execution_time
+    #         == 300
+    #     )
 
-        # 300 > tb > tl
-        time_batch = 140
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                time_batch
-            ).max_execution_time
-            == 300
-        )
+    #     # 300 > tb > tl
+    #     time_batch = 140
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             time_batch
+    #         ).max_execution_time
+    #         == 300
+    #     )
 
-        # 300 > tl > tb
-        time_batch = 10
-        assert (
-            sampling_backend._get_sampler_option_with_time_limit(
-                time_batch
-            ).max_execution_time
-            == 300
-        )
+    #     # 300 > tl > tb
+    #     time_batch = 10
+    #     assert (
+    #         sampling_backend._get_sampler_option_with_time_limit(
+    #             time_batch
+    #         ).max_execution_time
+    #         == 300
+    #     )

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -12,11 +12,10 @@ import json
 import random
 import re
 import string
+import warnings
 from collections import Counter
-from functools import partial
 from typing import Any
 from unittest.mock import MagicMock
-import warnings
 
 import pytest
 import qiskit

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -858,14 +858,6 @@ class TestQiskitPrimitive:
             )
 
         # test no warnings raised
-        try:
-            with pytest.warns(UserWarning):
-                sampling_backend._check_execution_time_limitability(
-                    batch_exe_time=300, batch_time_left=300
-                )
-        except:  # noqa: E722
-            assert True
-
         no_warning_funcs = map(
             lambda t: partial(
                 sampling_backend._check_execution_time_limitability,


### PR DESCRIPTION
1. Add `single_job_max_execution_time` to `QiskitRuntimeSamplingBackend` to let the user limit the time used by a single `(circuit, n_shot)` pair.
2. Add `strict_time_limit` option so that jobs that cannot be limited by the Runtime backend (those whose time limit is < 300 seconds) will be rejected.
3. Automatically distribute and add `max_execution_time` option to `Runtime Sampler` according to user input `single_job_max_execution_time` and time left set by the `total_run_time` option.