### PR TITLE
Add a dependency on scipy to quri-parts-core

### DIFF
--- a/.licenses/pip/matplotlib.dep.yml
+++ b/.licenses/pip/matplotlib.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: matplotlib
-version: 3.8.0
+version: 3.8.1
 type: pip
 summary: Python plotting package
 homepage: https://matplotlib.org

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -25,10 +25,11 @@ enable = true
 style = "pep440"
 
 [tool.poetry.dependencies]
-python = "^3.9.8"
+python = ">=3.9.8,<3.13"
 typing-extensions = "^4.1.1"
 numpy = ">=1.22.0"
 quri-parts-circuit = "*"
+scipy = "^1.11.3"
 
 [tool.poetry.group.dev.dependencies]
 quri-parts-circuit = {path = "../circuit", develop = true}

--- a/packages/pyscf/pyproject.toml
+++ b/packages/pyscf/pyproject.toml
@@ -28,7 +28,7 @@ style = "pep440"
 python = "^3.9.8"
 typing-extensions = "^4.1.1"
 numpy = ">=1.22.0"
-pyscf = "^2.1.1"
+pyscf = "^2.3.0"
 quri-parts-core = "*"
 quri-parts-chem = "*"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3594,7 +3594,7 @@ test = ["openfermion"]
 
 [[package]]
 name = "quri-parts-algo"
-version = "0.13.0"
+version = "0.0.0"
 description = "Algorithms for quantum computers"
 optional = false
 python-versions = ">=3.9.8,<3.12"
@@ -3613,7 +3613,7 @@ url = "packages/algo"
 
 [[package]]
 name = "quri-parts-braket"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use Amazon Braket SDK with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3632,7 +3632,7 @@ url = "packages/braket"
 
 [[package]]
 name = "quri-parts-chem"
-version = "0.13.0"
+version = "0.0.0"
 description = "Quantum computer algorithms for chemistry"
 optional = false
 python-versions = "^3.9.8"
@@ -3649,7 +3649,7 @@ url = "packages/chem"
 
 [[package]]
 name = "quri-parts-circuit"
-version = "0.13.0"
+version = "0.0.0"
 description = "Platform-independent quantum circuit library"
 optional = false
 python-versions = "^3.9.8"
@@ -3666,7 +3666,7 @@ url = "packages/circuit"
 
 [[package]]
 name = "quri-parts-cirq"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use Cirq with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3684,16 +3684,17 @@ url = "packages/cirq"
 
 [[package]]
 name = "quri-parts-core"
-version = "0.13.0"
+version = "0.0.0"
 description = "A platform-independent library for quantum computing"
 optional = false
-python-versions = "^3.9.8"
+python-versions = ">=3.9.8,<3.13"
 files = []
 develop = true
 
 [package.dependencies]
 numpy = ">=1.22.0"
 quri-parts-circuit = "*"
+scipy = "^1.11.3"
 typing-extensions = "^4.1.1"
 
 [package.source]
@@ -3702,7 +3703,7 @@ url = "packages/core"
 
 [[package]]
 name = "quri-parts-ionq"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use IonQ with QIRI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3719,7 +3720,7 @@ url = "packages/ionq"
 
 [[package]]
 name = "quri-parts-itensor"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use ITensor with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3737,7 +3738,7 @@ url = "packages/itensor"
 
 [[package]]
 name = "quri-parts-openfermion"
-version = "0.13.0"
+version = "0.0.0"
 description = "A support library for using OpenFermion with QURI Parts"
 optional = false
 python-versions = ">=3.9.8,<3.12"
@@ -3756,7 +3757,7 @@ url = "packages/openfermion"
 
 [[package]]
 name = "quri-parts-openqasm"
-version = "0.13.0"
+version = "0.0.0"
 description = "A support library for using OpenQASM 3 with QURI Parts"
 optional = false
 python-versions = ">=3.9.8,<3.12"
@@ -3772,7 +3773,7 @@ url = "packages/openqasm"
 
 [[package]]
 name = "quri-parts-pyscf"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use PySCF with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3792,7 +3793,7 @@ url = "packages/pyscf"
 
 [[package]]
 name = "quri-parts-qiskit"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use Qiskit with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3814,7 +3815,7 @@ url = "packages/qiskit"
 
 [[package]]
 name = "quri-parts-quantinuum"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use Quantinuum with QIRI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3831,7 +3832,7 @@ url = "packages/quantinuum"
 
 [[package]]
 name = "quri-parts-qulacs"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use Qulacs with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3850,7 +3851,7 @@ url = "packages/qulacs"
 
 [[package]]
 name = "quri-parts-stim"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use Stim with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -3868,7 +3869,7 @@ url = "packages/stim"
 
 [[package]]
 name = "quri-parts-tket"
