### PR TITLE
bind param by dict

### DIFF
--- a/packages/circuit/quri_parts/circuit/circuit_parametric.py
+++ b/packages/circuit/quri_parts/circuit/circuit_parametric.py
@@ -130,6 +130,19 @@ class UnboundParametricQuantumCircuitProtocol(QuantumCircuitProtocol, Protocol):
         """Returns the parameter mapping of the circuit."""
         ...
 
+    def bind_parameters_by_dict(
+        self, params_dict: dict[Parameter, float]
+    ) -> "ImmutableBoundParametricQuantumCircuit":
+        """Returns a new circuit with the parameters assigned concrete values.
+
+        This method does not modify self but returns a newly created
+        circuit.
+        """
+        param_list = []
+        for param in self.param_mapping.in_params:
+            param_list.append(params_dict[param])
+        return self.bind_parameters(param_list)
+
     def __add__(
         self, gates: Union[GateSequence, "UnboundParametricQuantumCircuitProtocol"]
     ) -> "UnboundParametricQuantumCircuitProtocol":

--- a/packages/circuit/tests/circuit/test_circuit_parametric.py
+++ b/packages/circuit/tests/circuit/test_circuit_parametric.py
@@ -8,6 +8,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+
 from quri_parts.circuit import (
     CNOT,
     RX,
@@ -72,6 +74,19 @@ class TestUnboundParametricQuantumCircuit:
         assert all([isinstance(gate, QuantumGate) for gate in circuit_bound.gates])
         assert circuit_bound.gates[3].params[0] == 1.0
         assert circuit_bound.gates[4].params[0] == 0.5
+
+    def test_bind_parameters_by_dict(self) -> None:
+        circuit = UnboundParametricQuantumCircuit(2)
+        for gate in _GATES:
+            circuit.add_gate(gate)
+        theta = circuit.add_ParametricRX_gate(0)
+        phi = circuit.add_ParametricPauliRotation_gate([1], [1])
+        param_vals = np.random.random(2).tolist()
+        param_dict = {theta: param_vals[0], phi: param_vals[1]}
+
+        expected_circuit = circuit.bind_parameters(param_vals)
+        circuit_bound = circuit.bind_parameters_by_dict(param_dict)
+        assert expected_circuit.gates == circuit_bound.gates
 
     def test_depth(self) -> None:
         circuit = mutable_circuit()


### PR DESCRIPTION
Support `.bind_parameters_by_dict` for parametric circuits to bind parameter by a `dict[Parameter, float]`.
The current `bind_parameter` method is still supported

Example:
```python
circuit = UnboundParametricQuantumCircuit(2)

theta = circuit.add_ParametricRX_gate(0)
phi = circuit.add_ParametricPauliRotation_gate([1], [1])

# current way for assigning `theta = 0`, `phi = 1`
circuit_bound = circuit.bind_parameters(param_vals)

# new for assigning `theta = 0`, `phi = 1`
param_dict = {theta: 0, phi: 1}
circuit_bound = circuit.bind_parameters_by_dict(param_dict)
```