### PR TITLE
Check operator estimatable

### DIFF
--- a/packages/core/quri_parts/core/estimator/sampling/estimator.py
+++ b/packages/core/quri_parts/core/estimator/sampling/estimator.py
@@ -23,6 +23,7 @@ from quri_parts.core.estimator.sampling.pauli import (
     general_pauli_sum_expectation_estimator,
     general_pauli_sum_sample_variance,
 )
+from quri_parts.core.estimator.utils import is_estimatable
 from quri_parts.core.measurement import (
     CommutablePauliSetMeasurementFactory,
     PauliReconstructorFactory,
@@ -109,6 +110,10 @@ def sampling_estimate(
         The estimated value (can be accessed with :attr:`.value`) with standard error
             of estimation (can be accessed with :attr:`.error`).
     """
+    assert is_estimatable(
+        op, state
+    ), "Number of qubits of the operator is too large to estimate."
+
     if not isinstance(op, Operator):
         op = Operator({op: 1.0})
 

--- a/packages/core/quri_parts/core/estimator/utils.py
+++ b/packages/core/quri_parts/core/estimator/utils.py
@@ -24,10 +24,8 @@ def is_estimatable(observable: Estimatable, state: QuantumState) -> bool:
         return min_state_qubit_required <= state.qubit_count
 
     elif isinstance(observable, Operator):
-        estimatable = True
         for op in observable:
-            estimatable &= is_estimatable(op, state)
-            if not estimatable:
+            if not is_estimatable(op, state):
                 return False
         return True
 

--- a/packages/core/quri_parts/core/estimator/utils.py
+++ b/packages/core/quri_parts/core/estimator/utils.py
@@ -14,9 +14,8 @@ from quri_parts.core.state import QuantumState
 
 
 def is_estimatable(observable: Estimatable, state: QuantumState) -> bool:
-    """Check if the qubit count of the observable is larger than that
-    of the state.
-    """
+    """Check if the qubit count of the observable is larger than that of the
+    state."""
     if observable == PAULI_IDENTITY or observable == zero():
         return True
 

--- a/packages/core/quri_parts/core/estimator/utils.py
+++ b/packages/core/quri_parts/core/estimator/utils.py
@@ -32,4 +32,4 @@ def is_estimatable(observable: Estimatable, state: QuantumState) -> bool:
         return True
 
     else:
-        assert False
+        assert False, "Observable should be either a PauliLabel or an Operator."

--- a/packages/core/quri_parts/core/estimator/utils.py
+++ b/packages/core/quri_parts/core/estimator/utils.py
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Union
+
+from quri_parts.core.operator import PAULI_IDENTITY, Operator, PauliLabel, zero
+from quri_parts.core.state import (
+    CircuitQuantumState,
+    ParametricCircuitQuantumState,
+    ParametricQuantumStateVector,
+    QuantumStateVector,
+)
+
+if TYPE_CHECKING:
+    from quri_parts.core.estimator import Estimatable
+
+
+def is_estimatable(
+    observable: "Estimatable",
+    state: Union[
+        CircuitQuantumState,
+        QuantumStateVector,
+        ParametricCircuitQuantumState,
+        ParametricQuantumStateVector,
+    ],
+) -> bool:
+    if observable == PAULI_IDENTITY or observable == zero():
+        return True
+
+    elif isinstance(observable, PauliLabel):
+        min_state_qubit_required = max(observable.qubit_indices()) + 1
+        return min_state_qubit_required <= state.qubit_count
+
+    elif isinstance(observable, Operator):
+        estimatable = True
+        for op in observable:
+            estimatable &= is_estimatable(op, state)
+            if not estimatable:
+                return False
+        return True
+
+    else:
+        assert False

--- a/packages/core/quri_parts/core/estimator/utils.py
+++ b/packages/core/quri_parts/core/estimator/utils.py
@@ -8,29 +8,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Union
-
+from quri_parts.core.estimator import Estimatable
 from quri_parts.core.operator import PAULI_IDENTITY, Operator, PauliLabel, zero
-from quri_parts.core.state import (
-    CircuitQuantumState,
-    ParametricCircuitQuantumState,
-    ParametricQuantumStateVector,
-    QuantumStateVector,
-)
-
-if TYPE_CHECKING:
-    from quri_parts.core.estimator import Estimatable
+from quri_parts.core.state import QuantumState
 
 
-def is_estimatable(
-    observable: "Estimatable",
-    state: Union[
-        CircuitQuantumState,
-        QuantumStateVector,
-        ParametricCircuitQuantumState,
-        ParametricQuantumStateVector,
-    ],
-) -> bool:
+def is_estimatable(observable: "Estimatable", state: QuantumState) -> bool:
     if observable == PAULI_IDENTITY or observable == zero():
         return True
 

--- a/packages/core/quri_parts/core/estimator/utils.py
+++ b/packages/core/quri_parts/core/estimator/utils.py
@@ -13,7 +13,10 @@ from quri_parts.core.operator import PAULI_IDENTITY, Operator, PauliLabel, zero
 from quri_parts.core.state import QuantumState
 
 
-def is_estimatable(observable: "Estimatable", state: QuantumState) -> bool:
+def is_estimatable(observable: Estimatable, state: QuantumState) -> bool:
+    """Check if the qubit count of the observable is larger than that
+    of the state.
+    """
     if observable == PAULI_IDENTITY or observable == zero():
         return True
 

--- a/packages/core/tests/core/estimator/sampling/test_sampling_estimator.py
+++ b/packages/core/tests/core/estimator/sampling/test_sampling_estimator.py
@@ -164,6 +164,20 @@ class TestSamplingEstimate:
         assert estimate.value == 0.0
         assert estimate.error == 0.0
 
+    def test_raise_when_not_estimatable(self) -> None:
+        with pytest.raises(
+            AssertionError,
+            match="Number of qubits of the operator is too large to estimate.",
+        ):
+            obs = pauli_label("Z3")
+            sampling_estimate(
+                obs, initial_state(), 1000, sampler, measurement_factory, allocator
+            )
+            obs = Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3})
+            sampling_estimate(
+                obs, initial_state(), 1000, sampler, measurement_factory, allocator
+            )
+
     def test_const_op(self) -> None:
         op = Operator({PAULI_IDENTITY: 3.0})
         estimate = sampling_estimate(
@@ -213,6 +227,15 @@ class TestSamplingEstimator:
         assert_sampler_args(s)
         assert_sample(estimate)
 
+        with pytest.raises(
+            AssertionError,
+            match="Number of qubits of the operator is too large to estimate.",
+        ):
+            obs = pauli_label("Z3")
+            estimator(obs, initial_state())
+            obs = Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3})
+            estimator(obs, initial_state())
+
 
 class TestConcurrentSamplingEstimate:
     def test_invalid_arguments(self) -> None:
@@ -231,6 +254,21 @@ class TestConcurrentSamplingEstimate:
         with pytest.raises(ValueError):
             concurrent_sampling_estimate(
                 [operator()] * 3,
+                [initial_state()] * 2,
+                total_shots(),
+                s,
+                measurement_factory,
+                allocator,
+            )
+
+        with pytest.raises(
+            AssertionError,
+            match="Number of qubits of the operator is too large to estimate.",
+        ):
+            obs1 = pauli_label("Z3")
+            obs2 = Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3})
+            concurrent_sampling_estimate(
+                [obs1, obs2],
                 [initial_state()] * 2,
                 total_shots(),
                 s,

--- a/packages/core/tests/core/estimator/sampling/test_sampling_estimator.py
+++ b/packages/core/tests/core/estimator/sampling/test_sampling_estimator.py
@@ -239,6 +239,11 @@ class TestSamplingEstimator:
         assert_sampler_args(s)
         assert_sample(estimate)
 
+    def test_raises_when_not_estimatable(self) -> None:
+        s = mock_sampler()
+        estimator = create_sampling_estimator(
+            total_shots(), s, measurement_factory, allocator
+        )
         with pytest.raises(
             AssertionError,
             match="Number of qubits of the operator is too large to estimate.",

--- a/packages/core/tests/core/estimator/sampling/test_sampling_estimator.py
+++ b/packages/core/tests/core/estimator/sampling/test_sampling_estimator.py
@@ -169,13 +169,25 @@ class TestSamplingEstimate:
             AssertionError,
             match="Number of qubits of the operator is too large to estimate.",
         ):
-            obs = pauli_label("Z3")
             sampling_estimate(
-                obs, initial_state(), 1000, sampler, measurement_factory, allocator
+                pauli_label("Z3"),
+                initial_state(),
+                1000,
+                sampler,
+                measurement_factory,
+                allocator,
             )
-            obs = Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3})
+        with pytest.raises(
+            AssertionError,
+            match="Number of qubits of the operator is too large to estimate.",
+        ):
             sampling_estimate(
-                obs, initial_state(), 1000, sampler, measurement_factory, allocator
+                Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3}),
+                initial_state(),
+                1000,
+                sampler,
+                measurement_factory,
+                allocator,
             )
 
     def test_const_op(self) -> None:
@@ -231,10 +243,16 @@ class TestSamplingEstimator:
             AssertionError,
             match="Number of qubits of the operator is too large to estimate.",
         ):
-            obs = pauli_label("Z3")
-            estimator(obs, initial_state())
-            obs = Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3})
-            estimator(obs, initial_state())
+            estimator(pauli_label("Z3"), initial_state())
+
+        with pytest.raises(
+            AssertionError,
+            match="Number of qubits of the operator is too large to estimate.",
+        ):
+            estimator(
+                Operator({pauli_label("Z3"): 3, pauli_label("X0 X1"): 3}),
+                initial_state(),
+            )
 
 
 class TestConcurrentSamplingEstimate:

--- a/packages/core/tests/core/estimator/test_utils.py
+++ b/packages/core/tests/core/estimator/test_utils.py
@@ -1,0 +1,77 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from quri_parts.circuit import UnboundParametricQuantumCircuit
+from quri_parts.core.estimator.utils import is_estimatable
+from quri_parts.core.operator import PAULI_IDENTITY, Operator, pauli_label, zero
+from quri_parts.core.state import (
+    ComputationalBasisState,
+    GeneralCircuitQuantumState,
+    ParametricCircuitQuantumState,
+    ParametricQuantumStateVector,
+    QuantumStateVector,
+)
+
+
+def test_is_estimatable() -> None:
+    states = [
+        GeneralCircuitQuantumState(3),
+        ComputationalBasisState(3),
+        QuantumStateVector(3),
+        ParametricCircuitQuantumState(3, circuit=UnboundParametricQuantumCircuit(3)),
+        ParametricQuantumStateVector(3, circuit=UnboundParametricQuantumCircuit(3)),
+    ]
+
+    valid_pauli_labels = [
+        zero(),
+        PAULI_IDENTITY,
+        pauli_label("X0"),
+        pauli_label("Y1"),
+        pauli_label("Z2"),
+        pauli_label("X0 Y2"),
+        pauli_label("Y1 Z2"),
+        pauli_label("Z2"),
+    ]
+
+    for op in valid_pauli_labels:
+        for state in states:
+            assert is_estimatable(op, state)
+
+    invalid_pauli_labels = [pauli_label("X3"), pauli_label("Z50000")]
+    for op in invalid_pauli_labels:
+        for state in states:
+            assert not is_estimatable(op, state)
+
+    valid_operator = Operator(
+        {
+            pauli_label("Z0 Z1 Z2"): 1,
+            pauli_label("X0 Z1 Y2"): 2,
+            pauli_label("X0 Z1 X2"): 2,
+            pauli_label("Z1"): 2,
+            PAULI_IDENTITY: 3,
+        }
+    )
+
+    for state in states:
+        assert is_estimatable(valid_operator, state)
+
+    invalid_operator = Operator(
+        {
+            pauli_label("Z50000"): 1,
+            pauli_label("Z3"): 1,
+            pauli_label("Z0 Z1 Z2"): 1,
+            pauli_label("X0 Z1 Y2"): 2,
+            pauli_label("X0 Z1 X2"): 2,
+            pauli_label("Z1"): 2,
+            PAULI_IDENTITY: 3,
+        }
+    )
+    for state in states:
+        assert not is_estimatable(invalid_operator, state)

--- a/packages/core/tests/core/estimator/test_utils.py
+++ b/packages/core/tests/core/estimator/test_utils.py
@@ -9,6 +9,7 @@
 # limitations under the License.
 
 from quri_parts.circuit import UnboundParametricQuantumCircuit
+from quri_parts.core.estimator import Estimatable
 from quri_parts.core.estimator.utils import is_estimatable
 from quri_parts.core.operator import PAULI_IDENTITY, Operator, pauli_label, zero
 from quri_parts.core.state import (
@@ -29,7 +30,7 @@ def test_is_estimatable() -> None:
         ParametricQuantumStateVector(3, circuit=UnboundParametricQuantumCircuit(3)),
     ]
 
-    valid_pauli_labels = [
+    valid_pauli_labels: list[Estimatable] = [
         zero(),
         PAULI_IDENTITY,
         pauli_label("X0"),


### PR DESCRIPTION
Currently in sampling estimate computations, there is no mechanism to check whether the qubit count of the operator is larger than the state on which it is estimated. A new function is_estimatable is added for checking that.

Note:
Qulacs estimators are not checked by the new function as Qulacs already performs the check by itself.