### PR TITLE
Bug fix: Qiskit backend max shots

### DIFF
--- a/packages/qiskit/quri_parts/qiskit/backend/utils.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/utils.py
@@ -75,13 +75,16 @@ def get_backend_min_max_shot(backend: Backend) -> tuple[int, Optional[int]]:
         raise BackendError("Backend not supported.")
 
     if hasattr(backend, "max_shots"):
-        return 1, backend.max_shots
-    if hasattr(backend, "configuration"):
+        max_shots = backend.max_shots
+    elif hasattr(backend, "configuration"):
         max_shots = getattr(
             backend.configuration(), "max_shots", _set_max_shot_to_default()
         )
-        if max_shots > 0:
-            return 1, max_shots
+    else:
+        max_shots = _set_max_shot_to_default()
+
+    if max_shots > 0:
+        return 1, max_shots
     return 1, _set_max_shot_to_default()
 
 
@@ -114,16 +117,14 @@ def get_job_mapper_and_circuit_transpiler(
         circuit_transpiler = SequentialTranspiler(
             [circuit_transpiler, mapper.circuit_transpiler]
         )
-        composite_job_qubit_mapper: Callable[
-            [SamplingJob], SamplingJob
-        ] = lambda job: QubitMappedSamplingJob(
-            job, mapper
+        composite_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
+            lambda job: QubitMappedSamplingJob(job, mapper)
         )  # noqa: E731
         return composite_job_qubit_mapper, circuit_transpiler
     else:
-        simple_job_qubit_mapper: Callable[
-            [SamplingJob], SamplingJob
-        ] = lambda job: job  # noqa: E731
+        simple_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
+            lambda job: job
+        )  # noqa: E731
         return simple_job_qubit_mapper, circuit_transpiler
 
 

--- a/packages/qiskit/quri_parts/qiskit/backend/utils.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/utils.py
@@ -74,25 +74,15 @@ def get_backend_min_max_shot(backend: Backend) -> tuple[int, Optional[int]]:
     if not isinstance(backend, (BackendV1, BackendV2)):
         raise BackendError("Backend not supported.")
 
-    # BackendV1
-    if isinstance(backend, BackendV1):
+    if hasattr(backend, "max_shots"):
+        return 1, backend.max_shots
+    if hasattr(backend, "configuration"):
         max_shots = getattr(
             backend.configuration(), "max_shots", _set_max_shot_to_default()
         )
         if max_shots > 0:
             return 1, max_shots
