### PR TITLE
Add `__eq__()` method to `(Parametric)QuantumGate`

### DIFF
--- a/packages/circuit/quri_parts/circuit/gate.py
+++ b/packages/circuit/quri_parts/circuit/gate.py
@@ -9,7 +9,9 @@
 # limitations under the License.
 
 from collections.abc import Sequence
-from typing import NamedTuple
+from typing import NamedTuple, TypeVar
+
+_QuantumGateT = TypeVar("_QuantumGateT", "QuantumGate", "ParametricQuantumGate")
 
 
 class QuantumGate(NamedTuple):
@@ -32,21 +34,7 @@ class QuantumGate(NamedTuple):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, QuantumGate):
             return False
-        if self.name != other.name:
-            return False
-        if set(self.control_indices) != set(other.control_indices):
-            return False
-        if self.params != other.params:
-            return False
-        if set(zip(self.target_indices, self.pauli_ids)) != set(
-            zip(other.target_indices, other.pauli_ids)
-        ):
-            return False
-        if self.name == "Measurement":
-            return set(zip(self.target_indices, self.classical_indices)) == set(
-                zip(other.target_indices, other.classical_indices)
-            )
-        return self.unitary_matrix == other.unitary_matrix
+        return is_gate_equal(self, other)
 
 
 class ParametricQuantumGate(NamedTuple):
@@ -65,10 +53,27 @@ class ParametricQuantumGate(NamedTuple):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, ParametricQuantumGate):
             return False
-        if self.name != other.name:
+        return is_gate_equal(self, other)
+
+
+def is_gate_equal(
+    gate1: _QuantumGateT,
+    gate2: _QuantumGateT,
+) -> bool:
+    if gate1.name != gate2.name:
+        return False
+    if set(gate1.control_indices) != set(gate1.control_indices):
+        return False
+    if set(zip(gate1.target_indices, gate1.pauli_ids)) != set(
+        zip(gate2.target_indices, gate2.pauli_ids)
+    ):
+        return False
+    if isinstance(gate1, QuantumGate):
+        if gate1.params != gate2.params:
             return False
-        if set(self.control_indices) != set(other.control_indices):
-            return False
-        return set(zip(self.target_indices, self.pauli_ids)) == set(
-            zip(other.target_indices, other.pauli_ids)
-        )
+        if gate1.name == "Measurement":
+            return set(zip(gate1.target_indices, gate1.classical_indices)) == set(
+                zip(gate2.target_indices, gate2.classical_indices)
+            )
+        return gate1.unitary_matrix == gate2.unitary_matrix
+    return True

