### PR TITLE
Fix scipy import error

### DIFF
--- a/packages/algo/quri_parts/algo/optimizer/lbfgs.py
+++ b/packages/algo/quri_parts/algo/optimizer/lbfgs.py
@@ -17,7 +17,7 @@ import numpy as np
 if TYPE_CHECKING:
     import numpy.typing as npt  # noqa: F401
 
-from scipy.optimize.linesearch import (
+from scipy.optimize._linesearch import (
     LineSearchWarning,
     line_search_wolfe1,
     line_search_wolfe2,


### PR DESCRIPTION
Installing `quri-parts-algo` with Python 3.10 or later comes with SciPy 1.14. However, SciPy 1.14 has removed `LineSearchWarning`, `line_search_wolfe1`, and `line_search_wolfe2` from public module. This PR fixes the import error by modifying the import path.