-        else:
-            return 1, _set_max_shot_to_default()
-
-    # BackendV2
-    if hasattr(backend, "max_shots"):
-        return 1, backend.max_shots
-    elif hasattr(backend, "configuration"):
-        return 1, getattr(
-            backend.configuration(), "max_shots", _set_max_shot_to_default()
-        )
-    else:
-        return 1, _set_max_shot_to_default()
+    return 1, _set_max_shot_to_default()
 
 
 def get_job_mapper_and_circuit_transpiler(
@@ -124,16 +114,14 @@ def get_job_mapper_and_circuit_transpiler(
         circuit_transpiler = SequentialTranspiler(
             [circuit_transpiler, mapper.circuit_transpiler]
         )
-        composite_job_qubit_mapper: Callable[
-            [SamplingJob], SamplingJob
-        ] = lambda job: QubitMappedSamplingJob(
-            job, mapper
+        composite_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
+            lambda job: QubitMappedSamplingJob(job, mapper)
         )  # noqa: E731
         return composite_job_qubit_mapper, circuit_transpiler
     else:
-        simple_job_qubit_mapper: Callable[
-            [SamplingJob], SamplingJob
-        ] = lambda job: job  # noqa: E731
+        simple_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
+            lambda job: job
+        )  # noqa: E731
         return simple_job_qubit_mapper, circuit_transpiler
 
 

--- a/packages/qiskit/quri_parts/qiskit/backend/utils.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/utils.py
@@ -117,14 +117,16 @@ def get_job_mapper_and_circuit_transpiler(
         circuit_transpiler = SequentialTranspiler(
             [circuit_transpiler, mapper.circuit_transpiler]
         )
-        composite_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
-            lambda job: QubitMappedSamplingJob(job, mapper)
+        composite_job_qubit_mapper: Callable[
+            [SamplingJob], SamplingJob
+        ] = lambda job: QubitMappedSamplingJob(
+            job, mapper
         )  # noqa: E731
         return composite_job_qubit_mapper, circuit_transpiler
     else:
-        simple_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
-            lambda job: job
-        )  # noqa: E731
+        simple_job_qubit_mapper: Callable[
+            [SamplingJob], SamplingJob
+        ] = lambda job: job  # noqa: E731
         return simple_job_qubit_mapper, circuit_transpiler
 
 

--- a/packages/qiskit/quri_parts/qiskit/backend/utils.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/utils.py
@@ -74,13 +74,17 @@ def get_backend_min_max_shot(backend: Backend) -> tuple[int, Optional[int]]:
     if not isinstance(backend, (BackendV1, BackendV2)):
         raise BackendError("Backend not supported.")
 
+    # BackendV1
     if isinstance(backend, BackendV1):
         max_shots = getattr(
             backend.configuration(), "max_shots", _set_max_shot_to_default()
         )
         if max_shots > 0:
             return 1, max_shots
+        else:
+            return 1, _set_max_shot_to_default()
 
+    # BackendV2
     if hasattr(backend, "max_shots"):
         return 1, backend.max_shots
     elif hasattr(backend, "configuration"):

--- a/packages/qiskit/quri_parts/qiskit/backend/utils.py
+++ b/packages/qiskit/quri_parts/qiskit/backend/utils.py
@@ -114,14 +114,16 @@ def get_job_mapper_and_circuit_transpiler(
         circuit_transpiler = SequentialTranspiler(
             [circuit_transpiler, mapper.circuit_transpiler]
         )
-        composite_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
-            lambda job: QubitMappedSamplingJob(job, mapper)
+        composite_job_qubit_mapper: Callable[
+            [SamplingJob], SamplingJob
+        ] = lambda job: QubitMappedSamplingJob(
+            job, mapper
         )  # noqa: E731
         return composite_job_qubit_mapper, circuit_transpiler
     else:
-        simple_job_qubit_mapper: Callable[[SamplingJob], SamplingJob] = (
-            lambda job: job
-        )  # noqa: E731
+        simple_job_qubit_mapper: Callable[
+            [SamplingJob], SamplingJob
+        ] = lambda job: job  # noqa: E731
         return simple_job_qubit_mapper, circuit_transpiler
 
 

--- a/packages/qiskit/tests/qiskit/backend/test_utils.py
+++ b/packages/qiskit/tests/qiskit/backend/test_utils.py
@@ -160,6 +160,21 @@ def test_get_backend_min_max_shot() -> None:
         assert min_shots == 1
         assert max_shots == DEFAULT_MAX_SHOT
 
+    backend = Mock(spec=BackendV1)
+    conf = Mock(spec=QasmBackendConfiguration)
+    conf.max_shots = 0
+    backend.configuration.return_value = conf
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "No max_shots setting is found. "
+            "The max shot is set to default value 1000000"
+        ),
+    ):
+        min_shots, max_shots = get_backend_min_max_shot(backend)
+        assert min_shots == 1
+        assert max_shots == DEFAULT_MAX_SHOT
+
     backend = Mock(spec=BackendV2)
     backend.max_shots = 10
     min_shots, max_shots = get_backend_min_max_shot(backend)
@@ -178,6 +193,19 @@ def test_get_backend_min_max_shot() -> None:
         assert min_shots == 1
         assert max_shots == DEFAULT_MAX_SHOT
 
+    backend = Mock(spec=BackendV2)
+    backend.max_shots = 0
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "No max_shots setting is found. "
+            "The max shot is set to default value 1000000"
+        ),
+    ):
+        min_shots, max_shots = get_backend_min_max_shot(backend)
+        assert min_shots == 1
+        assert max_shots == DEFAULT_MAX_SHOT
+
     backend = Mock(spec=IBMBackend)
     conf = Mock(spec=QasmBackendConfiguration)
     conf.max_shots = int(1e3)
@@ -185,3 +213,18 @@ def test_get_backend_min_max_shot() -> None:
     min_shots, max_shots = get_backend_min_max_shot(backend)
     assert min_shots == 1
     assert max_shots == 1000
+
+    backend = Mock(spec=IBMBackend)
+    conf = Mock(spec=QasmBackendConfiguration)
+    conf.max_shots = 0
+    backend.configuration.return_value = conf
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "No max_shots setting is found. "
+            "The max shot is set to default value 1000000"
+        ),
+    ):
+        min_shots, max_shots = get_backend_min_max_shot(backend)
+    assert min_shots == 1
+    assert max_shots == DEFAULT_MAX_SHOT

