### PR TITLE
Execute Pauli(Rotation)DecomposeTranspiler before converting circuit (quri-parts-itensor)

### DIFF
--- a/packages/itensor/quri_parts/itensor/circuit/__init__.py
+++ b/packages/itensor/quri_parts/itensor/circuit/__init__.py
@@ -126,7 +126,7 @@ def convert_circuit(
                 else:
                     raise ValueError("Invalid number of parameters.")
             else:
-                raise ValueError(f"Unknown single qubit gate name: {gate.name}")
+                raise ValueError(f"{gate.name} gate is not supported.")
         elif is_two_qubit_gate_name(gate.name):
             if gate.name == "SWAP":
                 gate_list = jl.add_two_qubit_gate(
@@ -151,6 +151,6 @@ def convert_circuit(
                 gate.target_indices[0] + 1,
             )
         else:
-            raise ValueError(f"Unknown gate name: {gate.name}")
+            raise ValueError(f"{gate.name} gate is not supported.")
     circuit = jl.ops(gate_list, qubit_sites)
     return circuit

--- a/packages/itensor/tests/itensor/circuit/test_itensor_convert_circuit.py
+++ b/packages/itensor/tests/itensor/circuit/test_itensor_convert_circuit.py
@@ -19,10 +19,9 @@ from juliacall import Main as jl
 
 from quri_parts.circuit import QuantumCircuit, QuantumGate, gates
 from quri_parts.circuit.transpile import (
-    SequentialTranspiler,
     IdentityInsertionTranspiler,
+    SequentialTranspiler,
 )
-
 from quri_parts.itensor.circuit import convert_circuit
 
 abs_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
In current implementation `QuantumCircuit` which contains `Pauli` or `PauliRotaion` gates is not available for `quri-parts-itensor`'s estimator and sampler.
This PR introduces `Pauli(Rotation)DecomposeTranspiler` as a default argument of `convert_circuit()` and it is executed before converting the circuit to ITensor's.