### PR TITLE
Fix python behavior to install quri-parts-rust package

### DIFF
--- a/packages/rust/pyproject.toml
+++ b/packages/rust/pyproject.toml
@@ -40,6 +40,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Typing :: Typed"
 ]
+packages = [
+    { include = "quri_parts" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.9.8"


### PR DESCRIPTION
Fix installation error, which occurs when installing it as a dependency of another poetry project.