### PR TITLE
Bug fix in fermion qubit mapping tutorial

### DIFF
--- a/docs/tutorials/quantum_chemistry/qubit_operator_mapping.ipynb
+++ b/docs/tutorials/quantum_chemistry/qubit_operator_mapping.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "state_mapper = jordan_wigner.get_state_mapper(n_spin_orbitals=4)"
+    "jw_state_mapper = jordan_wigner.get_state_mapper(n_spin_orbitals=4)"
    ]
   },
   {
@@ -248,15 +248,15 @@
       "ComputationalBasisState(qubit_count=4, bits=0b111, phase=0π/2) \n",
       "\n",
       "State preparation circuit\n",
-      "QuantumGate(name='X', target_indices=(0,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
-      "QuantumGate(name='X', target_indices=(1,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
-      "QuantumGate(name='X', target_indices=(2,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n"
+      "QuantumGate(name='X', target_indices=(0,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
+      "QuantumGate(name='X', target_indices=(1,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
+      "QuantumGate(name='X', target_indices=(2,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n"
      ]
     }
    ],
    "source": [
     "occupation_spin_orbitals = [0, 1, 2]\n",
-    "jw_state = state_mapper(occupation_spin_orbitals)\n",
+    "jw_state = jw_state_mapper(occupation_spin_orbitals)\n",
     "jw_state_preparation_circuit = jw_state.circuit  # The circuit that prepares the specified state\n",
     "\n",
     "print('State:')\n",
@@ -333,12 +333,12 @@
      "output_type": "stream",
      "text": [
       "State:\n",
-      "ComputationalBasisState(qubit_count=4, bits=0b111, phase=0π/2) \n",
+      "ComputationalBasisState(qubit_count=4, bits=0b1101, phase=0π/2) \n",
       "\n",
       "State preparation circuit:\n",
-      "QuantumGate(name='X', target_indices=(0,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
-      "QuantumGate(name='X', target_indices=(1,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
-      "QuantumGate(name='X', target_indices=(2,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n"
+      "QuantumGate(name='X', target_indices=(0,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
+      "QuantumGate(name='X', target_indices=(2,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
+      "QuantumGate(name='X', target_indices=(3,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n"
      ]
     }
    ],
@@ -346,7 +346,7 @@
     "bk_state_mapper = bravyi_kitaev.get_state_mapper(n_spin_orbitals=4)\n",
     "\n",
     "occupation_spin_orbitals = [0, 1, 2]\n",
-    "bk_state_mapper_state = state_mapper(occupation_spin_orbitals)\n",
+    "bk_state_mapper_state = bk_state_mapper(occupation_spin_orbitals)\n",
     "bk_state_preparation_circuit = bk_state_mapper_state.circuit\n",
     "\n",
     "print('State:')\n",
@@ -421,20 +421,19 @@
      "output_type": "stream",
      "text": [
       "State:\n",
-      "ComputationalBasisState(qubit_count=4, bits=0b111, phase=0π/2) \n",
+      "ComputationalBasisState(qubit_count=2, bits=0b11, phase=0π/2) \n",
       "\n",
       "State preparation circuit:\n",
-      "QuantumGate(name='X', target_indices=(0,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
-      "QuantumGate(name='X', target_indices=(1,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
-      "QuantumGate(name='X', target_indices=(2,), control_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n"
+      "QuantumGate(name='X', target_indices=(0,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n",
+      "QuantumGate(name='X', target_indices=(1,), control_indices=(), classical_indices=(), params=(), pauli_ids=(), unitary_matrix=())\n"
      ]
     }
    ],
    "source": [
-    "scbk_state_mapper = symmetry_conserving_bravyi_kitaev.get_state_mapper(n_fermions=2,n_spin_orbitals=4)\n",
+    "scbk_state_mapper = symmetry_conserving_bravyi_kitaev.get_state_mapper(n_fermions=2, n_spin_orbitals=4)\n",
     "\n",
-    "occupation_spin_orbitals = [0, 1, 2]\n",
-    "scbk_state_mapper_state = state_mapper(occupation_spin_orbitals)\n",
+    "occupation_spin_orbitals = [0, 1]\n",
+    "scbk_state_mapper_state = scbk_state_mapper(occupation_spin_orbitals)\n",
     "scbk_state_preparation_circuit = scbk_state_mapper_state.circuit\n",
     "\n",
     "print('State:')\n",


### PR DESCRIPTION
Bug fix in fermion qubit mapping tutorial

The bugs:

- Old (sc)bk state mapper were created but unused. The transformed state was using the jw state mapper.
- `n_fermion` for scbk was set to 2, but the state passed in to the state mapper was [0, 1, 2]. (Changed to [0, 1] for now)