-version = "0.13.0"
+version = "0.0.0"
 description = "A plugin to use tket with QURI Parts"
 optional = false
 python-versions = "^3.9.8"
@@ -4059,40 +4060,44 @@ crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "scipy"
-version = "1.10.1"
+version = "1.11.3"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
-python-versions = "<3.12,>=3.8"
+python-versions = "<3.13,>=3.9"
 files = [
-    {file = "scipy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e7354fd7527a4b0377ce55f286805b34e8c54b91be865bac273f527e1b839019"},
-    {file = "scipy-1.10.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:4b3f429188c66603a1a5c549fb414e4d3bdc2a24792e061ffbd607d3d75fd84e"},
-    {file = "scipy-1.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1553b5dcddd64ba9a0d95355e63fe6c3fc303a8fd77c7bc91e77d61363f7433f"},
-    {file = "scipy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c0ff64b06b10e35215abce517252b375e580a6125fd5fdf6421b98efbefb2d2"},
-    {file = "scipy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:fae8a7b898c42dffe3f7361c40d5952b6bf32d10c4569098d276b4c547905ee1"},
-    {file = "scipy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f1564ea217e82c1bbe75ddf7285ba0709ecd503f048cb1236ae9995f64217bd"},
-    {file = "scipy-1.10.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:d925fa1c81b772882aa55bcc10bf88324dadb66ff85d548c71515f6689c6dac5"},
-    {file = "scipy-1.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaea0a6be54462ec027de54fca511540980d1e9eea68b2d5c1dbfe084797be35"},
-    {file = "scipy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15a35c4242ec5f292c3dd364a7c71a61be87a3d4ddcc693372813c0b73c9af1d"},
-    {file = "scipy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:43b8e0bcb877faf0abfb613d51026cd5cc78918e9530e375727bf0625c82788f"},
-    {file = "scipy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5678f88c68ea866ed9ebe3a989091088553ba12c6090244fdae3e467b1139c35"},
-    {file = "scipy-1.10.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:39becb03541f9e58243f4197584286e339029e8908c46f7221abeea4b749fa88"},
-    {file = "scipy-1.10.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bce5869c8d68cf383ce240e44c1d9ae7c06078a9396df68ce88a1230f93a30c1"},
-    {file = "scipy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07c3457ce0b3ad5124f98a86533106b643dd811dd61b548e78cf4c8786652f6f"},
-    {file = "scipy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:049a8bbf0ad95277ffba9b3b7d23e5369cc39e66406d60422c8cfef40ccc8415"},
-    {file = "scipy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cd9f1027ff30d90618914a64ca9b1a77a431159df0e2a195d8a9e8a04c78abf9"},
-    {file = "scipy-1.10.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:79c8e5a6c6ffaf3a2262ef1be1e108a035cf4f05c14df56057b64acc5bebffb6"},
-    {file = "scipy-1.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51af417a000d2dbe1ec6c372dfe688e041a7084da4fdd350aeb139bd3fb55353"},
-    {file = "scipy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b4735d6c28aad3cdcf52117e0e91d6b39acd4272f3f5cd9907c24ee931ad601"},
-    {file = "scipy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:7ff7f37b1bf4417baca958d254e8e2875d0cc23aaadbe65b3d5b3077b0eb23ea"},
-    {file = "scipy-1.10.1.tar.gz", hash = "sha256:2cf9dfb80a7b4589ba4c40ce7588986d6d5cebc5457cad2c2880f6bc2d42f3a5"},
+    {file = "scipy-1.11.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:370f569c57e1d888304052c18e58f4a927338eafdaef78613c685ca2ea0d1fa0"},
+    {file = "scipy-1.11.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:9885e3e4f13b2bd44aaf2a1a6390a11add9f48d5295f7a592393ceb8991577a3"},
+    {file = "scipy-1.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e04aa19acc324a1a076abb4035dabe9b64badb19f76ad9c798bde39d41025cdc"},
+    {file = "scipy-1.11.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e1a8a4657673bfae1e05e1e1d6e94b0cabe5ed0c7c144c8aa7b7dbb774ce5c1"},
+    {file = "scipy-1.11.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7abda0e62ef00cde826d441485e2e32fe737bdddee3324e35c0e01dee65e2a88"},
+    {file = "scipy-1.11.3-cp310-cp310-win_amd64.whl", hash = "sha256:033c3fd95d55012dd1148b201b72ae854d5086d25e7c316ec9850de4fe776929"},
+    {file = "scipy-1.11.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:925c6f09d0053b1c0f90b2d92d03b261e889b20d1c9b08a3a51f61afc5f58165"},
+    {file = "scipy-1.11.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5664e364f90be8219283eeb844323ff8cd79d7acbd64e15eb9c46b9bc7f6a42a"},
+    {file = "scipy-1.11.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00f325434b6424952fbb636506f0567898dca7b0f7654d48f1c382ea338ce9a3"},
+    {file = "scipy-1.11.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f290cf561a4b4edfe8d1001ee4be6da60c1c4ea712985b58bf6bc62badee221"},
+    {file = "scipy-1.11.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:91770cb3b1e81ae19463b3c235bf1e0e330767dca9eb4cd73ba3ded6c4151e4d"},
+    {file = "scipy-1.11.3-cp311-cp311-win_amd64.whl", hash = "sha256:e1f97cd89c0fe1a0685f8f89d85fa305deb3067d0668151571ba50913e445820"},
+    {file = "scipy-1.11.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:dfcc1552add7cb7c13fb70efcb2389d0624d571aaf2c80b04117e2755a0c5d15"},
+    {file = "scipy-1.11.3-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:0d3a136ae1ff0883fffbb1b05b0b2fea251cb1046a5077d0b435a1839b3e52b7"},
+    {file = "scipy-1.11.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bae66a2d7d5768eaa33008fa5a974389f167183c87bf39160d3fefe6664f8ddc"},
+    {file = "scipy-1.11.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2f6dee6cbb0e263b8142ed587bc93e3ed5e777f1f75448d24fb923d9fd4dce6"},
+    {file = "scipy-1.11.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:74e89dc5e00201e71dd94f5f382ab1c6a9f3ff806c7d24e4e90928bb1aafb280"},
+    {file = "scipy-1.11.3-cp312-cp312-win_amd64.whl", hash = "sha256:90271dbde4be191522b3903fc97334e3956d7cfb9cce3f0718d0ab4fd7d8bfd6"},
+    {file = "scipy-1.11.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a63d1ec9cadecce838467ce0631c17c15c7197ae61e49429434ba01d618caa83"},
+    {file = "scipy-1.11.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:5305792c7110e32ff155aed0df46aa60a60fc6e52cd4ee02cdeb67eaccd5356e"},
+    {file = "scipy-1.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ea7f579182d83d00fed0e5c11a4aa5ffe01460444219dedc448a36adf0c3917"},
+    {file = "scipy-1.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c77da50c9a91e23beb63c2a711ef9e9ca9a2060442757dffee34ea41847d8156"},
+    {file = "scipy-1.11.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:15f237e890c24aef6891c7d008f9ff7e758c6ef39a2b5df264650eb7900403c0"},
+    {file = "scipy-1.11.3-cp39-cp39-win_amd64.whl", hash = "sha256:4b4bb134c7aa457e26cc6ea482b016fef45db71417d55cc6d8f43d799cdf9ef2"},
+    {file = "scipy-1.11.3.tar.gz", hash = "sha256:bba4d955f54edd61899776bad459bf7326e14b9fa1c552181f0479cc60a568cd"},
 ]
 
 [package.dependencies]
