### PR TITLE
State vector sampler

### DIFF
--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -8,7 +8,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Counter
 from typing import (
     Callable,
     Collection,
@@ -65,9 +64,10 @@ def sample_from_state_vector(
     assert n_qubits.is_integer(), "Length of the state vector must be a power of 2."
     if not np.isclose(np.linalg.norm(state_vector), 1):
         raise ValueError("probabilities do not sum to 1")
-    prob = np.abs(state_vector) ** 2
-    sample_cnt = np.random.default_rng().multinomial(n_shots, prob)
-    return Counter({i: cnt for i, cnt in enumerate(sample_cnt) if cnt > 0})
+    probs = np.abs(state_vector) ** 2
+    rng = np.random.default_rng()
+    counts = rng.multinomial(n_shots, probs)
+    return dict(((i, count) for i, count in enumerate(counts) if count > 0))
 
 
 def ideal_sample_from_state_vector(
@@ -79,8 +79,8 @@ def ideal_sample_from_state_vector(
     if not np.isclose(np.linalg.norm(state_vector), 1):
         raise ValueError("probabilities do not sum to 1")
 
-    prob = np.abs(state_vector) ** 2
-    return {i: p * n_shots for i, p in enumerate(prob)}
+    probs = np.abs(state_vector) ** 2
+    return {i: prob * n_shots for i, prob in enumerate(probs)}
 
 
 def create_sampler_from_sampling_backend(backend: SamplingBackend) -> Sampler:

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -9,7 +9,16 @@
 # limitations under the License.
 
 from collections import Counter
-from typing import Callable, Collection, Iterable, Mapping, NamedTuple, Sequence, Union
+from typing import (
+    Callable,
+    Collection,
+    Iterable,
+    Mapping,
+    NamedTuple,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 import numpy.typing as npt
@@ -19,6 +28,12 @@ from quri_parts.backend import SamplingBackend
 from quri_parts.circuit import NonParametricQuantumCircuit
 from quri_parts.core.operator import CommutablePauliSet, Operator
 from quri_parts.core.state import CircuitQuantumState, QuantumStateVector
+
+#: A type variable represents *any* non-parametric quantum state classes.
+#: This is different from :class:`quri_parts.core.state.QuantumStateT`;
+#: ``QuantumStateT`` represents *either one of* the classes, while ``_StateT`` also
+#: covers *a union of* multiple state classes.
+_StateT = TypeVar("_StateT", bound=Union[CircuitQuantumState, QuantumStateVector])
 
 #: MeasurementCounts represents count statistics of repeated measurements of a quantum
 #: circuit. Keys are observed bit patterns encoded in integers and values are counts
@@ -39,9 +54,7 @@ ConcurrentSampler: TypeAlias = Callable[
 #: StateSampler representes a function that samples a specific (non-parametric) state by
 #: specified times and returns the count statistics. In the case of an ideal
 #: StateSampler, the return value corresponds to probabilities multiplied by shot count.
-StateSampler: TypeAlias = Callable[
-    [Union[CircuitQuantumState, QuantumStateVector], int], MeasurementCounts
-]
+StateSampler: TypeAlias = Callable[[_StateT, int], MeasurementCounts]
 
 
 def sample_from_state_vector(

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -50,8 +50,11 @@ def sample_from_state_vector(
     """Perform sampling from a state vector."""
     n_qubits: float = np.log2(state_vector.shape[0])
     assert n_qubits.is_integer(), "Length of the state vector must be a power of 2."
+    if not np.isclose(np.linalg.norm(state_vector), 1):
+        raise ValueError("probabilities do not sum to 1")
     prob = np.abs(state_vector) ** 2
-    return Counter(np.random.choice(range(len(state_vector)), size=n_shots, p=prob))
+    sample_cnt = np.random.default_rng().multinomial(n_shots, prob)
+    return Counter({i: cnt for i, cnt in enumerate(sample_cnt) if cnt > 0})
 
 
 def ideal_sample_from_state_vector(

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -8,6 +8,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import Counter
 from typing import (
     Callable,
     Collection,
@@ -67,7 +68,7 @@ def sample_from_state_vector(
     probs = np.abs(state_vector) ** 2
     rng = np.random.default_rng()
     counts = rng.multinomial(n_shots, probs)
-    return dict(((i, count) for i, count in enumerate(counts) if count > 0))
+    return Counter(dict(((i, count) for i, count in enumerate(counts) if count > 0)))
 
 
 def ideal_sample_from_state_vector(

--- a/packages/core/tests/core/sampling/test_sample_state_vector.py
+++ b/packages/core/tests/core/sampling/test_sample_state_vector.py
@@ -1,0 +1,75 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+
+import numpy as np
+import pytest
+
+from quri_parts.core.sampling import (
+    ideal_sample_from_state_vector,
+    sample_from_state_vector,
+)
+
+
+class TestSampleFromStateVector:
+    def test_sample_from_state_vector(self) -> None:
+        n_qubits = 2
+        for i in range(2**n_qubits):
+            phase = np.random.random()
+            state = np.zeros(2**n_qubits, dtype=np.complex128)
+            state[i] = np.exp(1j * phase)
+            assert sample_from_state_vector(state, 1000) == Counter({i: 1000})
+
+    def test_invalid_input(self) -> None:
+        with pytest.raises(
+            AssertionError, match="Length of the state vector must be a power of 2."
+        ):
+            sample_from_state_vector(
+                np.array([0.5, 0.1, np.sqrt(1 - 0.25 - 0.01)]), 1000
+            )
+
+        with pytest.raises(ValueError, match="probabilities do not sum to 1"):
+            sample_from_state_vector(
+                np.random.random(4) + 1j * np.random.random(4), 1000
+            )
+
+
+class TestIdealSampleFromStateVector:
+    def test_ideal_sample_from_state_vector(self) -> None:
+        n_qubits = 2
+        state_vector = np.array(
+            [
+                0.13106223 + 0.70435299j,
+                0.16605566 - 0.36973591j,
+                0.10202236 + 0.48950168j,
+                0.18068102 - 0.19940998j,
+            ]
+        )
+        sampled_cnt = ideal_sample_from_state_vector(state_vector, 1000)
+        expected_cnt = Counter(
+            {0: 513.29044785, 1: 164.27912771, 2: 250.02045389, 3: 72.40997054}
+        )
+
+        for i in range(2**n_qubits):
+            assert np.isclose(sampled_cnt[i], expected_cnt[i])
+
+    def test_invalid_input(self) -> None:
+        with pytest.raises(
+            AssertionError, match="Length of the state vector must be a power of 2."
+        ):
+            ideal_sample_from_state_vector(
+                np.array([0.5, 0.1, np.sqrt(1 - 0.25 - 0.01)]), 1000
+            )
+
+        with pytest.raises(ValueError, match="probabilities do not sum to 1"):
+            ideal_sample_from_state_vector(
+                np.random.random(4) + 1j * np.random.random(4), 1000
+            )

--- a/packages/core/tests/core/sampling/test_sample_state_vector.py
+++ b/packages/core/tests/core/sampling/test_sample_state_vector.py
@@ -60,6 +60,7 @@ class TestIdealSampleFromStateVector:
 
         for i in range(2**n_qubits):
             assert np.isclose(sampled_cnt[i], expected_cnt[i])
+        assert np.isclose(sum(expected_cnt.values()), 1000)
 
     def test_invalid_input(self) -> None:
         with pytest.raises(

--- a/packages/qulacs/quri_parts/qulacs/sampler.py
+++ b/packages/qulacs/quri_parts/qulacs/sampler.py
@@ -24,15 +24,15 @@ from quri_parts.core.utils.concurrent import execute_concurrently
 
 from .circuit.noise import convert_circuit_with_noise_model
 from .simulator import (
-    create_qulacs_ideal_state_vector_sampler,
-    create_qulacs_state_vector_sampler,
+    create_qulacs_ideal_vector_state_sampler,
+    create_qulacs_vector_state_sampler,
 )
 
 if TYPE_CHECKING:
     from concurrent.futures import Executor
 
-_state_vector_sampler = create_qulacs_state_vector_sampler()
-_ideal_vector_sampler = create_qulacs_ideal_state_vector_sampler()
+_state_vector_sampler = create_qulacs_vector_state_sampler()
+_ideal_vector_sampler = create_qulacs_ideal_vector_state_sampler()
 
 
 def _sample(circuit: NonParametricQuantumCircuit, shots: int) -> MeasurementCounts:

--- a/packages/qulacs/quri_parts/qulacs/simulator.py
+++ b/packages/qulacs/quri_parts/qulacs/simulator.py
@@ -104,7 +104,9 @@ def get_marginal_probability(
     return qulacs_state.get_marginal_probability(measured)
 
 
-def create_qulacs_state_vector_sampler() -> StateSampler:
+def create_qulacs_state_vector_sampler() -> (
+    StateSampler[Union[CircuitQuantumState, QuantumStateVector]]
+):
     """Creates a state sampler based on Qulacs circuit execution."""
 
     def state_sampler(
@@ -116,7 +118,9 @@ def create_qulacs_state_vector_sampler() -> StateSampler:
     return state_sampler
 
 
-def create_qulacs_ideal_state_vector_sampler() -> StateSampler:
+def create_qulacs_ideal_state_vector_sampler() -> (
+    StateSampler[Union[CircuitQuantumState, QuantumStateVector]]
+):
     """Creates an ideal state sampler based on Qulacs circuit execution."""
 
     def ideal_state_sampler(

--- a/packages/qulacs/quri_parts/qulacs/simulator.py
+++ b/packages/qulacs/quri_parts/qulacs/simulator.py
@@ -16,6 +16,12 @@ from numpy import cfloat, zeros
 from numpy.typing import NDArray
 
 from quri_parts.circuit import NonParametricQuantumCircuit
+from quri_parts.core.sampling import (
+    MeasurementCounts,
+    StateSampler,
+    ideal_sample_from_state_vector,
+    sample_from_state_vector,
+)
 from quri_parts.core.state import CircuitQuantumState, QuantumStateVector
 from quri_parts.qulacs.circuit import convert_circuit
 from quri_parts.qulacs.circuit.compiled_circuit import _QulacsCircuit
@@ -96,3 +102,27 @@ def get_marginal_probability(
     qulacs_state.load(cast_to_list(state_vector))
     measured = [measured_values.get(i, 2) for i in range(int(n_qubits))]
     return qulacs_state.get_marginal_probability(measured)
+
+
+def create_qulacs_state_vector_sampler() -> StateSampler:
+    """Creates a state sampler based on Qulacs circuit execution."""
+
+    def state_sampler(
+        state: Union[CircuitQuantumState, QuantumStateVector], n_shots: int
+    ) -> MeasurementCounts:
+        state_vector = evaluate_state_to_vector(state).vector
+        return sample_from_state_vector(state_vector, n_shots)
+
+    return state_sampler
+
+
+def create_qulacs_ideal_state_vector_sampler() -> StateSampler:
+    """Creates an ideal state sampler based on Qulacs circuit execution."""
+
+    def ideal_state_sampler(
+        state: Union[CircuitQuantumState, QuantumStateVector], n_shots: int
+    ) -> MeasurementCounts:
+        state_vector = evaluate_state_to_vector(state).vector
+        return ideal_sample_from_state_vector(state_vector, n_shots)
+
+    return ideal_state_sampler

--- a/packages/qulacs/quri_parts/qulacs/simulator.py
+++ b/packages/qulacs/quri_parts/qulacs/simulator.py
@@ -27,12 +27,10 @@ from quri_parts.core.state import CircuitQuantumState, QuantumStateVector
 from quri_parts.qulacs.circuit import convert_circuit
 from quri_parts.qulacs.circuit.compiled_circuit import _QulacsCircuit
 
-from . import cast_to_list
+from . import QulacsStateT, cast_to_list
 
 
-def _evaluate_qp_state_to_qulacs_state(
-    state: Union[CircuitQuantumState, QuantumStateVector]
-) -> ql.QuantumState:
+def _evaluate_qp_state_to_qulacs_state(state: QulacsStateT) -> ql.QuantumState:
     n_qubits = state.qubit_count
 
     if isinstance(state, QuantumStateVector):
@@ -68,9 +66,7 @@ def _get_updated_qulacs_state_from_vector(
     return qulacs_state
 
 
-def evaluate_state_to_vector(
-    state: Union[CircuitQuantumState, QuantumStateVector]
-) -> QuantumStateVector:
+def evaluate_state_to_vector(state: QulacsStateT) -> QuantumStateVector:
     """Convert GeneralCircuitQuantumState or QuantumStateVector to
     QuantumStateVector that only contains the state vector."""
     out_state_vector = _evaluate_qp_state_to_qulacs_state(state)
@@ -122,14 +118,10 @@ def get_marginal_probability(
     return qulacs_state.get_marginal_probability(measured)
 
 
-def create_qulacs_state_vector_sampler() -> (
-    StateSampler[Union[CircuitQuantumState, QuantumStateVector]]
-):
+def create_qulacs_state_vector_sampler() -> StateSampler[QulacsStateT]:
     """Creates a state sampler based on Qulacs circuit execution."""
 
-    def state_sampler(
-        state: Union[CircuitQuantumState, QuantumStateVector], n_shots: int
-    ) -> MeasurementCounts:
+    def state_sampler(state: QulacsStateT, n_shots: int) -> MeasurementCounts:
         if n_shots > 2 ** max(state.qubit_count, 10):
             # Use multinomial distribution for faster sampling
             state_vector = evaluate_state_to_vector(state).vector
@@ -141,9 +133,7 @@ def create_qulacs_state_vector_sampler() -> (
     return state_sampler
 
 
-def create_qulacs_ideal_state_vector_sampler() -> (
-    StateSampler[Union[CircuitQuantumState, QuantumStateVector]]
-):
+def create_qulacs_ideal_state_vector_sampler() -> StateSampler[QulacsStateT]:
     """Creates an ideal state sampler based on Qulacs circuit execution."""
 
     def ideal_state_sampler(

--- a/packages/qulacs/quri_parts/qulacs/simulator.py
+++ b/packages/qulacs/quri_parts/qulacs/simulator.py
@@ -118,7 +118,7 @@ def get_marginal_probability(
     return qulacs_state.get_marginal_probability(measured)
 
 
-def create_qulacs_state_vector_sampler() -> StateSampler[QulacsStateT]:
+def create_qulacs_vector_state_sampler() -> StateSampler[QulacsStateT]:
     """Creates a state sampler based on Qulacs circuit execution."""
 
     def state_sampler(state: QulacsStateT, n_shots: int) -> MeasurementCounts:
@@ -133,7 +133,7 @@ def create_qulacs_state_vector_sampler() -> StateSampler[QulacsStateT]:
     return state_sampler
 
 
-def create_qulacs_ideal_state_vector_sampler() -> StateSampler[QulacsStateT]:
+def create_qulacs_ideal_vector_state_sampler() -> StateSampler[QulacsStateT]:
     """Creates an ideal state sampler based on Qulacs circuit execution."""
 
     def ideal_state_sampler(

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -8,10 +8,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+from collections import Counter
+
 import pytest
 from numpy import allclose, array, isclose, pi
 
-from quri_parts.circuit import QuantumCircuit
+from quri_parts.circuit import QuantumCircuit, X
 from quri_parts.core.state import (
     ComputationalBasisState,
     GeneralCircuitQuantumState,
@@ -19,6 +22,8 @@ from quri_parts.core.state import (
 )
 from quri_parts.qulacs.circuit import compile_circuit
 from quri_parts.qulacs.simulator import (
+    create_qulacs_ideal_state_vector_sampler,
+    create_qulacs_state_vector_sampler,
     evaluate_state_to_vector,
     get_marginal_probability,
     run_circuit,
@@ -191,3 +196,50 @@ def test_get_marginal_probability() -> None:
         AssertionError, match="The specified qubit index 2 is out of range."
     ):
         get_marginal_probability(array([1.0, 0.0, 0.0, 0.0]), {0: 0, 2: 1}),
+
+
+def test_create_qulacs_state_vector_sampler() -> None:
+    state_vector_sampler = create_qulacs_state_vector_sampler()
+    n_shots = 1000
+
+    n_qubits = 2
+    for i, j in itertools.product(range(2), repeat=2):
+        vector_state = QuantumStateVector(
+            n_qubits,
+            circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
+        )
+        vector_sampling_cnt = state_vector_sampler(vector_state, n_shots)
+        assert vector_sampling_cnt == Counter({2 * i + j: n_shots})
+
+        circuit_state = GeneralCircuitQuantumState(
+            n_qubits,
+            circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
+        )
+        circuit_sampling_cnt = state_vector_sampler(circuit_state, n_shots)
+        assert circuit_sampling_cnt == Counter({2 * i + j: n_shots})
+
+
+def test_create_qulacs_ideal_state_vector_sampler() -> None:
+    n_qubits = 2
+    n_shots = 1000
+
+    ideal_sampler = create_qulacs_ideal_state_vector_sampler()
+
+    quantum_circuit = QuantumCircuit(n_qubits)
+    quantum_circuit.add_CNOT_gate(0, 1)
+    quantum_circuit.add_X_gate(0)
+    quantum_circuit.add_RX_gate(0, pi / 7)
+    quantum_circuit.add_RY_gate(0, pi / 8)
+    quantum_circuit.add_H_gate(1)
+
+    expected_cnt = {0: 41.90342, 1: 458.09677, 2: 41.90342, 3: 458.09677}
+
+    vector_state = QuantumStateVector(n_qubits, circuit=quantum_circuit)
+    vector_cnt = ideal_sampler(vector_state, n_shots)
+    for i in range(2**n_qubits):
+        assert isclose(expected_cnt[i], vector_cnt[i])
+
+    circuit_state = GeneralCircuitQuantumState(n_qubits, circuit=quantum_circuit)
+    circuit_cnt = ideal_sampler(circuit_state, n_shots)
+    for i in range(2**n_qubits):
+        assert isclose(expected_cnt[i], circuit_cnt[i])

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -238,8 +238,10 @@ def test_create_qulacs_ideal_state_vector_sampler() -> None:
     vector_cnt = ideal_sampler(vector_state, n_shots)
     for i in range(2**n_qubits):
         assert isclose(expected_cnt[i], vector_cnt[i])
+    assert isclose(sum(vector_cnt.values()), 1000)
 
     circuit_state = GeneralCircuitQuantumState(n_qubits, circuit=quantum_circuit)
     circuit_cnt = ideal_sampler(circuit_state, n_shots)
     for i in range(2**n_qubits):
         assert isclose(expected_cnt[i], circuit_cnt[i])
+    assert isclose(sum(circuit_cnt.values()), 1000)

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -23,8 +23,8 @@ from quri_parts.core.state import (
 )
 from quri_parts.qulacs.circuit import compile_circuit
 from quri_parts.qulacs.simulator import (
-    create_qulacs_ideal_state_vector_sampler,
-    create_qulacs_state_vector_sampler,
+    create_qulacs_ideal_vector_state_sampler,
+    create_qulacs_vector_state_sampler,
     evaluate_state_to_vector,
     get_marginal_probability,
     run_circuit,
@@ -199,8 +199,8 @@ def test_get_marginal_probability() -> None:
         get_marginal_probability(array([1.0, 0.0, 0.0, 0.0]), {0: 0, 2: 1}),
 
 
-def test_create_qulacs_state_vector_sampler() -> None:
-    state_vector_sampler = create_qulacs_state_vector_sampler()
+def test_create_qulacs_vector_state_sampler() -> None:
+    state_vector_sampler = create_qulacs_vector_state_sampler()
     n_shots = 1000
 
     n_qubits = 2
@@ -231,11 +231,11 @@ def test_create_qulacs_state_vector_sampler() -> None:
         assert circuit_sampling_cnt == Counter({2 * i + j: n_shots})
 
 
-def test_create_qulacs_ideal_state_vector_sampler() -> None:
+def test_create_qulacs_ideal_vector_state_sampler() -> None:
     n_qubits = 2
     n_shots = 1000
 
-    ideal_sampler = create_qulacs_ideal_state_vector_sampler()
+    ideal_sampler = create_qulacs_ideal_vector_state_sampler()
 
     quantum_circuit = QuantumCircuit(n_qubits)
     quantum_circuit.add_CNOT_gate(0, 1)


### PR DESCRIPTION
- A `StateSampler` interfaces is added as a type alias as to sample on  either `CircuitQuantumState` and `QuantumStateVector`
- `(ideal_)sample_from_state_vector` is added in `quri_parts.core.sampling` to perform sampling from a 1-d numpy array.
- `create_qulacs_(ideal)_vector_state_sampler` is added in `quri_parts.qulacs.simulator` for using Qulacs to perform circuit execution and sample the resulting state with `(ideal_)sample_from_state_vector`.