--- a/packages/circuit/quri_parts/circuit/gate.py
+++ b/packages/circuit/quri_parts/circuit/gate.py
@@ -29,6 +29,25 @@ class QuantumGate(NamedTuple):
     pauli_ids: Sequence[int] = ()
     unitary_matrix: Sequence[Sequence[complex]] = ()
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, QuantumGate):
+            return False
+        if self.name != other.name:
+            return False
+        if set(self.control_indices) != set(other.control_indices):
+            return False
+        if self.params != other.params:
+            return False
+        if set(zip(self.target_indices, self.pauli_ids)) != set(
+            zip(other.target_indices, other.pauli_ids)
+        ):
+            return False
+        if self.name == "Measurement":
+            return set(zip(self.target_indices, self.classical_indices)) == set(
+                zip(other.target_indices, other.classical_indices)
+            )
+        return self.unitary_matrix == other.unitary_matrix
+
 
 class ParametricQuantumGate(NamedTuple):
     """Parametric quantum gate.
@@ -42,3 +61,14 @@ class ParametricQuantumGate(NamedTuple):
     target_indices: Sequence[int]
     control_indices: Sequence[int] = ()
     pauli_ids: Sequence[int] = ()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ParametricQuantumGate):
+            return False
+        if self.name != other.name:
+            return False
+        if set(self.control_indices) != set(other.control_indices):
+            return False
+        return set(zip(self.target_indices, self.pauli_ids)) == set(
+            zip(other.target_indices, other.pauli_ids)
+        )

--- a/packages/circuit/quri_parts/circuit/gate.py
+++ b/packages/circuit/quri_parts/circuit/gate.py
@@ -11,6 +11,8 @@
 from collections.abc import Sequence
 from typing import NamedTuple, TypeVar
 
+from .gate_names import UnitaryMatrix
+
 _QuantumGateT = TypeVar("_QuantumGateT", "QuantumGate", "ParametricQuantumGate")
 
 
@@ -64,6 +66,12 @@ def is_gate_equal(
         return False
     if set(gate1.control_indices) != set(gate1.control_indices):
         return False
+    if gate1.name == UnitaryMatrix:
+        if gate1.target_indices != gate2.target_indices:
+            return False
+    else:
+        if set(gate1.target_indices) != set(gate2.target_indices):
+            return False
     if set(zip(gate1.target_indices, gate1.pauli_ids)) != set(
         zip(gate2.target_indices, gate2.pauli_ids)
     ):

--- a/packages/circuit/tests/circuit/test_gates.py
+++ b/packages/circuit/tests/circuit/test_gates.py
@@ -239,59 +239,59 @@ def test_gate_addition() -> None:
 def test_gate_equal() -> None:
     # Quantum Gate
     assert X(0) == X(0)
-    assert X(0) != X(1)
-    assert X(0) != H(1)
+    assert not X(0) == X(1)
+    assert not X(0) == H(1)
     assert H(1) == H(1)
     assert RX(0, 0.1) == RX(0, 0.1)
-    assert RX(0, 0.1) != RX(0, 0.2)
+    assert not RX(0, 0.1) == RX(0, 0.2)
     assert U2(1, 0.1, 0.2) == U2(1, 0.1, 0.2)
-    assert U2(1, 0.1, 0.2) != U2(1, 0.2, 0.2)
-    assert U2(1, 0.1, 0.2) != U2(1, 0.1, 0.1)
+    assert not U2(1, 0.1, 0.2) == U2(1, 0.2, 0.2)
+    assert not U2(1, 0.1, 0.2) == U2(1, 0.1, 0.1)
     assert U3(2, 0.1, 0.2, 0.3) == U3(2, 0.1, 0.2, 0.3)
-    assert U3(2, 0.1, 0.2, 0.3) != U3(2, 0.2, 0.2, 0.3)
-    assert U3(2, 0.1, 0.2, 0.3) != U3(2, 0.1, 0.1, 0.3)
-    assert U3(2, 0.1, 0.2, 0.3) != U3(2, 0.1, 0.2, 0.2)
+    assert not U3(2, 0.1, 0.2, 0.3) == U3(2, 0.2, 0.2, 0.3)
+    assert not U3(2, 0.1, 0.2, 0.3) == U3(2, 0.1, 0.1, 0.3)
+    assert not U3(2, 0.1, 0.2, 0.3) == U3(2, 0.1, 0.2, 0.2)
     assert CNOT(0, 1) == CNOT(0, 1)
-    assert CNOT(0, 1) != CNOT(1, 0)
+    assert not CNOT(0, 1) == CNOT(1, 0)
     assert TOFFOLI(0, 1, 2) == TOFFOLI(0, 1, 2)
     assert TOFFOLI(0, 1, 2) == TOFFOLI(1, 0, 2)
-    assert TOFFOLI(0, 1, 2) != TOFFOLI(0, 2, 1)
+    assert not TOFFOLI(0, 1, 2) == TOFFOLI(0, 2, 1)
     assert UnitaryMatrix(
         (0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0))
     ) == UnitaryMatrix((0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0)))
-    assert UnitaryMatrix(
+    assert not UnitaryMatrix(
         (0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0))
-    ) != UnitaryMatrix((1, 0), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0)))
-    assert UnitaryMatrix(
+    ) == UnitaryMatrix((1, 0), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0)))
+    assert not UnitaryMatrix(
         (0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0))
-    ) != UnitaryMatrix((0, 1), ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)))
+    ) == UnitaryMatrix((0, 1), ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)))
     assert Pauli((0, 1), (1, 3)) == Pauli((0, 1), (1, 3))
-    assert Pauli((0, 1), (1, 3)) != Pauli((1, 0), (1, 3))
+    assert not Pauli((0, 1), (1, 3)) == Pauli((1, 0), (1, 3))
     assert Pauli((0, 1), (1, 3)) == Pauli((1, 0), (3, 1))
     assert PauliRotation((1, 2, 3), (3, 2, 1), 0.1) == PauliRotation(
         (1, 2, 3), (3, 2, 1), 0.1
     )
-    assert PauliRotation((1, 2, 3), (3, 2, 1), 0.2) != PauliRotation(
+    assert not PauliRotation((1, 2, 3), (3, 2, 1), 0.2) == PauliRotation(
         (1, 2, 3), (3, 2, 1), 0.1
     )
     assert PauliRotation((2, 1, 3), (2, 3, 1), 0.1) == PauliRotation(
         (1, 2, 3), (3, 2, 1), 0.1
     )
-    assert PauliRotation((2, 1, 3), (3, 2, 1), 0.1) != PauliRotation(
+    assert not PauliRotation((2, 1, 3), (3, 2, 1), 0.1) == PauliRotation(
         (1, 2, 3), (3, 2, 1), 0.1
     )
     assert Measurement([0, 1], [1, 0]) == Measurement([0, 1], [1, 0])
-    assert Measurement([0, 1], [1, 0]) != Measurement([0, 1], [0, 1])
+    assert not Measurement([0, 1], [1, 0]) == Measurement([0, 1], [0, 1])
     assert Measurement([0, 1], [1, 0]) == Measurement([1, 0], [0, 1])
 
     # ParametricQuantumGate
     assert ParametricRX(0) == ParametricRX(0)
-    assert ParametricRX(0) != ParametricRX(1)
-    assert ParametricRX(0) != ParametricRY(0)
+    assert not ParametricRX(0) == ParametricRX(1)
+    assert not ParametricRX(0) == ParametricRY(0)
     assert ParametricPauliRotation((0, 1, 2), (2, 1, 3)) == ParametricPauliRotation(
         (0, 1, 2), (2, 1, 3)
     )
-    assert ParametricPauliRotation((0, 1, 2), (2, 1, 3)) != ParametricPauliRotation(
+    assert not ParametricPauliRotation((0, 1, 2), (2, 1, 3)) == ParametricPauliRotation(
         (0, 1, 2), (1, 2, 3)
     )
     assert ParametricPauliRotation((0, 1, 2), (2, 1, 3)) == ParametricPauliRotation(

--- a/packages/circuit/tests/circuit/test_gates.py
+++ b/packages/circuit/tests/circuit/test_gates.py
@@ -234,3 +234,66 @@ def test_gate_addition() -> None:
     mc.measure(0, 0)
 
     assert lc == mc
+
+
+def test_gate_equal() -> None:
+    # Quantum Gate
+    assert X(0) == X(0)
+    assert X(0) != X(1)
+    assert X(0) != H(1)
+    assert H(1) == H(1)
+    assert RX(0, 0.1) == RX(0, 0.1)
+    assert RX(0, 0.1) != RX(0, 0.2)
+    assert U2(1, 0.1, 0.2) == U2(1, 0.1, 0.2)
+    assert U2(1, 0.1, 0.2) != U2(1, 0.2, 0.2)
+    assert U2(1, 0.1, 0.2) != U2(1, 0.1, 0.1)
+    assert U3(2, 0.1, 0.2, 0.3) == U3(2, 0.1, 0.2, 0.3)
+    assert U3(2, 0.1, 0.2, 0.3) != U3(2, 0.2, 0.2, 0.3)
+    assert U3(2, 0.1, 0.2, 0.3) != U3(2, 0.1, 0.1, 0.3)
+    assert U3(2, 0.1, 0.2, 0.3) != U3(2, 0.1, 0.2, 0.2)
+    assert CNOT(0, 1) == CNOT(0, 1)
+    assert CNOT(0, 1) != CNOT(1, 0)
+    assert TOFFOLI(0, 1, 2) == TOFFOLI(0, 1, 2)
+    assert TOFFOLI(0, 1, 2) == TOFFOLI(1, 0, 2)
+    assert TOFFOLI(0, 1, 2) != TOFFOLI(0, 2, 1)
+    assert UnitaryMatrix(
+        (0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0))
+    ) == UnitaryMatrix((0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0)))
+    assert UnitaryMatrix(
+        (0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0))
+    ) != UnitaryMatrix((1, 0), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0)))
+    assert UnitaryMatrix(
+        (0, 1), ((1, 0, 0, 0), (0, 0, 0, 1), (0, 0, 1, 0), (0, 1, 0, 0))
+    ) != UnitaryMatrix((0, 1), ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)))
+    assert Pauli((0, 1), (1, 3)) == Pauli((0, 1), (1, 3))
+    assert Pauli((0, 1), (1, 3)) != Pauli((1, 0), (1, 3))
+    assert Pauli((0, 1), (1, 3)) == Pauli((1, 0), (3, 1))
+    assert PauliRotation((1, 2, 3), (3, 2, 1), 0.1) == PauliRotation(
+        (1, 2, 3), (3, 2, 1), 0.1
+    )
+    assert PauliRotation((1, 2, 3), (3, 2, 1), 0.2) != PauliRotation(
+        (1, 2, 3), (3, 2, 1), 0.1
+    )
+    assert PauliRotation((2, 1, 3), (2, 3, 1), 0.1) == PauliRotation(
+        (1, 2, 3), (3, 2, 1), 0.1
+    )
+    assert PauliRotation((2, 1, 3), (3, 2, 1), 0.1) != PauliRotation(
+        (1, 2, 3), (3, 2, 1), 0.1
+    )
+    assert Measurement([0, 1], [1, 0]) == Measurement([0, 1], [1, 0])
+    assert Measurement([0, 1], [1, 0]) != Measurement([0, 1], [0, 1])
+    assert Measurement([0, 1], [1, 0]) == Measurement([1, 0], [0, 1])
+
+    # ParametricQuantumGate
+    assert ParametricRX(0) == ParametricRX(0)
+    assert ParametricRX(0) != ParametricRX(1)
+    assert ParametricRX(0) != ParametricRY(0)
+    assert ParametricPauliRotation((0, 1, 2), (2, 1, 3)) == ParametricPauliRotation(
+        (0, 1, 2), (2, 1, 3)
+    )
+    assert ParametricPauliRotation((0, 1, 2), (2, 1, 3)) != ParametricPauliRotation(
+        (0, 1, 2), (1, 2, 3)
+    )
+    assert ParametricPauliRotation((0, 1, 2), (2, 1, 3)) == ParametricPauliRotation(
+        (0, 2, 1), (2, 3, 1)
+    )


### PR DESCRIPTION
Comparing two `Pauli` or `PauliRotation` gates that have equivalent matrix representation but different order of `target_indice` and `pauli_ids` gives the result we don't expect.

For example,

```python
Pauli(target_indices=(0,1), pauli_ids=(1,2)) == Pauli(target_indices=(0,1), pauli_ids=(1,2))  # True
Pauli(target_indices=(0,1), pauli_ids=(1,2)) == Pauli(target_indices=(1,0), pauli_ids=(2,1))  # False
```

This PR adds `__eq__()` method to `QuantumGate` and `ParametricQuantumGate` that compares the pairs of `target_index` and `pauli_id`