### PR TITLE
Gate set conversion transpiler for STAR architecture

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -10,6 +10,8 @@
 
 from typing import Callable
 
+from quri_parts.circuit import gate_names
+
 from .clifford_approximation import CliffordApproximationTranspiler
 from .fuse import (
     CNOTHCNOTFusingTranspiler,
@@ -93,82 +95,18 @@ from .unitary_matrix_decomposer import (
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only X, SqrtX, CNOT, and RZ.
 #: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
-RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
-    [
-        SingleQubitUnitaryMatrix2RYRZTranspiler(),
-        TwoQubitUnitaryMatrixKAKTranspiler(),
-        ParallelDecomposer(
-            [
-                CZ2CNOTHTranspiler(),
-                PauliDecomposeTranspiler(),
-                PauliRotationDecomposeTranspiler(),
-                TOFFOLI2HTTdagCNOTTranspiler(),
-            ]
-        ),
-        ParallelDecomposer(
-            [
-                Identity2RZTranspiler(),
-                Y2RZXTranspiler(),
-                Z2RZTranspiler(),
-                H2RZSqrtXTranspiler(),
-                SqrtXdag2RZSqrtXTranspiler(),
-                SqrtY2RZSqrtXTranspiler(),
-                SqrtYdag2RZSqrtXTranspiler(),
-                S2RZTranspiler(),
-                Sdag2RZTranspiler(),
-                T2RZTranspiler(),
-                Tdag2RZTranspiler(),
-                RX2RZSqrtXTranspiler(),
-                RY2RZSqrtXTranspiler(),
-                U1ToRZTranspiler(),
-                U2ToRZSqrtXTranspiler(),
-                U3ToRZSqrtXTranspiler(),
-                SWAP2CNOTTranspiler(),
-            ]
-        ),
-        FuseRotationTranspiler(),
-    ]
+RZSetTranspiler: Callable[[], CircuitTranspiler] = lambda: GateSetConversionTranspiler(
+    [gate_names.X, gate_names.SqrtX, gate_names.RZ, gate_names.CNOT]
 )
 
 
 #: CircuitTranspiler to transpile a QuntumCircuit into another
 #: QuantumCircuit containing only RX, RY, RZ, and CNOT.
 #: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
-RotationSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
-    [
-        SingleQubitUnitaryMatrix2RYRZTranspiler(),
-        TwoQubitUnitaryMatrixKAKTranspiler(),
-        ParallelDecomposer(
-            [
-                PauliDecomposeTranspiler(),
-                PauliRotationDecomposeTranspiler(),
-                TOFFOLI2HTTdagCNOTTranspiler(),
-            ]
-        ),
-        ParallelDecomposer(
-            [
-                Identity2RZTranspiler(),
-                H2RXRYTranspiler(),
-                X2RXTranspiler(),
-                Y2RYTranspiler(),
-                Z2RZTranspiler(),
-                SqrtX2RXTranspiler(),
-                SqrtXdag2RXTranspiler(),
-                SqrtY2RYTranspiler(),
-                SqrtYdag2RYTranspiler(),
-                S2RZTranspiler(),
-                Sdag2RZTranspiler(),
-                T2RZTranspiler(),
-                Tdag2RZTranspiler(),
-                U1ToRZTranspiler(),
-                U2ToRXRZTranspiler(),
-                U3ToRXRZTranspiler(),
-                CZ2RXRYCNOTTranspiler(),
-                SWAP2CNOTTranspiler(),
-            ]
-        ),
-        FuseRotationTranspiler(),
-    ]
+RotationSetTranspiler: Callable[
+    [], CircuitTranspiler
+] = lambda: GateSetConversionTranspiler(
+    [gate_names.RX, gate_names.RY, gate_names.RZ, gate_names.CNOT]
 )
 
 
@@ -216,45 +154,53 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
         )
 
 
+#: CircuitTranspiler to transpile a QuntumCircuit into another
+#: QuantumCircuit containing only basic gates for STAR architecture (H, RZ, and CNOT).
+#: (UnitaryMatrix gate for 3 or more qubits are not decomposed.)
+STARSetTranspiler: Callable[
+    [], CircuitTranspiler
+] = lambda: GateSetConversionTranspiler([gate_names.H, gate_names.RZ, gate_names.CNOT])
+
+
 __all__ = [
     "CliffordConversionTranspiler",
+    "CliffordRZSetTranspiler",
+    "CliffordApproximationTranspiler",
+    "CircuitTranspiler",
+    "CircuitTranspilerProtocol",
+    "CNOT2CZHTranspiler",
+    "CZ2CNOTHTranspiler",
+    "CZ2RXRYCNOTTranspiler",
+    "CNOTHCNOTFusingTranspiler",
+    "FuseRotationTranspiler",
+    "GateDecomposer",
+    "GateKindDecomposer",
     "GateSetConversionTranspiler",
+    "H2RXRYTranspiler",
+    "H2RZSqrtXTranspiler",
+    "IdentityEliminationTranspiler",
+    "IdentityInsertionTranspiler",
+    "Identity2RZTranspiler",
+    "NormalizeRotationTranspiler",
+    "ParallelDecomposer",
+    "PauliDecomposeTranspiler",
+    "PauliRotationDecomposeTranspiler",
+    "QubitRemappingTranspiler",
     "RotationConversionTranspiler",
     "RX2RYRZTranspiler",
     "RX2RZHTranspiler",
     "RY2RXRZTranspiler",
     "RY2RZHTranspiler",
     "RZ2RXRYTranspiler",
-    "CircuitTranspiler",
-    "CircuitTranspilerProtocol",
-    "GateDecomposer",
-    "GateKindDecomposer",
-    "ParallelDecomposer",
-    "SequentialTranspiler",
     "RZSetTranspiler",
     "RotationSetTranspiler",
-    "CliffordRZSetTranspiler",
-    "CliffordApproximationTranspiler",
-    "IdentityEliminationTranspiler",
-    "IdentityInsertionTranspiler",
-    "Identity2RZTranspiler",
-    "PauliDecomposeTranspiler",
-    "PauliRotationDecomposeTranspiler",
-    "CNOT2CZHTranspiler",
-    "CZ2CNOTHTranspiler",
-    "CZ2RXRYCNOTTranspiler",
-    "CNOTHCNOTFusingTranspiler",
-    "FuseRotationTranspiler",
-    "NormalizeRotationTranspiler",
-    "H2RXRYTranspiler",
-    "H2RZSqrtXTranspiler",
-    "QubitRemappingTranspiler",
     "Rotation2NamedTranspiler",
     "RX2RZSqrtXTranspiler",
     "RY2RZSqrtXTranspiler",
     "RX2NamedTranspiler",
     "RY2NamedTranspiler",
     "RZ2NamedTranspiler",
+    "SequentialTranspiler",
     "S2RZTranspiler",
     "Sdag2RZTranspiler",
     "SingleQubitUnitaryMatrix2RYRZTranspiler",
@@ -267,6 +213,7 @@ __all__ = [
     "SqrtYdag2RYTranspiler",
     "SqrtYdag2RZSqrtXTranspiler",
     "SWAP2CNOTTranspiler",
+    "STARSetTranspiler",
     "T2RZTranspiler",
     "Tdag2RZTranspiler",
     "TOFFOLI2HTTdagCNOTTranspiler",

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -292,7 +292,7 @@ class ZeroRotationEliminationTranspiler(GateKindDecomposer):
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
         theta = gate.params[0] % (2.0 * np.pi)
-        if self._is_close(theta, 0.0):
+        if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return []
         else:
             return [gate]

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -271,3 +271,22 @@ class Rotation2NamedTranspiler(SequentialTranspiler):
                 RZ2NamedTranspiler(epsilon),
             ]
         )
+
+
+class ZeroRotationEliminationTranspiler(GateKindDecomposer):
+    def __init__(self, epsilon: float = 1.0e-9):
+        self._epsilon = epsilon
+
+    @property
+    def target_gate_names(self) -> Sequence[str]:
+        return [gate_names.RX, gate_names.RY, gate_names.RZ]
+
+    def _is_close(self, a: float, b: float) -> bool:
+        return abs(a - b) < self._epsilon
+
+    def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
+        theta = gate.params[0] % (2.0 * np.pi)
+        if self._is_close(theta, 0.0):
+            return []
+        else:
+            return [gate]

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -263,6 +263,9 @@ class RZ2NamedTranspiler(GateKindDecomposer):
 
 
 class Rotation2NamedTranspiler(SequentialTranspiler):
+    """Convert rotation gates (RX, RY, and RZ) to Identity, Z, S, Sdag, T, or
+    Tdag gates if it is equivalent ot a sequence of these gates."""
+
     def __init__(self, epsilon: float = 1.0e-9):
         super().__init__(
             [
@@ -274,6 +277,9 @@ class Rotation2NamedTranspiler(SequentialTranspiler):
 
 
 class ZeroRotationEliminationTranspiler(GateKindDecomposer):
+    """Remove rotation gates (RX, RY, and RZ) with rotation angles smaller than
+    epsilon."""
+
     def __init__(self, epsilon: float = 1.0e-9):
         self._epsilon = epsilon
 

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -264,7 +264,7 @@ class RZ2NamedTranspiler(GateKindDecomposer):
 
 class Rotation2NamedTranspiler(SequentialTranspiler):
     """Convert rotation gates (RX, RY, and RZ) to Identity, Z, S, Sdag, T, or
-    Tdag gates if it is equivalent ot a sequence of these gates."""
+    Tdag gates if it is equivalent to a sequence of these gates."""
 
     def __init__(self, epsilon: float = 1.0e-9):
         super().__init__(

--- a/packages/circuit/quri_parts/circuit/transpile/gateset.py
+++ b/packages/circuit/quri_parts/circuit/transpile/gateset.py
@@ -394,6 +394,7 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
     """
 
     def __init__(self, target_gateset: Iterable[GateNameType], epsilon: float = 1.0e-9):
+        self._epsilon = epsilon
         self._gateset = set(target_gateset)
         self._target_clifford = cast(
             set[CliffordGateNameType],
@@ -409,9 +410,10 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
         ts.extend(self._construct_two_qubit_gate_decomposer())
 
         if self._target_clifford:
+            ts.extend(self._construct_rotation_fuser())
             ts.extend(
                 [
-                    Rotation2NamedTranspiler(),  # Optimizer
+                    Rotation2NamedTranspiler(epsilon=self._epsilon),  # Optimizer
                     CliffordConversionTranspiler(tuple(self._target_clifford)),
                 ]
             )
@@ -420,20 +422,23 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
             ts.append(IdentityEliminationTranspiler())
 
         ts.extend(self._construct_clifford_to_rotation_decomposer())
-        ts.extend(
-            [
-                FuseRotationTranspiler(),  # Optimizer
-                RotationConversionTranspiler(
-                    target_rotation=tuple(self._target_rotation),
-                    favorable_clifford=tuple(self._target_clifford),
-                ),
-                FuseRotationTranspiler(),  # Optimizer
-                NormalizeRotationTranspiler(),
-                ZeroRotationEliminationTranspiler(),
-            ]
+        ts.extend(self._construct_rotation_fuser())
+        ts.append(
+            RotationConversionTranspiler(
+                target_rotation=tuple(self._target_rotation),
+                favorable_clifford=tuple(self._target_clifford),
+            )
         )
+        ts.extend(self._construct_rotation_fuser())
 
         return SequentialTranspiler(ts)
+
+    def _construct_rotation_fuser(self) -> list[CircuitTranspiler]:
+        return [
+            FuseRotationTranspiler(),  # Optimizer
+            NormalizeRotationTranspiler(),
+            ZeroRotationEliminationTranspiler(epsilon=self._epsilon),  # Optimizer
+        ]
 
     def _construct_complex_gate_decomposer(self) -> list[CircuitTranspiler]:
         return self._collect_decomposers_for_target_gateset(

--- a/packages/circuit/quri_parts/circuit/transpile/gateset.py
+++ b/packages/circuit/quri_parts/circuit/transpile/gateset.py
@@ -48,7 +48,12 @@ from quri_parts.circuit.gate_names import (
     Z,
 )
 
-from .fuse import FuseRotationTranspiler, Rotation2NamedTranspiler
+from .fuse import (
+    FuseRotationTranspiler,
+    NormalizeRotationTranspiler,
+    Rotation2NamedTranspiler,
+    ZeroRotationEliminationTranspiler,
+)
 from .gate_kind_decomposer import (
     CNOT2CZHTranspiler,
     CZ2CNOTHTranspiler,
@@ -388,7 +393,7 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
         target_gateset: A Sequence of allowed output gate names.
     """
 
-    def __init__(self, target_gateset: Iterable[GateNameType]):
+    def __init__(self, target_gateset: Iterable[GateNameType], epsilon: float = 1.0e-9):
         self._gateset = set(target_gateset)
         self._target_clifford = cast(
             set[CliffordGateNameType],
@@ -423,6 +428,8 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
                     favorable_clifford=tuple(self._target_clifford),
                 ),
                 FuseRotationTranspiler(),  # Optimizer
+                NormalizeRotationTranspiler(),
+                ZeroRotationEliminationTranspiler(),
             ]
         )
 

--- a/packages/circuit/tests/circuit/transpile/test_fuse.py
+++ b/packages/circuit/tests/circuit/transpile/test_fuse.py
@@ -18,6 +18,7 @@ from quri_parts.circuit.transpile import (
     RX2NamedTranspiler,
     RY2NamedTranspiler,
     RZ2NamedTranspiler,
+    ZeroRotationEliminationTranspiler,
 )
 
 
@@ -316,6 +317,36 @@ class TestCNOTHCNOTFuse:
                 gates.H(1),
                 gates.CNOT(1, 2),
                 gates.X(0),
+            ]
+        )
+
+        assert transpiled == expect
+
+
+class TestZeroRotationElimination:
+    def test_eliminate_rot(self) -> None:
+        circuit = QuantumCircuit(1)
+        circuit.extend(
+            [
+                gates.RX(0, 1.0e-11),
+                gates.RY(0, 1.0e-7),
+                gates.RZ(0, -1.0e-11),
+                gates.RX(0, -1.0e-7),
+                gates.RY(0, 2.0 * np.pi - 1.0e-11),
+                gates.RZ(0, 2.0 * np.pi - 1.0e-7),
+                gates.RX(0, 2.0 * np.pi + 1.0e-11),
+                gates.RY(0, 2.0 * np.pi + 1.0e-7),
+            ]
+        )
+        transpiled = ZeroRotationEliminationTranspiler(epsilon=1.0e-9)(circuit)
+
+        expect = QuantumCircuit(1)
+        expect.extend(
+            [
+                gates.RY(0, 1.0e-7),
+                gates.RX(0, -1.0e-7),
+                gates.RZ(0, 2.0 * np.pi - 1.0e-7),
+                gates.RY(0, 2.0 * np.pi + 1.0e-7),
             ]
         )
 

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -47,6 +47,7 @@ from quri_parts.circuit.transpile import (
     H2RXRYTranspiler,
     H2RZSqrtXTranspiler,
     Identity2RZTranspiler,
+    RotationSetTranspiler,
     RX2RZSqrtXTranspiler,
     RY2RZSqrtXTranspiler,
     RZSetTranspiler,
@@ -632,6 +633,19 @@ class TestRotationSetTranspile:
         )
 
         assert transpiled.gates == expect.gates
+
+    def test_rotationset_transpile(self) -> None:
+        theta = np.pi / 7.0
+
+        circuit = QuantumCircuit(3)
+        circuit.add_Pauli_gate([2, 0, 1], [2, 3, 1])
+        circuit.add_PauliRotation_gate([1, 0, 2], [1, 3, 2], theta)
+        transpiled = RotationSetTranspiler()(circuit)
+
+        target_set = {gate.name for gate in transpiled.gates}
+        expect_set = {gate_names.RX, gate_names.RY, gate_names.RZ, gate_names.CNOT}
+
+        assert target_set <= expect_set
 
 
 class TestCliffordRZSetTranspile:

--- a/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
+++ b/packages/circuit/tests/circuit/transpile/test_gate_kind_decomposer.py
@@ -38,6 +38,7 @@ from quri_parts.circuit import (
     X,
     Y,
     Z,
+    gate_names,
 )
 from quri_parts.circuit.transpile import (
     CliffordRZSetTranspiler,
@@ -59,6 +60,7 @@ from quri_parts.circuit.transpile import (
     SqrtY2RZSqrtXTranspiler,
     SqrtYdag2RYTranspiler,
     SqrtYdag2RZSqrtXTranspiler,
+    STARSetTranspiler,
     SWAP2CNOTTranspiler,
     T2RZTranspiler,
     Tdag2RZTranspiler,
@@ -673,3 +675,18 @@ class TestCliffordRZSetTranspile:
 
         for t, e in zip(transpiled.gates, expect.gates):
             assert _gates_close(t, e)
+
+
+class TestSTARSetTranspile:
+    def test_starset_transpile(self) -> None:
+        theta = np.pi / 7.0
+
+        circuit = QuantumCircuit(3)
+        circuit.add_Pauli_gate([2, 0, 1], [2, 3, 1])
+        circuit.add_PauliRotation_gate([1, 0, 2], [1, 3, 2], theta)
+        transpiled = STARSetTranspiler()(circuit)
+
+        target_set = {gate.name for gate in transpiled.gates}
+        expect_set = {gate_names.H, gate_names.RZ, gate_names.CNOT}
+
+        assert target_set <= expect_set


### PR DESCRIPTION
- Add a default gate set conversion transpiler for STAR architecture {H, RZ, CNOT}.
- Simplify `RotationSetTranspiler` by using `GateSetConversionTranspiler`.
- Slightly enhanced rotational gate optimization for `GateSetConversionTranspiler` (normalization of rotation angle, removal of gates with zero rotation angle).