--- a/packages/qiskit/tests/qiskit/backend/test_utils.py
+++ b/packages/qiskit/tests/qiskit/backend/test_utils.py
@@ -11,12 +11,12 @@
 from unittest.mock import Mock
 
 import pytest
-from qiskit_ibm_runtime import IBMBackend
-from quri_parts.backend import BackendError
-from quri_parts.circuit import NonParametricQuantumCircuit, QuantumCircuit
-
 from qiskit.providers.backend import Backend, BackendV1, BackendV2
 from qiskit.providers.models import QasmBackendConfiguration
+from qiskit_ibm_runtime import IBMBackend
+
+from quri_parts.backend import BackendError
+from quri_parts.circuit import NonParametricQuantumCircuit, QuantumCircuit
 from quri_parts.qiskit.backend import (
     QiskitSavedDataSamplingJob,
     QiskitSavedDataSamplingResult,

--- a/packages/qiskit/tests/qiskit/backend/test_utils.py
+++ b/packages/qiskit/tests/qiskit/backend/test_utils.py
@@ -8,14 +8,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import Mock
+
+import pytest
+from qiskit_ibm_runtime import IBMBackend
+from quri_parts.backend import BackendError
 from quri_parts.circuit import NonParametricQuantumCircuit, QuantumCircuit
+
+from qiskit.providers.backend import Backend, BackendV1, BackendV2
+from qiskit.providers.models import QasmBackendConfiguration
 from quri_parts.qiskit.backend import (
     QiskitSavedDataSamplingJob,
     QiskitSavedDataSamplingResult,
     convert_qiskit_sampling_count_to_qp_sampling_count,
     distribute_backend_shots,
+    get_backend_min_max_shot,
     get_job_mapper_and_circuit_transpiler,
 )
+from quri_parts.qiskit.backend.utils import DEFAULT_MAX_SHOT
 
 
 class TestDistributeBackendShots:
@@ -121,3 +131,57 @@ def test_convert_qiskit_sampling_count_to_qp_sampling_count() -> None:
         {"00": 1, "01": 2, "10": 3, "11": 4}
     )
     assert converted_sampling_count == {0: 1, 1: 2, 2: 3, 3: 4}
+
+
+def test_get_backend_min_max_shot() -> None:
+    backend = Mock(spec=Backend)
+    with pytest.raises(BackendError, match="Backend not supported"):
+        get_backend_min_max_shot(backend)
+
+    backend = Mock(spec=BackendV1)
+    conf = Mock(spec=QasmBackendConfiguration)
+    conf.max_shots = int(1e3)
+    backend.configuration.return_value = conf
+    min_shots, max_shots = get_backend_min_max_shot(backend)
+    assert min_shots == 1
+    assert max_shots == int(1e3)
+
+    backend = Mock(spec=BackendV1)
+    conf = Mock(spec=QasmBackendConfiguration)
+    backend.configuration.return_value = conf
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "No max_shots setting is found. "
+            "The max shot is set to default value 1000000"
+        ),
+    ):
+        min_shots, max_shots = get_backend_min_max_shot(backend)
+        assert min_shots == 1
+        assert max_shots == DEFAULT_MAX_SHOT
+
+    backend = Mock(spec=BackendV2)
+    backend.max_shots = 10
+    min_shots, max_shots = get_backend_min_max_shot(backend)
+    assert min_shots == 1
+    assert max_shots == 10
+
+    backend = Mock(spec=BackendV2)
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "No max_shots setting is found. "
+            "The max shot is set to default value 1000000"
+        ),
+    ):
+        min_shots, max_shots = get_backend_min_max_shot(backend)
+        assert min_shots == 1
+        assert max_shots == DEFAULT_MAX_SHOT
+
+    backend = Mock(spec=IBMBackend)
+    conf = Mock(spec=QasmBackendConfiguration)
+    conf.max_shots = int(1e3)
+    backend.configuration.return_value = conf
+    min_shots, max_shots = get_backend_min_max_shot(backend)
+    assert min_shots == 1
+    assert max_shots == 1000


### PR DESCRIPTION
This PR fixes the issue of `max_shots` being 0 when Qiskit Aer is used as a `SamplingBackend`.