### PR TITLE
Concurrent state sampler

### DIFF
--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -56,8 +56,8 @@ ConcurrentSampler: TypeAlias = Callable[
 #: StateSampler, the return value corresponds to probabilities multiplied by shot count.
 StateSampler: TypeAlias = Callable[[_StateT, int], MeasurementCounts]
 
-#: ConcurrentSampler represents a function that samples specified (non-parametric) state by
-#: specified times and returns the count statistics concurrently. 
+#: ConcurrentSampler represents a function that samples specified (non-parametric)
+#: state by specified times and returns the count statistics concurrently.
 ConcurrentStateSampler: TypeAlias = Callable[
     [Iterable[tuple[_StateT, int]]], Iterable[MeasurementCounts]
 ]

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -56,6 +56,12 @@ ConcurrentSampler: TypeAlias = Callable[
 #: StateSampler, the return value corresponds to probabilities multiplied by shot count.
 StateSampler: TypeAlias = Callable[[_StateT, int], MeasurementCounts]
 
+#: ConcurrentSampler represents a function that samples specified (non-parametric) state by
+#: specified times and returns the count statistics concurrently. 
+ConcurrentStateSampler: TypeAlias = Callable[
+    [Iterable[tuple[_StateT, int]]], Iterable[MeasurementCounts]
+]
+
 
 def sample_from_state_vector(
     state_vector: npt.NDArray[np.complex128], n_shots: int

--- a/packages/qulacs/quri_parts/qulacs/simulator.py
+++ b/packages/qulacs/quri_parts/qulacs/simulator.py
@@ -9,23 +9,23 @@
 # limitations under the License.
 
 from collections import Counter
-from typing import Union, Iterable, Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
 import numpy as np
 import qulacs as ql
 from numpy import cfloat, zeros
 from numpy.typing import NDArray
 
-from quri_parts.core.utils.concurrent import execute_concurrently
-from quri_parts.core.sampling import ConcurrentStateSampler
 from quri_parts.circuit import NonParametricQuantumCircuit
 from quri_parts.core.sampling import (
+    ConcurrentStateSampler,
     MeasurementCounts,
     StateSampler,
     ideal_sample_from_state_vector,
     sample_from_state_vector,
 )
 from quri_parts.core.state import CircuitQuantumState, QuantumStateVector
+from quri_parts.core.utils.concurrent import execute_concurrently
 from quri_parts.qulacs.circuit import convert_circuit
 from quri_parts.qulacs.circuit.compiled_circuit import _QulacsCircuit
 
@@ -138,7 +138,9 @@ def create_qulacs_vector_state_sampler() -> StateSampler[QulacsStateT]:
     return state_sampler
 
 
-def _sequential_vector_state_sampler(_: Any, state_shots_tuples: Iterable[tuple[QulacsStateT, int]]) -> Iterable[MeasurementCounts]:
+def _sequential_vector_state_sampler(
+    _: Any, state_shots_tuples: Iterable[tuple[QulacsStateT, int]]
+) -> Iterable[MeasurementCounts]:
     state_sampler = create_qulacs_vector_state_sampler()
     return [state_sampler(state, shots) for state, shots in state_shots_tuples]
 
@@ -146,10 +148,17 @@ def _sequential_vector_state_sampler(_: Any, state_shots_tuples: Iterable[tuple[
 def create_concurrent_vector_state_sampler(
     executor: Optional["Executor"] = None, concurrency: int = 1
 ) -> ConcurrentStateSampler[QulacsStateT]:
-    def concurrent_state_sampler(state_shots_tuples: Iterable[tuple[QulacsStateT, int]]) -> Iterable[MeasurementCounts]:
+    def concurrent_state_sampler(
+        state_shots_tuples: Iterable[tuple[QulacsStateT, int]]
+    ) -> Iterable[MeasurementCounts]:
         return execute_concurrently(
-            _sequential_vector_state_sampler, None, state_shots_tuples, executor, concurrency
+            _sequential_vector_state_sampler,
+            None,
+            state_shots_tuples,
+            executor,
+            concurrency,
         )
+
     return concurrent_state_sampler
 
 

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -23,9 +23,9 @@ from quri_parts.core.state import (
 )
 from quri_parts.qulacs.circuit import compile_circuit
 from quri_parts.qulacs.simulator import (
+    create_concurrent_vector_state_sampler,
     create_qulacs_ideal_vector_state_sampler,
     create_qulacs_vector_state_sampler,
-    create_concurrent_vector_state_sampler,
     evaluate_state_to_vector,
     get_marginal_probability,
     run_circuit,
@@ -237,44 +237,44 @@ def test_create_concurrent_vector_state_sampler() -> None:
 
     n_shots = [1000, 2000, 3000, 4000]
     n_qubits = 2
-    
+
     # vector with only circuit
-    state_shots_tuples=[]
-    ans=[]
+    state_shots_tuples = []
+    ans = []
     for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
         vector_state = QuantumStateVector(
             n_qubits,
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples.append([vector_state, n_shots[ind_shot]])
-        ans.append(Counter({2 * i + j: n_shots[ind_shot]}))
+        state_shots_tuples+=[(vector_state, n_shots[ind_shot])]
+        ans+=[Counter({2 * i + j: n_shots[ind_shot]})]
     vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
     assert vector_sampling_cnts == ans
 
     # vector-valued state with circuit applied
-    state_shots_tuples=[]
-    ans=[]
+    state_shots_tuples = []
+    ans = []
     for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
         vector_valued_state = QuantumStateVector(
             n_qubits,
             vector=array([0, 1, 0, 0]),
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples.append([vector_valued_state, n_shots[ind_shot]])
-        ans.append(Counter({(2 * i + j) ^ (0b01): n_shots[ind_shot]}))
+        state_shots_tuples+=[(vector_valued_state, n_shots[ind_shot])]
+        ans+=[Counter({(2 * i + j) ^ (0b01): n_shots[ind_shot]})]
     vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
     assert vector_sampling_cnts == ans
 
     # circuit state
-    state_shots_tuples=[]
-    ans=[]
+    state_shots_tuples = []
+    ans = []
     for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
         circuit_state = GeneralCircuitQuantumState(
             n_qubits,
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples.append([circuit_state, n_shots[ind_shot]])
-        ans.append(Counter({2 * i + j: n_shots[ind_shot]}))
+        state_shots_tuples+=[(circuit_state, n_shots[ind_shot])]
+        ans+=[Counter({2 * i + j: n_shots[ind_shot]})]
     vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
     assert vector_sampling_cnts == ans
 

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -25,6 +25,7 @@ from quri_parts.qulacs.circuit import compile_circuit
 from quri_parts.qulacs.simulator import (
     create_qulacs_ideal_vector_state_sampler,
     create_qulacs_vector_state_sampler,
+    create_concurrent_vector_state_sampler,
     evaluate_state_to_vector,
     get_marginal_probability,
     run_circuit,
@@ -229,6 +230,53 @@ def test_create_qulacs_vector_state_sampler() -> None:
         )
         circuit_sampling_cnt = state_vector_sampler(circuit_state, n_shots)
         assert circuit_sampling_cnt == Counter({2 * i + j: n_shots})
+
+
+def test_create_concurrent_vector_state_sampler() -> None:
+    state_vector_concurrent_sampler = create_concurrent_vector_state_sampler()
+
+    n_shots = [1000, 2000, 3000, 4000]
+    n_qubits = 2
+    
+    # vector with only circuit
+    state_shots_tuples=[]
+    ans=[]
+    for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
+        vector_state = QuantumStateVector(
+            n_qubits,
+            circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
+        )
+        state_shots_tuples.append([vector_state, n_shots[ind_shot]])
+        ans.append(Counter({2 * i + j: n_shots[ind_shot]}))
+    vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
+    assert vector_sampling_cnts == ans
+
+    # vector-valued state with circuit applied
+    state_shots_tuples=[]
+    ans=[]
+    for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
+        vector_valued_state = QuantumStateVector(
+            n_qubits,
+            vector=array([0, 1, 0, 0]),
+            circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
+        )
+        state_shots_tuples.append([vector_valued_state, n_shots[ind_shot]])
+        ans.append(Counter({(2 * i + j) ^ (0b01): n_shots[ind_shot]}))
+    vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
+    assert vector_sampling_cnts == ans
+
+    # circuit state
+    state_shots_tuples=[]
+    ans=[]
+    for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
+        circuit_state = GeneralCircuitQuantumState(
+            n_qubits,
+            circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
+        )
+        state_shots_tuples.append([circuit_state, n_shots[ind_shot]])
+        ans.append(Counter({2 * i + j: n_shots[ind_shot]}))
+    vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
+    assert vector_sampling_cnts == ans
 
 
 def test_create_qulacs_ideal_vector_state_sampler() -> None:

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -252,7 +252,7 @@ def test_create_concurrent_vector_state_sampler() -> None:
     assert vector_sampling_cnts == ans
 
     # vector-valued state with circuit applied
-    state_shots_tuples = []
+    vector_state_shots_tuples = []
     ans = []
     for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
         vector_valued_state = QuantumStateVector(
@@ -260,22 +260,22 @@ def test_create_concurrent_vector_state_sampler() -> None:
             vector=array([0, 1, 0, 0]),
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples += [(vector_valued_state, n_shots[ind_shot])]
+        vector_state_shots_tuples += [(vector_valued_state, n_shots[ind_shot])]
         ans += [Counter({(2 * i + j) ^ (0b01): n_shots[ind_shot]})]
-    vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
+    vector_sampling_cnts = state_vector_concurrent_sampler(vector_state_shots_tuples)
     assert vector_sampling_cnts == ans
 
     # circuit state
-    state_shots_tuples = []
+    circuit_state_shots_tuples = []
     ans = []
     for ind_shot, (i, j) in enumerate(itertools.product(range(2), repeat=2)):
         circuit_state = GeneralCircuitQuantumState(
             n_qubits,
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples += [(circuit_state, n_shots[ind_shot])]
+        circuit_state_shots_tuples += [(circuit_state, n_shots[ind_shot])]
         ans += [Counter({2 * i + j: n_shots[ind_shot]})]
-    vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
+    vector_sampling_cnts = state_vector_concurrent_sampler(circuit_state_shots_tuples)
     assert vector_sampling_cnts == ans
 
 

--- a/packages/qulacs/tests/qulacs/simulator/test_simulator.py
+++ b/packages/qulacs/tests/qulacs/simulator/test_simulator.py
@@ -246,8 +246,8 @@ def test_create_concurrent_vector_state_sampler() -> None:
             n_qubits,
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples+=[(vector_state, n_shots[ind_shot])]
-        ans+=[Counter({2 * i + j: n_shots[ind_shot]})]
+        state_shots_tuples += [(vector_state, n_shots[ind_shot])]
+        ans += [Counter({2 * i + j: n_shots[ind_shot]})]
     vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
     assert vector_sampling_cnts == ans
 
@@ -260,8 +260,8 @@ def test_create_concurrent_vector_state_sampler() -> None:
             vector=array([0, 1, 0, 0]),
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples+=[(vector_valued_state, n_shots[ind_shot])]
-        ans+=[Counter({(2 * i + j) ^ (0b01): n_shots[ind_shot]})]
+        state_shots_tuples += [(vector_valued_state, n_shots[ind_shot])]
+        ans += [Counter({(2 * i + j) ^ (0b01): n_shots[ind_shot]})]
     vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
     assert vector_sampling_cnts == ans
 
@@ -273,8 +273,8 @@ def test_create_concurrent_vector_state_sampler() -> None:
             n_qubits,
             circuit=QuantumCircuit(n_qubits, gates=[X(1)] * i + [X(0)] * j),
         )
-        state_shots_tuples+=[(circuit_state, n_shots[ind_shot])]
-        ans+=[Counter({2 * i + j: n_shots[ind_shot]})]
+        state_shots_tuples += [(circuit_state, n_shots[ind_shot])]
+        ans += [Counter({2 * i + j: n_shots[ind_shot]})]
     vector_sampling_cnts = state_vector_concurrent_sampler(state_shots_tuples)
     assert vector_sampling_cnts == ans
 


### PR DESCRIPTION
Provide concurrent state sampler to users via the new `create_concurrent_vector_state_sampler` function. The created function takes a list of (state, shots) tuples, `state_shots_tuples`, as input parameters and samples each state with the corresponding number of shots.

Example code:
```
state_vector_concurrent_sampler = create_concurrent_vector_state_sampler()

state_shots_tuple = [(state_1, n_shots_1), (state_2, n_shots_2), (state_3, n_shots_3)]

# concurrent sampler
state_vector_concurrent_sampler(state_shots_tuples)
```