### PR TITLE
Base ActiveSpaceMolecularOrbital class

### DIFF
--- a/packages/chem/quri_parts/chem/mol/__init__.py
+++ b/packages/chem/quri_parts/chem/mol/__init__.py
@@ -15,6 +15,7 @@ from .active_space import (
 from .models import (
     ActiveSpace,
     ActiveSpaceMolecularOrbitals,
+    ActiveSpaceMolecularOrbitalsBase,
     AO1eInt,
     AO2eInt,
     AOeIntSet,
@@ -52,6 +53,7 @@ __all__ = [
     "ActiveSpace",
     "cas",
     "ActiveSpaceMolecularOrbitals",
+    "ActiveSpaceMolecularOrbitalsBase",
     "AO1eInt",
     "AO2eInt",
     "AOeIntSet",

--- a/packages/chem/quri_parts/chem/mol/models.py
+++ b/packages/chem/quri_parts/chem/mol/models.py
@@ -84,7 +84,7 @@ class MolecularOrbitals(Protocol):
         ...
 
 
-class ActiveSpaceMolecularOrbitalsBase(ABC, MolecularOrbitals):
+class ActiveSpaceMolecularOrbitalsBase(MolecularOrbitals, ABC):
     @abstractproperty
     def n_active_ele(self) -> int:
         ...

--- a/packages/chem/quri_parts/chem/mol/models.py
+++ b/packages/chem/quri_parts/chem/mol/models.py
@@ -8,7 +8,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod, abstractproperty
+from abc import ABC, abstractmethod, abstractproperty
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import NamedTuple, Optional, Protocol, Sequence
@@ -84,7 +84,40 @@ class MolecularOrbitals(Protocol):
         ...
 
 
-class ActiveSpaceMolecularOrbitals(MolecularOrbitals):
+class ActiveSpaceMolecularOrbitalsBase(ABC, MolecularOrbitals):
+    @abstractproperty
+    def n_active_ele(self) -> int:
+        ...
+
+    @abstractproperty
+    def n_core_ele(self) -> int:
+        ...
+
+    @abstractproperty
+    def n_active_orb(self) -> int:
+        """Returns the number of active orbitals."""
+        ...
+
+    @abstractproperty
+    def n_core_orb(self) -> int:
+        """Returns the number of core orbitals."""
+        ...
+
+    @abstractproperty
+    def n_vir_orb(self) -> int:
+        """Returns the number of virtual orbitals."""
+        ...
+
+    @abstractmethod
+    def get_core_and_active_orb(self) -> tuple[Sequence[int], Sequence[int]]:
+        ...
+
+    @abstractmethod
+    def orb_type(self, mo_index: int) -> OrbitalType:
+        ...
+
+
+class ActiveSpaceMolecularOrbitals(ActiveSpaceMolecularOrbitalsBase):
     """Represents a data of the active space for the molecule.
 
     Args:
@@ -309,7 +342,7 @@ class AOeIntSet(Protocol):
 
     def to_active_space_mo_int(
         self,
-        active_space_mo: ActiveSpaceMolecularOrbitals,
+        active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     ) -> "SpinMOeIntSet":
         """Compute the active space spin mo integral."""
         ...

--- a/packages/chem/quri_parts/chem/mol/non_relativistic_models.py
+++ b/packages/chem/quri_parts/chem/mol/non_relativistic_models.py
@@ -18,6 +18,7 @@ from numpy import arange, tensordot, trace, zeros
 
 from .models import (
     ActiveSpaceMolecularOrbitals,
+    ActiveSpaceMolecularOrbitalsBase,
     AO1eInt,
     AO2eInt,
     AOeIntSet,
@@ -121,7 +122,7 @@ class AOeIntArraySet(AOeIntSet):
 
     def to_active_space_mo_int(
         self,
-        active_space_mo: ActiveSpaceMolecularOrbitals,
+        active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     ) -> SpinMOeIntSet:
         """Computes the active space spin mo integrals.
 
@@ -130,10 +131,11 @@ class AOeIntArraySet(AOeIntSet):
         takes additional time to convert ao_eint to mo_eint.
         Performance penalty grows when the full space mo integral is large.
         """
+        assert isinstance(active_space_mo, ActiveSpaceMolecularOrbitals)
         return get_active_space_spin_integrals_from_ao_eint(active_space_mo, self)
 
     def to_active_space_spatial_mo_int(
-        self, active_space_mo: ActiveSpaceMolecularOrbitals
+        self, active_space_mo: ActiveSpaceMolecularOrbitalsBase
     ) -> SpatialMOeIntSet:
         """Computes the active space spatial mo integrals.
 
@@ -142,6 +144,7 @@ class AOeIntArraySet(AOeIntSet):
         takes additional time to convert ao_eint to mo_eint.
         Performance penalty grows when the full space mo integral is large.
         """
+        assert isinstance(active_space_mo, ActiveSpaceMolecularOrbitals)
         return get_active_space_spatial_integrals_from_ao_eint(active_space_mo, self)
 
 

--- a/packages/chem/quri_parts/chem/mol/non_relativistic_models.py
+++ b/packages/chem/quri_parts/chem/mol/non_relativistic_models.py
@@ -331,7 +331,7 @@ def spatial_mo_eint_set_to_spin_mo_eint_set(
 
 
 def get_active_space_spatial_integrals_from_mo_eint(
-    active_space_mo: ActiveSpaceMolecularOrbitals,
+    active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     electron_mo_ints: SpatialMOeIntSet,
 ) -> SpatialMOeIntSet:
     """Compute the active space effective core energy and all the spin space
@@ -376,7 +376,7 @@ def get_active_space_spatial_integrals_from_mo_eint(
 
 
 def get_active_space_spin_integrals_from_mo_eint(
-    active_space_mo: ActiveSpaceMolecularOrbitals,
+    active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     electron_mo_ints: SpatialMOeIntSet,
 ) -> SpinMOeIntSet:
     """Compute the active space spin electron integrals from mo electron
@@ -390,7 +390,7 @@ def get_active_space_spin_integrals_from_mo_eint(
 
 
 def get_active_space_spatial_integrals_from_ao_eint(
-    active_space_mo: ActiveSpaceMolecularOrbitals,
+    active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     electron_ao_ints: AOeIntArraySet,
 ) -> SpatialMOeIntSet:
     """Compute the active space spatial electron integrals from ao electron
@@ -411,7 +411,7 @@ def get_active_space_spatial_integrals_from_ao_eint(
 
 
 def get_active_space_spin_integrals_from_ao_eint(
-    active_space_mo: ActiveSpaceMolecularOrbitals,
+    active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     electron_ao_ints: AOeIntArraySet,
 ) -> SpinMOeIntSet:
     """Compute the active space spin electron integrals from ao electron

--- a/packages/pyscf/quri_parts/pyscf/mol/non_relativistic.py
+++ b/packages/pyscf/quri_parts/pyscf/mol/non_relativistic.py
@@ -18,6 +18,7 @@ from pyscf import ao2mo, gto, mcscf, scf
 from quri_parts.chem.mol import (
     ActiveSpace,
     ActiveSpaceMolecularOrbitals,
+    ActiveSpaceMolecularOrbitalsBase,
     AO1eInt,
     AO1eIntArray,
     AO2eInt,
@@ -118,17 +119,19 @@ class PySCFAOeIntSet(AOeIntSet):
 
     def to_active_space_mo_int(
         self,
-        active_space_mo: ActiveSpaceMolecularOrbitals,
+        active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     ) -> SpinMOeIntSet:
         """Returns the full space spin electon integrals."""
+        assert isinstance(active_space_mo, ActiveSpaceMolecularOrbitals)
         spin_mo_eint_set = get_active_space_spin_integrals(active_space_mo, self)
         return spin_mo_eint_set
 
     def to_active_space_spatial_mo_int(
         self,
-        active_space_mo: ActiveSpaceMolecularOrbitals,
+        active_space_mo: ActiveSpaceMolecularOrbitalsBase,
     ) -> SpatialMOeIntSet:
         """Returns the full space spatial electon integrals."""
+        assert isinstance(active_space_mo, ActiveSpaceMolecularOrbitals)
         spatial_mo_eint_set = get_active_space_spatial_integrals(active_space_mo, self)
         return spatial_mo_eint_set
 


### PR DESCRIPTION
Add base `ActiveSpaceMolecularOrbital` class for generic electron-integral-related usage.

Motivation of this PR:
The `to_active_space_mo_int` method of the Protocol class `AOeIntSet` takes in `ActiveSpaceMolecularOrbitals` originally, which is an object reserved for non-relativistic molecular systems. We want to follow the same interface for generic systems other than molecular systems, whose corresponding active space MO should not be a subclass of the active space MO for molecular systems. Thus, it makes sense to have a base class for active space MO and implement it for different systems.