### PR TITLE
Bug of draw_circuit function

### DIFF
--- a/packages/circuit/quri_parts/circuit/utils/circuit_drawer.py
+++ b/packages/circuit/quri_parts/circuit/utils/circuit_drawer.py
@@ -389,6 +389,8 @@ def _connect_wire(circuit_picture: npt.NDArray[np.string_]) -> npt.NDArray[np.st
     for row in range(2, circuit_picture.shape[0], 4):
         p = 0
         while True:
+            if p + 1 == horizontal_size:
+                break
             char_now = circuit_picture[row][p]
             if char_now == "●":
                 circuit_picture[row][p + 1] = "-"
@@ -404,8 +406,6 @@ def _connect_wire(circuit_picture: npt.NDArray[np.string_]) -> npt.NDArray[np.st
                         circuit_picture[row][p + 2] = "-"
                         p += 1
             p += 1
-            if p + 1 == horizontal_size:
-                break
     return circuit_picture
 
 

--- a/packages/circuit/tests/circuit/utils/test_circuit_drawer.py
+++ b/packages/circuit/tests/circuit/utils/test_circuit_drawer.py
@@ -8,10 +8,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 import pytest
 
-from quri_parts.circuit import CNOT, RZ, SWAP, PauliRotation, UnitaryMatrix, X
-from quri_parts.circuit.utils.circuit_drawer import _generate_gate_aa
+from quri_parts.circuit import (
+    CNOT,
+    RZ,
+    SWAP,
+    PauliRotation,
+    QuantumCircuit,
+    UnitaryMatrix,
+    X,
+)
+from quri_parts.circuit.utils.circuit_drawer import _generate_gate_aa, draw_circuit
+
+
+def test_draw_empty_circuit(capsys: pytest.CaptureFixture[Any]) -> None:
+    draw_circuit(QuantumCircuit(1))
+    expected = " \n \n-\n \n"
+    assert capsys.readouterr().out == expected
 
 
 def test_generate_gate_aa() -> None:

--- a/packages/circuit/tests/circuit/utils/test_circuit_drawer.py
+++ b/packages/circuit/tests/circuit/utils/test_circuit_drawer.py
@@ -29,6 +29,10 @@ def test_draw_empty_circuit(capsys: pytest.CaptureFixture[Any]) -> None:
     expected = " \n \n-\n \n"
     assert capsys.readouterr().out == expected
 
+    draw_circuit(QuantumCircuit(2))
+    expected = " \n \n-\n \n \n \n-\n \n"
+    assert capsys.readouterr().out == expected
+
 
 def test_generate_gate_aa() -> None:
     expected = ["  ___  ", " | X | ", "-|0  |-", " |___| "]


### PR DESCRIPTION
I fixed a bug,

>  IndexError: index 1 is out of bounds for axis 0 with size 1

, when  we use `draw_circuit` method while there is no gate on the circuit. 
In a result, when there is no gate on the circuit, 'draw_circuit' shows lines(`-`)  representing the number of qubits.