### PR TITLE
Force int time limit

### DIFF
--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -148,8 +148,8 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
         sampler_options: Union[None, Options, Dict[str, Any]] = None,
         run_kwargs: Mapping[str, Any] = {},
         save_data_while_sampling: bool = False,
-        total_time_limit: Optional[float] = None,
-        single_job_max_execution_time: Optional[float] = None,
+        total_time_limit: Optional[int] = None,
+        single_job_max_execution_time: Optional[int] = None,
         strict_time_limit: bool = False,
     ):
         self._backend = backend
@@ -267,7 +267,7 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
                 )
 
     def _get_sampler_option_with_time_limit(
-        self, batch_exe_time: Optional[float], batch_time_left: Optional[float]
+        self, batch_exe_time: Optional[int], batch_time_left: Optional[int]
     ) -> Options:
         options = (
             deepcopy(self._qiskit_sampler_options)
@@ -294,16 +294,16 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
 
     def _get_batch_execution_time_and_time_left(
         self, shot_dist: Sequence[int]
-    ) -> tuple[Optional[float], Optional[float]]:
+    ) -> tuple[Optional[int], Optional[int]]:
         n_batch = len(shot_dist)
         batch_execution_time, batch_time_left = None, None
 
         if self._single_job_max_execution_time is not None:
-            batch_execution_time = self._single_job_max_execution_time // n_batch
+            batch_execution_time = int(self._single_job_max_execution_time // n_batch)
 
         if self.tracker is not None:
             time_left = self._time_limit - self.tracker.total_run_time
-            batch_time_left = time_left // n_batch
+            batch_time_left = int(time_left // n_batch)
 
         return batch_execution_time, batch_time_left
 

--- a/packages/qiskit/quri_parts/qiskit/backend/primitive.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/primitive.py
@@ -299,11 +299,11 @@ class QiskitRuntimeSamplingBackend(SamplingBackend):
         batch_execution_time, batch_time_left = None, None
 
         if self._single_job_max_execution_time is not None:
-            batch_execution_time = self._single_job_max_execution_time / n_batch
+            batch_execution_time = self._single_job_max_execution_time // n_batch
 
         if self.tracker is not None:
             time_left = self._time_limit - self.tracker.total_run_time
-            batch_time_left = time_left / n_batch
+            batch_time_left = time_left // n_batch
 
         return batch_execution_time, batch_time_left
 

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -596,7 +596,6 @@ class TestQiskitPrimitive:
         job2 = sampling_backend.sample(QuantumCircuit(2), 100)
         assert sampling_backend.tracker.running_jobs == [job1, job2]
 
-    
     def test_get_batch_execution_time_not_divisible(self) -> None:
         runtime_service = mock_get_backend("FakeVigo")
         service = runtime_service()

--- a/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
+++ b/packages/qiskit/tests/qiskit/backend/test_qiskit_primitive.py
@@ -596,6 +596,64 @@ class TestQiskitPrimitive:
         job2 = sampling_backend.sample(QuantumCircuit(2), 100)
         assert sampling_backend.tracker.running_jobs == [job1, job2]
 
+    
+    def test_get_batch_execution_time_not_divisible(self) -> None:
+        runtime_service = mock_get_backend("FakeVigo")
+        service = runtime_service()
+        backend = service.backend()
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend,
+            service=service,
+            single_job_max_execution_time=500,
+            total_time_limit=1000,
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50]
+        ) == (500 // 3, 1000 // 3)
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 1]
+        ) == (500 // 3, 1000 // 3)
+        assert sampling_backend._get_batch_execution_time_and_time_left([50]) == (
+            500,
+            1000,
+        )
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, total_time_limit=1000
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50]
+        ) == (None, 1000 // 3)
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 1]
+        ) == (None, 1000 // 3)
+        assert sampling_backend._get_batch_execution_time_and_time_left([50]) == (
+            None,
+            1000,
+        )
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service, single_job_max_execution_time=500
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50]
+        ) == (500 // 3, None)
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 1]
+        ) == (500 // 3, None)
+        assert sampling_backend._get_batch_execution_time_and_time_left([50]) == (
+            500,
+            None,
+        )
+
+        sampling_backend = QiskitRuntimeSamplingBackend(
+            backend=backend, service=service
+        )
+        assert sampling_backend._get_batch_execution_time_and_time_left(
+            [50, 50, 50, 50]
+        ) == (None, None)
+
     def test_get_batch_execution_time(self) -> None:
         runtime_service = mock_get_backend("FakeVigo")
         service = runtime_service()


### PR DESCRIPTION
Force the time limit for setting `Runtime.Options.max_execution_time` to be integer-valued.