### PR TITLE
Bug Fix: sz=0 ignored in post selection filter

### DIFF
--- a/packages/openfermion/quri_parts/openfermion/utils/post_selection_filters.py
+++ b/packages/openfermion/quri_parts/openfermion/utils/post_selection_filters.py
@@ -31,7 +31,7 @@ def create_jw_electron_number_post_selection_filter_fn(
     """
 
     def filter_fn(bits: int) -> bool:
-        if sz:
+        if sz is not None:
             n_up = bin(bits)[-1:1:-2].count("1")
             n_down = bin(bits)[-2:1:-2].count("1")
             if n_up - n_down != sz * 2:
@@ -58,7 +58,7 @@ def create_bk_electron_number_post_selection_filter_fn(
     def filter_fn(bits: int) -> bool:
         state = ComputationalBasisState(qubit_count, bits=bits)
         occ_indices = inv_st_mapper(state)
-        if sz and occupation_state_sz(occ_indices) != sz:
+        if sz is not None and occupation_state_sz(occ_indices) != sz:
             return False
         return len(occ_indices) == n_electrons
 

--- a/packages/openfermion/tests/openfermion/utils/test_post_selection_filters.py
+++ b/packages/openfermion/tests/openfermion/utils/test_post_selection_filters.py
@@ -34,6 +34,16 @@ def test_create_jw_electron_number_post_selection_filter_fn() -> None:
     assert not filter_fn(0b1011)
     assert not filter_fn(0b11010)
 
+    n_electrons = 2
+    filter_fn = create_jw_electron_number_post_selection_filter_fn(n_electrons, sz=0)
+    assert not filter_fn(0b00)
+    assert not filter_fn(0b10)
+    assert filter_fn(0b11)
+    assert filter_fn(0b1100)
+    assert filter_fn(0b1001)
+    assert not filter_fn(0b101)
+    assert not filter_fn(0b1111)
+
 
 def test_create_bk_electron_number_post_selection_filter_fn() -> None:
     qubit_count = 10
@@ -56,6 +66,22 @@ def test_create_bk_electron_number_post_selection_filter_fn() -> None:
     assert filter_fn(0b0111)
     assert not filter_fn(0b0010)
     assert filter_fn(59)
+
+    filter_fn = create_bk_electron_number_post_selection_filter_fn(
+        qubit_count, n_electrons, sz=0.0
+    )
+    assert filter_fn(0b1)
+    assert filter_fn(0b11)
+    assert filter_fn(0b101011)
+    assert filter_fn(0b1011)
+    assert filter_fn(0b1100)
+    assert filter_fn(0b100)
+    assert not filter_fn(0b111)
+    assert not filter_fn(0b111011)
+    assert not filter_fn(0b1001011)
+    assert not filter_fn(0b1000)
+    assert not filter_fn(0b1000010)
+    assert not filter_fn(0b1110000100)
 
 
 def test_create_scbk_electron_number_post_selection_filter_fn() -> None:


### PR DESCRIPTION
When `sz=0`, it is currently recognized as `sz=None` and does not check `sz` for the state