### PR TITLE
bug fix: correct adding gate in front of the circuit

### DIFF
--- a/packages/circuit/quri_parts/circuit/circuit.py
+++ b/packages/circuit/quri_parts/circuit/circuit.py
@@ -362,7 +362,7 @@ class QuantumCircuit(NonParametricQuantumCircuit, MutableQuantumCircuitProtocol)
                 "than cbit_count",
             )
 
-        if gate_index:
+        if gate_index is not None:
             self._gates.insert(gate_index, gate)
         else:
             self._gates.append(gate)

--- a/packages/circuit/quri_parts/circuit/circuit_parametric.py
+++ b/packages/circuit/quri_parts/circuit/circuit_parametric.py
@@ -307,7 +307,7 @@ class UnboundParametricQuantumCircuit(
             raise ValueError(
                 "The indices of the gate applied must be smaller than qubit_count"
             )
-        if gate_index:
+        if gate_index is not None:
             self._gates.insert(gate_index, (gate, None))
         else:
             self._gates.append((gate, None))

--- a/packages/circuit/tests/circuit/test_circuit.py
+++ b/packages/circuit/tests/circuit/test_circuit.py
@@ -48,6 +48,10 @@ class TestQuantumCircuit:
         with pytest.raises(ValueError):
             circuit.add_gate(X(3))
 
+        circuit.add_gate(X(0), 0)
+        assert circuit.gates == (X(0),) + tuple(_GATES)
+        assert len(circuit.gates) == len(_GATES) + 1
+
     def test_get_mutable_copy(self) -> None:
         circuit = mutable_circuit()
         circuit_copied = circuit.get_mutable_copy()

--- a/packages/circuit/tests/circuit/test_circuit_parametric.py
+++ b/packages/circuit/tests/circuit/test_circuit_parametric.py
@@ -13,6 +13,8 @@ from quri_parts.circuit import (
     RX,
     ImmutableBoundParametricQuantumCircuit,
     ImmutableUnboundParametricQuantumCircuit,
+    ParametricPauliRotation,
+    ParametricRX,
     QuantumCircuit,
     QuantumGate,
     UnboundParametricQuantumCircuit,
@@ -116,6 +118,18 @@ class TestUnboundParametricQuantumCircuit:
         exp_circuit.add_ParametricRX_gate(0)
         exp_circuit.add_ParametricPauliRotation_gate([1], [1])
         assert got_circuit.gates == exp_circuit.gates
+
+    def test_add_gate(self) -> None:
+        circuit = mutable_circuit()
+        assert circuit.gates == _GATES + [
+            ParametricRX(0),
+            ParametricPauliRotation([1], [1]),
+        ]
+        circuit.add_gate(X(0), 0)
+        assert circuit.gates == [X(0)] + _GATES + [
+            ParametricRX(0),
+            ParametricPauliRotation([1], [1]),
+        ]
 
 
 class TestImmutableUnboundParametricQuantumCircuit:


### PR DESCRIPTION
Correct the bug of inserting gate to position 0 of a circuit goes to the back of the circuit.