-numpy = ">=1.19.5,<1.27.0"
+numpy = ">=1.21.6,<1.28.0"
 
 [package.extras]
-dev = ["click", "doit (>=0.36.0)", "flake8", "mypy", "pycodestyle", "pydevtool", "rich-click", "typing_extensions"]
-doc = ["matplotlib (>2)", "numpydoc", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-design (>=0.2.0)"]
+dev = ["click", "cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
+doc = ["jupytext", "matplotlib (>2)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-design (>=0.2.0)"]
 test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3027,36 +3027,23 @@ files = [
 
 [[package]]
 name = "pyscf"
-version = "2.2.1"
+version = "2.4.0"
 description = "PySCF: Python-based Simulations of Chemistry Framework"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pyscf-2.2.1-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:c57c02b01caef2ecb7e173d3d244e8aef88c347baae50bd536e5e2ed344d1b06"},
-    {file = "pyscf-2.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29889ffc3afef89961b6f192a70d5b366c4241534bbf3639419d535a090ba867"},
-    {file = "pyscf-2.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b107f618957d9012558a01ebd733a53df845c756e83a33a2140a6f93947d31b2"},
-    {file = "pyscf-2.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d91cff5afa1ccc2b56c0ec6d4f5bff73790e4c895bfa614531cc2114d2a1151c"},
-    {file = "pyscf-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e69e586b06d377c1b37c6e009707cf878dba28d24b511ab04c0a63bdee17f4ab"},
-    {file = "pyscf-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940e2e6faf02fa9242cba2be684bc344ba924d7143e17818fbeafc27b6043a0c"},
-    {file = "pyscf-2.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:580c9a706cb1431b5235319377cfa40a7a1bfb2d38c1c20223bf24a22acdba05"},
-    {file = "pyscf-2.2.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6ffc6903e4ed7f0c88ce77175cd8407bf7bcaefa410d386d7318f3834d6bde3"},
-    {file = "pyscf-2.2.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2343d6788f711158f0a2dbfff47c06d85c961c5f8ad591ef7ea80d721ef05e91"},
-    {file = "pyscf-2.2.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:28016bbaedc969bac7f241f5eed11de088accf23343d4e349ba3129d15b83454"},
-    {file = "pyscf-2.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4b41aae766c4d3136be67a6bbb252cba4c55bb490e6f390d36c94635cd5f89b"},
-    {file = "pyscf-2.2.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92c632901bac59137e35dff79fc78280e6511ccf5f2b411554cfebe2c639190e"},
-    {file = "pyscf-2.2.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:ff96e85977d7bf5017b19c6de37f87129c888e1c64d895be613cc955f7e748ff"},
-    {file = "pyscf-2.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:985a94bd34e15ede01a90d5d44d2e0f3c4946603c2ad887559a434c0385a0633"},
-    {file = "pyscf-2.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:69f3dc501a71d2b4c0e98ca028b42684e8e16b548ec1e6fe4978fde8c0786f7d"},
-    {file = "pyscf-2.2.1-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:365123d0314257e720c038ec51bd09a87fcfdb76ab5a7612543cb851292a80db"},
-    {file = "pyscf-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e7bcdda255b19cf5f95863d1537a98fb6c561927f582dad9aac0203f29f8d5d"},
-    {file = "pyscf-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee89c5a9e7e10482da10d15f54801ef4312971f5c9e87361dd2e68eb036714f0"},
-    {file = "pyscf-2.2.1.tar.gz", hash = "sha256:4ff6851351caadc5dfa543b6b2c5fbd926ded87e3cc39faa0054e1e5090ed69a"},
+    {file = "pyscf-2.4.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:fd3839144540dfe2fc7e81995c869fd97708ecc268d726678bf0d9eafd40374a"},
+    {file = "pyscf-2.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8b300e970e226512fe3bc55ff918dbaecd475ec887b6defbca567ce6bd418c5f"},
+    {file = "pyscf-2.4.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c9de88f339e18a0c6292633556c0822ef0ca29692a5642b8bc0bae2c8465939"},
+    {file = "pyscf-2.4.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be8a4240fde06e6ed3a8092969fa71a55c3ad4895b30eb65663d0388af4ce441"},
+    {file = "pyscf-2.4.0.tar.gz", hash = "sha256:af0597c481851b5448e7055c3160aef28dc12a1e0b35dda8279555c0780c0d45"},
 ]
 
 [package.dependencies]
 h5py = ">=2.7"
 numpy = ">=1.13,<1.16 || >1.16,<1.17 || >1.17"
 scipy = "<1.5.0 || >1.5.0,<1.5.1 || >1.5.1"
+setuptools = "*"
 
 [package.extras]
 all = ["basis-set-exchange", "cppe", "geometric (>=0.9.7.2)", "mcfun (>=0.2.1)", "pyberny (>=0.6.2)", "pyqmc", "pyscf-doci", "pyscf-icmpspt", "pyscf-properties", "pyscf-qsdopt", "pyscf-semiempirical", "pyscf-shciscf"]
@@ -3782,7 +3769,7 @@ develop = true
 
 [package.dependencies]
 numpy = ">=1.22.0"
-pyscf = "^2.1.1"
+pyscf = "^2.3.0"
 quri-parts-chem = "*"
 quri-parts-core = "*"
 typing-extensions = "^4.1.1"


### PR DESCRIPTION
`quri-parts-core` now requires scipy so this PR add the dependency on it.

Changes:

- Add a dependency `scipy = "^1.11.3"` to `quri-parts-core`
- Tighten the version constraints of pyscf `pyscf = "^2.3.0"`
  - From scipy 1.11.0 the keyword `sym_pos` when calling `scipy.linalg.solve`, which is used by pyscf 2.2 and earlier, is not available