### PR TITLE
Bugfix: Add missing argument (quri-parts-itensor)

### DIFF
--- a/packages/itensor/quri_parts/itensor/sampler.py
+++ b/packages/itensor/quri_parts/itensor/sampler.py
@@ -127,6 +127,8 @@ def create_itensor_mps_concurrent_sampler(
     def sampler(
         circuit_shots_tuples: Iterable[tuple[NonParametricQuantumCircuit, int]]
     ) -> Iterable[MeasurementCounts]:
-        return _sample_concurrently(circuit_shots_tuples, executor, concurrency)
+        return _sample_concurrently(
+            circuit_shots_tuples, executor, concurrency, **kwargs
+        )
 
     return sampler


### PR DESCRIPTION
In the current implementation `create_itensor_mps_concurrent_sampler()` accepts the arguments `maxdim`, `cutoff` and `**kwargs` but they don't work.
This PR fixes the bug by passing `**kwargs` to `_sample_concurrently()` correctly.