### PR TITLE
Param sampler

### DIFF
--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -9,15 +9,19 @@
 # limitations under the License.
 
 from collections import Counter
+from dataclasses import dataclass, field
 from typing import (
+    Any,
     Callable,
     Collection,
+    Generic,
     Iterable,
     Mapping,
     NamedTuple,
     Sequence,
     TypeVar,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -25,15 +29,32 @@ import numpy.typing as npt
 from typing_extensions import TypeAlias
 
 from quri_parts.backend import SamplingBackend
-from quri_parts.circuit import ImmutableQuantumCircuit
+from quri_parts.circuit import (
+    ImmutableQuantumCircuit,
+    UnboundParametricQuantumCircuitProtocol,
+)
 from quri_parts.core.operator import CommutablePauliSet, Operator
-from quri_parts.core.state import CircuitQuantumState, QuantumStateVector
+from quri_parts.core.state import (
+    CircuitQuantumState,
+    ParametricCircuitQuantumState,
+    ParametricQuantumStateVector,
+    QuantumStateVector,
+)
 
 #: A type variable represents *any* non-parametric quantum state classes.
 #: This is different from :class:`quri_parts.core.state.QuantumStateT`;
 #: ``QuantumStateT`` represents *either one of* the classes, while ``_StateT`` also
 #: covers *a union of* multiple state classes.
 _StateT = TypeVar("_StateT", bound=Union[CircuitQuantumState, QuantumStateVector])
+
+#: A type variable represents *any* parametric quantum state classes.
+#: This is different from :class:`quri_parts.core.state.ParametricQuantumStateT`;
+#: ``ParametricQuantumStateT`` represents *either one of* the classes, while ``_ParametricStateT``
+#: also covers *a union of* multiple state classes.
+_ParametricStateT = TypeVar(
+    "_ParametricStateT",
+    bound=Union[ParametricCircuitQuantumState, ParametricQuantumStateVector],
+)
 
 #: MeasurementCounts represents count statistics of repeated measurements of a quantum
 #: circuit. Keys are observed bit patterns encoded in integers and values are counts
@@ -51,6 +72,22 @@ ConcurrentSampler: TypeAlias = Callable[
     [Iterable[tuple[ImmutableQuantumCircuit, int]]], Iterable[MeasurementCounts]
 ]
 
+
+#: ParametricSampler represents a sampler that samples from a parametric circuit with
+#: a fixed set of circuit parameters.
+ParametricSampler: TypeAlias = Callable[
+    [UnboundParametricQuantumCircuitProtocol, int, Sequence[float]], MeasurementCounts
+]
+
+
+#: ConcurrentParametricSampler represents a sampler that samples from a parametric
+#: circuit with a sequence of circuit parameter list.
+ConcurrentParametricSampler: TypeAlias = Callable[
+    [Iterable[tuple[UnboundParametricQuantumCircuitProtocol, int, Sequence[float]]]],
+    Iterable[MeasurementCounts],
+]
+
+
 #: StateSampler representes a function that samples a specific (non-parametric) state by
 #: specified times and returns the count statistics. In the case of an ideal
 #: StateSampler, the return value corresponds to probabilities multiplied by shot count.
@@ -61,6 +98,132 @@ StateSampler: TypeAlias = Callable[[_StateT, int], MeasurementCounts]
 ConcurrentStateSampler: TypeAlias = Callable[
     [Iterable[tuple[_StateT, int]]], Iterable[MeasurementCounts]
 ]
+
+
+#: ParametricStateSampler represents a state sampler that samples from a
+#: parametric state with a fixed set of circuit parameters.
+ParametricStateSampler: TypeAlias = Callable[
+    [_ParametricStateT, int, Sequence[float]], MeasurementCounts
+]
+
+
+#: ConcurrentParametricStateSampler represents a state sampler that samples from a
+#: parametric state with a sequence of circuit parameter list.
+ConcurrentParametricStateSampler: TypeAlias = Callable[
+    [Iterable[tuple[_ParametricStateT, int, Sequence[float]]]],
+    Iterable[MeasurementCounts],
+]
+
+
+@dataclass
+class GeneralSampler(Generic[_StateT, _ParametricStateT]):
+    sampler: Sampler
+    state_sampler: StateSampler[_StateT]
+    parametric_sampler: ParametricSampler = field(init=False)
+    parametric_state_sampler: ParametricStateSampler = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.parametric_sampler = create_parametric_sampler_from_sampler(self.sampler)
+        self.parametric_state_sampler = (
+            create_parametric_state_sampler_from_state_sampler(self.state_sampler)
+        )
+
+    def __call__(
+        self, *sampler_input: Any
+    ) -> Union[MeasurementCounts, Iterable[MeasurementCounts]]:
+        if isinstance(sampler_input[0], NonParametricQuantumCircuit):
+            assert isinstance(sampler_input[1], int), "Shot is not specified properly."
+            return self.sampler(*sampler_input)
+        if isinstance(sampler_input[0], UnboundParametricQuantumCircuitProtocol):
+            assert isinstance(sampler_input[1], int), "Shot is not specified properly."
+            assert isinstance(
+                sampler_input[2], Iterable
+            ), "Circuit parameter is not specified properly."
+            return self.parametric_sampler(*sampler_input)
+        if isinstance(sampler_input[0], (CircuitQuantumState, QuantumStateVector)):
+            assert isinstance(sampler_input[1], int), "Shot is not specified properly."
+            return self.state_sampler(*sampler_input)
+        if isinstance(
+            sampler_input[0],
+            (ParametricCircuitQuantumState, ParametricQuantumStateVector),
+        ):
+            assert isinstance(sampler_input[1], int), "Shot is not specified properly."
+            return self.parametric_state_sampler(*sampler_input)
+
+        if isinstance(sampler_input[0][0], Iterable):
+            return self(*sampler_input[0])
+
+        return [self(*comb) for comb in sampler_input]
+
+
+def create_parametric_sampler_from_sampler(sampler: Sampler) -> ParametricSampler:
+    """Create a :class:`ParametricSampler` from a :class:`Sampler`."""
+
+    def _parametric_sampler(
+        param_circuit: UnboundParametricQuantumCircuitProtocol,
+        measurement_cnt: int,
+        param: Sequence[float],
+    ) -> MeasurementCounts:
+        bound_circuit = param_circuit.bind_parameters(param)
+        return sampler(bound_circuit, measurement_cnt)
+
+    return _parametric_sampler
+
+
+def create_concurrent_parametric_sampler_from_concurrent_sampler(
+    concurrent_sampler: ConcurrentSampler,
+) -> ConcurrentParametricSampler:
+    """Create a :class:`ConcurrentParametricSampler` from a :class:`ConcurrentSampler`."""
+
+    def _concurrent_parametric_sampler(
+        circuit_shot_param_tuples: Iterable[
+            tuple[UnboundParametricQuantumCircuitProtocol, int, Sequence[float]]
+        ]
+    ) -> Iterable[MeasurementCounts]:
+        circuit_shot_tuples = [
+            (circuit.bind_parameters(param), shot)
+            for circuit, shot, param in circuit_shot_param_tuples
+        ]
+        return concurrent_sampler(circuit_shot_tuples)
+
+    return _concurrent_parametric_sampler
+
+
+def create_parametric_state_sampler_from_state_sampler(
+    state_sampler: StateSampler[_StateT],
+) -> ParametricStateSampler[_ParametricStateT]:
+    """Create a :class:`ParametricStateSampler` from a :class:`StateSampler`."""
+
+    def _parametric_state_sampler(
+        param_state: _ParametricStateT,
+        measurement_cnt: int,
+        param: Sequence[float],
+    ) -> MeasurementCounts:
+        bound_state = cast(_StateT, param_state.bind_parameters(param))
+        return state_sampler(bound_state, measurement_cnt)
+
+    return _parametric_state_sampler
+
+
+def create_concurrent_parametric_state_sampler_from_concurrent_state_sampler(
+    concurrent_state_sampler: ConcurrentStateSampler[_StateT],
+) -> ConcurrentParametricStateSampler[_ParametricStateT]:
+    """Create a :class:`ConcurrentParametricStateSampler` from a
+    :class:`ConcurrentStateSampler`.
+    """
+
+    def _concurrent_parametric_state_sampler(
+        state_shot_param_tuples: Iterable[
+            tuple[_ParametricStateT, int, Sequence[float]]
+        ]
+    ) -> Iterable[MeasurementCounts]:
+        state_shot_tuples = [
+            (cast(_StateT, state.bind_parameters(param)), shot)
+            for state, shot, param in state_shot_param_tuples
+        ]
+        return concurrent_state_sampler(state_shot_tuples)
+
+    return _concurrent_parametric_state_sampler
 
 
 def sample_from_state_vector(

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -24,11 +24,10 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import Unpack
 
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, Unpack
 
 from quri_parts.backend import SamplingBackend
 from quri_parts.circuit import (

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -133,7 +133,7 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
 
     @overload
     def __call__(
-        self, *sampler_input: Unpack[tuple[NonParametricQuantumCircuit, int]]
+        self, *sampler_input: Unpack[tuple[ImmutableQuantumCircuit, int]]
     ) -> MeasurementCounts:
         """A :class:`Sampler`"""
         ...
@@ -214,7 +214,7 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
     def __call__(
         self,
         *sampler_input: Union[
-            tuple[NonParametricQuantumCircuit, int],
+            tuple[ImmutableQuantumCircuit, int],
             tuple[UnboundParametricQuantumCircuitProtocol, int, Sequence[float]],
             tuple[_StateT, int],
             tuple[_ParametricStateT, int, Sequence[float]],
@@ -237,7 +237,7 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
             tuple[
                 Iterable[
                     Union[
-                        tuple[NonParametricQuantumCircuit, int],
+                        tuple[ImmutableQuantumCircuit, int],
                         tuple[
                             UnboundParametricQuantumCircuitProtocol,
                             int,
@@ -263,7 +263,7 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
     def __call__(
         self, *sampler_input: Any
     ) -> Union[MeasurementCounts, Iterable[MeasurementCounts]]:
-        if isinstance(sampler_input[0], NonParametricQuantumCircuit):
+        if isinstance(sampler_input[0], ImmutableQuantumCircuit):
             return self._sample(*sampler_input)
         if isinstance(sampler_input[0], UnboundParametricQuantumCircuitProtocol):
             if isinstance(sampler_input[1], Iterable):
@@ -332,7 +332,7 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
         ]
 
     def _sample(
-        self, circuit: NonParametricQuantumCircuit, shots: int
+        self, circuit: ImmutableQuantumCircuit, shots: int
     ) -> MeasurementCounts:
         self._check_shot_is_int(shots)
         return self.sampler(circuit, shots)

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -200,6 +200,19 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
     @overload
     def __call__(
         self,
+        *sampler_input: Unpack[
+            tuple[ParametricCircuitQuantumState, Iterable[tuple[int, Sequence[float]]]]
+        ],
+    ) -> Iterable[MeasurementCounts]:
+        """A :class:`ConcurrentParametricStateSampler`"""
+        # NOTE: the `tuple[ParametricCircuitQuantumState, int, Sequence[float]]`
+        # is added because mypy recognizes _ParametricStateT as:
+        # Union[ParametricQuantumStateVector, ParametricQuantumStateVector]
+        ...
+
+    @overload
+    def __call__(
+        self,
         *sampler_input: Union[
             tuple[NonParametricQuantumCircuit, int],
             tuple[UnboundParametricQuantumCircuitProtocol, int, Sequence[float]],

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -84,7 +84,7 @@ ParametricSampler: TypeAlias = Callable[
 #: ConcurrentParametricSampler represents a sampler that samples from a parametric
 #: circuit with a sequence of circuit parameter list.
 ConcurrentParametricSampler: TypeAlias = Callable[
-    [Iterable[tuple[UnboundParametricQuantumCircuitProtocol, int, Sequence[float]]]],
+    [UnboundParametricQuantumCircuitProtocol, Iterable[tuple[int, Sequence[float]]]],
     Iterable[MeasurementCounts],
 ]
 
@@ -111,7 +111,7 @@ ParametricStateSampler: TypeAlias = Callable[
 #: ConcurrentParametricStateSampler represents a state sampler that samples from a
 #: parametric state with a sequence of circuit parameter list.
 ConcurrentParametricStateSampler: TypeAlias = Callable[
-    [Iterable[tuple[_ParametricStateT, int, Sequence[float]]]],
+    [_ParametricStateT, Iterable[tuple[int, Sequence[float]]]],
     Iterable[MeasurementCounts],
 ]
 
@@ -310,13 +310,12 @@ def create_concurrent_parametric_sampler_from_concurrent_sampler(
     :class:`ConcurrentSampler`."""
 
     def _concurrent_parametric_sampler(
-        circuit_shot_param_tuples: Iterable[
-            tuple[UnboundParametricQuantumCircuitProtocol, int, Sequence[float]]
-        ]
+        param_circuit: UnboundParametricQuantumCircuitProtocol,
+        shot_param_tuples: Iterable[tuple[int, Sequence[float]]],
     ) -> Iterable[MeasurementCounts]:
         circuit_shot_tuples = [
-            (circuit.bind_parameters(param), shot)
-            for circuit, shot, param in circuit_shot_param_tuples
+            (param_circuit.bind_parameters(param), shot)
+            for shot, param in shot_param_tuples
         ]
         return concurrent_sampler(circuit_shot_tuples)
 
@@ -348,13 +347,12 @@ def create_concurrent_parametric_state_sampler_from_concurrent_state_sampler(
     """
 
     def _concurrent_parametric_state_sampler(
-        state_shot_param_tuples: Iterable[
-            tuple[_ParametricStateT, int, Sequence[float]]
-        ]
+        param_state: _ParametricStateT,
+        shot_param_tuples: Iterable[tuple[int, Sequence[float]]],
     ) -> Iterable[MeasurementCounts]:
         state_shot_tuples = [
-            (cast(_StateT, state.bind_parameters(param)), shot)
-            for state, shot, param in state_shot_param_tuples
+            (cast(_StateT, param_state.bind_parameters(param)), shot)
+            for shot, param in shot_param_tuples
         ]
         return concurrent_state_sampler(state_shot_tuples)
 

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -49,8 +49,8 @@ _StateT = TypeVar("_StateT", bound=Union[CircuitQuantumState, QuantumStateVector
 
 #: A type variable represents *any* parametric quantum state classes.
 #: This is different from :class:`quri_parts.core.state.ParametricQuantumStateT`;
-#: ``ParametricQuantumStateT`` represents *either one of* the classes, while ``_ParametricStateT``
-#: also covers *a union of* multiple state classes.
+#: ``ParametricQuantumStateT`` represents *either one of* the classes, while
+#: ``_ParametricStateT`` also covers *a union of* multiple state classes.
 _ParametricStateT = TypeVar(
     "_ParametricStateT",
     bound=Union[ParametricCircuitQuantumState, ParametricQuantumStateVector],
@@ -120,7 +120,9 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
     sampler: Sampler
     state_sampler: StateSampler[_StateT]
     parametric_sampler: ParametricSampler = field(init=False)
-    parametric_state_sampler: ParametricStateSampler = field(init=False)
+    parametric_state_sampler: ParametricStateSampler[_ParametricStateT] = field(
+        init=False
+    )
 
     def __post_init__(self) -> None:
         self.parametric_sampler = create_parametric_sampler_from_sampler(self.sampler)
@@ -153,7 +155,7 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
         if isinstance(sampler_input[0][0], Iterable):
             return self(*sampler_input[0])
 
-        return [self(*comb) for comb in sampler_input]
+        return [cast(MeasurementCounts, self(*comb)) for comb in sampler_input]
 
 
 def create_parametric_sampler_from_sampler(sampler: Sampler) -> ParametricSampler:
@@ -173,7 +175,8 @@ def create_parametric_sampler_from_sampler(sampler: Sampler) -> ParametricSample
 def create_concurrent_parametric_sampler_from_concurrent_sampler(
     concurrent_sampler: ConcurrentSampler,
 ) -> ConcurrentParametricSampler:
-    """Create a :class:`ConcurrentParametricSampler` from a :class:`ConcurrentSampler`."""
+    """Create a :class:`ConcurrentParametricSampler` from a
+    :class:`ConcurrentSampler`."""
 
     def _concurrent_parametric_sampler(
         circuit_shot_param_tuples: Iterable[
@@ -192,7 +195,8 @@ def create_concurrent_parametric_sampler_from_concurrent_sampler(
 def create_parametric_state_sampler_from_state_sampler(
     state_sampler: StateSampler[_StateT],
 ) -> ParametricStateSampler[_ParametricStateT]:
-    """Create a :class:`ParametricStateSampler` from a :class:`StateSampler`."""
+    """Create a :class:`ParametricStateSampler` from a
+    :class:`StateSampler`."""
 
     def _parametric_state_sampler(
         param_state: _ParametricStateT,

--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -82,7 +82,7 @@ ParametricSampler: TypeAlias = Callable[
 
 
 #: ConcurrentParametricSampler represents a sampler that samples from a parametric
-#: circuit with a sequence of circuit parameter list.
+#: circuit with a (shot, circuit parameter) pairs.
 ConcurrentParametricSampler: TypeAlias = Callable[
     [UnboundParametricQuantumCircuitProtocol, Iterable[tuple[int, Sequence[float]]]],
     Iterable[MeasurementCounts],
@@ -109,7 +109,7 @@ ParametricStateSampler: TypeAlias = Callable[
 
 
 #: ConcurrentParametricStateSampler represents a state sampler that samples from a
-#: parametric state with a sequence of circuit parameter list.
+#: parametric state with a sequence of (shot, circuit parameter) pairs.
 ConcurrentParametricStateSampler: TypeAlias = Callable[
     [_ParametricStateT, Iterable[tuple[int, Sequence[float]]]],
     Iterable[MeasurementCounts],
@@ -222,8 +222,9 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
         ],
     ) -> Iterable[MeasurementCounts]:
         """Mixing :class:`ConcurrentSampler`, :class:`ConcurrentStateSampler`,
-        :class:`ConcurrentParametricSampler`, :class:`ConcurrentParametricStateSampler`
-        """
+        `Iterable[tuple[UnboundParametricQuantumCircuitProtocol, int,
+        Sequence[float]]]`, `Iterable[tuple[_ParametricStateT, int,
+        Sequence[float]]]`"""
         # NOTE: the `tuple[ParametricCircuitQuantumState, int, Sequence[float]]`
         # is added because mypy recognizes _ParametricStateT as:
         # Union[ParametricQuantumStateVector, ParametricQuantumStateVector]
@@ -251,8 +252,9 @@ class GeneralSampler(Generic[_StateT, _ParametricStateT]):
         ],
     ) -> Iterable[MeasurementCounts]:
         """Mixing :class:`ConcurrentSampler`, :class:`ConcurrentStateSampler`,
-        :class:`ConcurrentParametricSampler`, :class:`ConcurrentParametricStateSampler`
-        """
+        `Iterable[tuple[UnboundParametricQuantumCircuitProtocol, int,
+        Sequence[float]]]`, `Iterable[tuple[_ParametricStateT, int,
+        Sequence[float]]]`"""
         # NOTE: the `tuple[ParametricCircuitQuantumState, int, Sequence[float]]`
         # is added because mypy recognizes _ParametricStateT as:
         # Union[ParametricQuantumStateVector, ParametricQuantumStateVector]

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -274,6 +274,14 @@ class TestGeneralSampler(TestCase):
 
     def test_concurrent_param_state_sampler_input(self) -> None:
         assert self.general_sampler(
+            self.param_state_1, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: 3000}, {0: 14000}]
+
+        assert self.general_sampler(
+            self.param_state_2, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: (-8 + 20) * 1000 * 2}, {0: (-14 + 38) * 2000 * 2}]
+
+        assert self.general_sampler(
             (self.param_state_1, 1000, [1, 2]),
             (self.param_state_1, 2000, [3, 4]),
             (self.param_state_2, 1000, [1, 2]),
@@ -346,13 +354,7 @@ class TestGeneralSampler(TestCase):
             )
 
         # Test param sample
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                "Shot expected to be integer, but got <class 'list'>. "
-                "Input value is [1.0, 2.0]."
-            ),
-        ):
+        with pytest.raises(TypeError):
             self.general_sampler(self.param_circuit_1, [1.0, 2.0], 100)  # type: ignore
 
         with pytest.raises(
@@ -391,13 +393,7 @@ class TestGeneralSampler(TestCase):
             )
 
         # Test param sample
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                "Shot expected to be integer, but got <class 'list'>. "
-                "Input value is [1.0, 2.0]."
-            ),
-        ):
+        with pytest.raises(TypeError):
             self.general_sampler(self.param_state_1, [1.0, 2.0], 100)  # type: ignore
 
         with pytest.raises(

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -376,7 +376,7 @@ class TestGeneralSampler(TestCase):
 
         with pytest.raises(
             TypeError,
-            match=re.escape("arguments 'params': Can't extract 'str' to 'Vec'"),
+            match=re.escape("argument 'params': Can't extract 'str' to 'Vec'"),
         ):
             self.general_sampler(self.param_circuit_1, 100, "ab")  # type: ignore
 
@@ -415,7 +415,7 @@ class TestGeneralSampler(TestCase):
 
         with pytest.raises(
             TypeError,
-            match=re.escape("arguments 'params': Can't extract 'str' to 'Vec'"),
+            match="argument 'params': Can't extract 'str' to 'Vec'",
         ):
             self.general_sampler(self.param_state_1, 100, "ab")  # type: ignore
 

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -224,6 +224,14 @@ class TestGeneralSampler(TestCase):
 
     def test_concurrent_param_sampler_input(self) -> None:
         assert self.general_sampler(
+            self.param_circuit_1, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: 3000}, {0: 14000}]
+
+        assert self.general_sampler(
+            self.param_circuit_2, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
+
+        assert self.general_sampler(
             (self.param_circuit_1, 1000, [1, 2]),
             (self.param_circuit_1, 2000, [3, 4]),
             (self.param_circuit_2, 1000, [1, 2]),

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -316,6 +316,20 @@ class TestGeneralSampler(TestCase):
             {0: (-14 + 38) * 2000 * 2},
         ]
 
+        assert self.general_sampler(
+            [
+                (self.param_circuit_1.bind_parameters([1, 2]), 1000),
+                (self.param_circuit_1, 2000, [3, 4]),
+                (self.param_state_2.bind_parameters([1, 2]), 1000),
+                (self.param_state_2, 2000, [3, 4]),
+            ]
+        ) == [
+            {0: 3000},
+            {0: 14000},
+            {0: (-8 + 20) * 1000 * 2},
+            {0: (-14 + 38) * 2000 * 2},
+        ]
+
 
 def create_mock_backend(counts: Sequence[MeasurementCounts]) -> mock.Mock:
     def create_job(c: MeasurementCounts) -> mock.Mock:

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -119,13 +119,13 @@ class TestParametricSampler(TestCase):
         )
 
         assert concurrent_param_sampler(
-            [
-                (self.param_circuit_1, 1000, [1, 2]),
-                (self.param_circuit_1, 2000, [3, 4]),
-                (self.param_circuit_2, 1000, [1, 2]),
-                (self.param_circuit_2, 2000, [3, 4]),
-            ],
-        ) == [{0: 3000}, {0: 14000}, {0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
+            self.param_circuit_1, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: 3000}, {0: 14000}]
+
+        assert concurrent_param_sampler(
+            self.param_circuit_2,
+            [(1000, [1, 2]), (2000, [3, 4])],
+        ) == [{0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
 
     def test_create_parametric_state_sampler_from_state_sampler(self) -> None:
         state_sampler = fake_state_sampler
@@ -151,18 +151,12 @@ class TestParametricSampler(TestCase):
             concurrent_state_sampler
         )
         assert concurrent_parametric_state_sampler(
-            [
-                (self.param_state_1, 1000, [1, 2]),
-                (self.param_state_1, 2000, [3, 4]),
-                (self.param_state_2, 1000, [1, 2]),
-                (self.param_state_2, 2000, [3, 4]),
-            ]
-        ) == [
-            {0: 3000},
-            {0: 14000},
-            {0: (-8 + 20) * 1000 * 2},
-            {0: (-14 + 38) * 2000 * 2},
-        ]
+            self.param_state_1, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: 3000}, {0: 14000}]
+
+        assert concurrent_parametric_state_sampler(
+            self.param_state_2, [(1000, [1, 2]), (2000, [3, 4])]
+        ) == [{0: (-8 + 20) * 1000 * 2}, {0: (-14 + 38) * 2000 * 2}]
 
 
 class TestGeneralSampler(TestCase):

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -8,15 +8,294 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Sequence
-from unittest import mock
+from collections.abc import Iterable, Sequence
+from typing import Union
+from unittest import TestCase, mock
 
-from quri_parts.circuit import QuantumCircuit
+import numpy as np
+
+from quri_parts.circuit import (
+    CONST,
+    LinearMappedUnboundParametricQuantumCircuit,
+    NonParametricQuantumCircuit,
+    QuantumCircuit,
+    UnboundParametricQuantumCircuit,
+)
 from quri_parts.core.sampling import (
+    GeneralSampler,
     MeasurementCounts,
+    create_concurrent_parametric_sampler_from_concurrent_sampler,
+    create_concurrent_parametric_state_sampler_from_concurrent_state_sampler,
     create_concurrent_sampler_from_sampling_backend,
+    create_parametric_sampler_from_sampler,
+    create_parametric_state_sampler_from_state_sampler,
     create_sampler_from_sampling_backend,
 )
+from quri_parts.core.state import CircuitQuantumState, QuantumStateVector, quantum_state
+
+
+def fake_sampler(circuit: NonParametricQuantumCircuit, shot: int) -> MeasurementCounts:
+    cnt = 0
+    for g in circuit.gates:
+        cnt += sum(g.params)
+    return {0: int(cnt) * shot}
+
+
+def fake_concurrent_sampler(
+    circuit_shot_pairs: Iterable[tuple[NonParametricQuantumCircuit, int]]
+) -> Iterable[MeasurementCounts]:
+    return [fake_sampler(c, s) for c, s in circuit_shot_pairs]
+
+
+def fake_state_sampler(
+    state: Union[CircuitQuantumState, QuantumStateVector], shot: int
+) -> MeasurementCounts:
+    cnt = 0
+    for g in state.circuit.gates:
+        cnt += sum(g.params)
+    if isinstance(state, QuantumStateVector):
+        cnt *= int(np.linalg.norm(state.vector, 1))
+    return {0: int(cnt) * shot}
+
+
+def fake_concurrent_state_sampler(
+    state_shot_pairs: Iterable[
+        tuple[Union[CircuitQuantumState, QuantumStateVector], int]
+    ]
+) -> Iterable[MeasurementCounts]:
+    return [fake_state_sampler(c, s) for c, s in state_shot_pairs]
+
+
+class TestParametricSampler(TestCase):
+    param_circuit_1: UnboundParametricQuantumCircuit
+    param_circuit_2: LinearMappedUnboundParametricQuantumCircuit
+
+    def setUp(self) -> None:
+        self.param_circuit_1 = UnboundParametricQuantumCircuit(2)
+        self.param_circuit_1.add_ParametricRX_gate(0)
+        self.param_circuit_1.add_ParametricRZ_gate(1)
+
+        self.param_circuit_2 = LinearMappedUnboundParametricQuantumCircuit(2)
+        a, b = self.param_circuit_2.add_parameters("a", "b")
+        self.param_circuit_2.add_ParametricRX_gate(0, {a: -1, b: -2, CONST: -3})
+        self.param_circuit_2.add_ParametricRZ_gate(1, {a: 4, b: 5, CONST: 6})
+
+        self.param_state_1 = quantum_state(2, circuit=self.param_circuit_1)
+        self.param_state_2 = quantum_state(
+            2, circuit=self.param_circuit_2, vector=np.ones(4) / 2
+        )
+
+    def test_create_parametric_sampler_from_sampler(self) -> None:
+        sampler = fake_sampler
+        param_sampler = create_parametric_sampler_from_sampler(sampler)
+
+        assert param_sampler(self.param_circuit_1, 1000, [1, 2]) == {0: 3000}
+        assert param_sampler(self.param_circuit_1, 2000, [3, 4]) == {0: 14000}
+
+        assert param_sampler(self.param_circuit_2, 1000, [1, 2]) == {
+            0: (-8 + 20) * 1000
+        }
+        assert param_sampler(self.param_circuit_2, 2000, [3, 4]) == {
+            0: (-14 + 38) * 2000
+        }
+
+    def test_create_concurrent_parametric_sampler_from_concurrent_sampler(self) -> None:
+        concurrent_sampler = fake_concurrent_sampler
+        concurrent_param_sampler = (
+            create_concurrent_parametric_sampler_from_concurrent_sampler(
+                concurrent_sampler
+            )
+        )
+
+        assert concurrent_param_sampler(
+            [
+                (self.param_circuit_1, 1000, [1, 2]),
+                (self.param_circuit_1, 2000, [3, 4]),
+                (self.param_circuit_2, 1000, [1, 2]),
+                (self.param_circuit_2, 2000, [3, 4]),
+            ],
+        ) == [{0: 3000}, {0: 14000}, {0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
+
+    def test_create_parametric_state_sampler_from_state_sampler(self) -> None:
+        state_sampler = fake_state_sampler
+        parametric_state_sampler = create_parametric_state_sampler_from_state_sampler(
+            state_sampler
+        )
+        assert parametric_state_sampler(self.param_state_1, 1000, [1, 2]) == {0: 3000}
+        assert parametric_state_sampler(self.param_state_1, 2000, [3, 4]) == {0: 14000}
+        assert parametric_state_sampler(self.param_state_2, 1000, [1, 2]) == {
+            0: (-8 + 20) * 1000 * 2
+        }
+        assert parametric_state_sampler(self.param_state_2, 2000, [3, 4]) == {
+            0: (-14 + 38) * 2000 * 2
+        }
+
+    def test_create_concurrent_parametric_state_sampler_from_concurrent_state_sampler(
+        self,
+    ) -> None:
+        concurrent_state_sampler = fake_concurrent_state_sampler
+        concurrent_parametric_state_sampler = (
+            create_concurrent_parametric_state_sampler_from_concurrent_state_sampler(
+                concurrent_state_sampler
+            )
+        )
+        assert concurrent_parametric_state_sampler(
+            [
+                (self.param_state_1, 1000, [1, 2]),
+                (self.param_state_1, 2000, [3, 4]),
+                (self.param_state_2, 1000, [1, 2]),
+                (self.param_state_2, 2000, [3, 4]),
+            ]
+        ) == [
+            {0: 3000},
+            {0: 14000},
+            {0: (-8 + 20) * 1000 * 2},
+            {0: (-14 + 38) * 2000 * 2},
+        ]
+
+
+class TestGeneralSampler(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.param_circuit_1 = UnboundParametricQuantumCircuit(2)
+        cls.param_circuit_1.add_ParametricRX_gate(0)
+        cls.param_circuit_1.add_ParametricRZ_gate(1)
+
+        cls.param_circuit_2 = LinearMappedUnboundParametricQuantumCircuit(2)
+        a, b = cls.param_circuit_2.add_parameters("a", "b")
+        cls.param_circuit_2.add_ParametricRX_gate(0, {a: -1, b: -2, CONST: -3})
+        cls.param_circuit_2.add_ParametricRZ_gate(1, {a: 4, b: 5, CONST: 6})
+
+        cls.param_state_1 = quantum_state(2, circuit=cls.param_circuit_1)
+        cls.param_state_2 = quantum_state(
+            2, circuit=cls.param_circuit_2, vector=np.ones(4) / 2
+        )
+
+        cls.general_sampler = GeneralSampler(
+            sampler=fake_sampler, state_sampler=fake_state_sampler
+        )
+
+    def test_sampler_input(self) -> None:
+        circuit = self.param_circuit_1.bind_parameters([1, 2])
+        assert self.general_sampler(circuit, 1000) == {0: 3000}
+        circuit = self.param_circuit_1.bind_parameters([3, 4])
+        assert self.general_sampler(circuit, 2000) == {0: 14000}
+        circuit = self.param_circuit_2.bind_parameters([1, 2])
+        assert self.general_sampler(circuit, 1000) == {0: (-8 + 20) * 1000}
+        circuit = self.param_circuit_2.bind_parameters([3, 4])
+        assert self.general_sampler(circuit, 2000) == {0: (-14 + 38) * 2000}
+
+    def test_concurrent_sampler_input(self) -> None:
+        circuit_1 = self.param_circuit_1.bind_parameters([1, 2])
+        circuit_2 = self.param_circuit_1.bind_parameters([3, 4])
+        assert self.general_sampler((circuit_1, 1000), (circuit_2, 2000)) == [
+            {0: 3000},
+            {0: 14000},
+        ]
+
+        assert self.general_sampler([(circuit_1, 1000), (circuit_2, 2000)]) == [
+            {0: 3000},
+            {0: 14000},
+        ]
+
+    def test_param_sampler_input(self) -> None:
+        assert self.general_sampler(self.param_circuit_1, 1000, [1, 2]) == {0: 3000}
+        assert self.general_sampler(self.param_circuit_1, 2000, [3, 4]) == {0: 14000}
+        assert self.general_sampler(self.param_circuit_2, 1000, [1, 2]) == {
+            0: (-8 + 20) * 1000
+        }
+        assert self.general_sampler(self.param_circuit_2, 2000, [3, 4]) == {
+            0: (-14 + 38) * 2000
+        }
+
+    def test_concurrent_param_sampler_input(self) -> None:
+        assert self.general_sampler(
+            (self.param_circuit_1, 1000, [1, 2]),
+            (self.param_circuit_1, 2000, [3, 4]),
+            (self.param_circuit_2, 1000, [1, 2]),
+            (self.param_circuit_2, 2000, [3, 4]),
+        ) == [{0: 3000}, {0: 14000}, {0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
+
+        assert self.general_sampler(
+            [
+                (self.param_circuit_1, 1000, [1, 2]),
+                (self.param_circuit_1, 2000, [3, 4]),
+                (self.param_circuit_2, 1000, [1, 2]),
+                (self.param_circuit_2, 2000, [3, 4]),
+            ]
+        ) == [{0: 3000}, {0: 14000}, {0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
+
+    def test_state_sampler_input(self) -> None:
+        state = self.param_state_1.bind_parameters([1, 2])
+        assert self.general_sampler(state, 1000) == {0: 3000}
+        state = self.param_state_1.bind_parameters([3, 4])
+        assert self.general_sampler(state, 2000) == {0: 14000}
+        state = self.param_state_2.bind_parameters([1, 2])
+        assert self.general_sampler(state, 1000) == {0: (-8 + 20) * 1000 * 2}
+        state = self.param_state_2.bind_parameters([3, 4])
+        assert self.general_sampler(state, 2000) == {0: (-14 + 38) * 2000 * 2}
+
+    def test_concurrent_state_sampler_input(self) -> None:
+        state_1 = self.param_state_1.bind_parameters([1, 2])
+        state_2 = self.param_state_1.bind_parameters([3, 4])
+        assert self.general_sampler((state_1, 1000), (state_2, 2000)) == [
+            {0: 3000},
+            {0: 14000},
+        ]
+        assert self.general_sampler([(state_1, 1000), (state_2, 2000)]) == [
+            {0: 3000},
+            {0: 14000},
+        ]
+
+    def test_param_state_sampler_input(self) -> None:
+        assert self.general_sampler(self.param_state_1, 1000, [1, 2]) == {0: 3000}
+        assert self.general_sampler(self.param_state_1, 2000, [3, 4]) == {0: 14000}
+        assert self.general_sampler(self.param_state_2, 1000, [1, 2]) == {
+            0: (-8 + 20) * 1000 * 2
+        }
+        assert self.general_sampler(self.param_state_2, 2000, [3, 4]) == {
+            0: (-14 + 38) * 2000 * 2
+        }
+
+    def test_concurrent_param_state_sampler_input(self) -> None:
+        assert self.general_sampler(
+            (self.param_state_1, 1000, [1, 2]),
+            (self.param_state_1, 2000, [3, 4]),
+            (self.param_state_2, 1000, [1, 2]),
+            (self.param_state_2, 2000, [3, 4]),
+        ) == [
+            {0: 3000},
+            {0: 14000},
+            {0: (-8 + 20) * 1000 * 2},
+            {0: (-14 + 38) * 2000 * 2},
+        ]
+
+        assert self.general_sampler(
+            [
+                (self.param_state_1, 1000, [1, 2]),
+                (self.param_state_1, 2000, [3, 4]),
+                (self.param_state_2, 1000, [1, 2]),
+                (self.param_state_2, 2000, [3, 4]),
+            ]
+        ) == [
+            {0: 3000},
+            {0: 14000},
+            {0: (-8 + 20) * 1000 * 2},
+            {0: (-14 + 38) * 2000 * 2},
+        ]
+
+    def test_mixed_concurrent_input(self) -> None:
+        assert self.general_sampler(
+            (self.param_circuit_1.bind_parameters([1, 2]), 1000),
+            (self.param_circuit_1, 2000, [3, 4]),
+            (self.param_state_2.bind_parameters([1, 2]), 1000),
+            (self.param_state_2, 2000, [3, 4]),
+        ) == [
+            {0: 3000},
+            {0: 14000},
+            {0: (-8 + 20) * 1000 * 2},
+            {0: (-14 + 38) * 2000 * 2},
+        ]
 
 
 def create_mock_backend(counts: Sequence[MeasurementCounts]) -> mock.Mock:

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -244,19 +244,19 @@ class TestGeneralSampler(TestCase):
         ) == [{0: 3000}, {0: 14000}, {0: (-8 + 20) * 1000}, {0: (-14 + 38) * 2000}]
 
     def test_state_sampler_input(self) -> None:
-        state = self.param_state_1.bind_parameters([1, 2])
+        state = self.param_state_1.bind_parameters([1.0, 2.0])
         assert self.general_sampler(state, 1000) == {0: 3000}
-        state = self.param_state_1.bind_parameters([3, 4])
+        state = self.param_state_1.bind_parameters([3.0, 4.0])
         assert self.general_sampler(state, 2000) == {0: 14000}
 
-        state_vector = self.param_state_2.bind_parameters([1, 2])
+        state_vector = self.param_state_2.bind_parameters([1.0, 2.0])
         assert self.general_sampler(state_vector, 1000) == {0: (-8 + 20) * 1000 * 2}
-        state_vector = self.param_state_2.bind_parameters([3, 4])
+        state_vector = self.param_state_2.bind_parameters([3.0, 4.0])
         assert self.general_sampler(state_vector, 2000) == {0: (-14 + 38) * 2000 * 2}
 
     def test_concurrent_state_sampler_input(self) -> None:
-        state_1 = self.param_state_1.bind_parameters([1, 2])
-        state_2 = self.param_state_1.bind_parameters([3, 4])
+        state_1 = self.param_state_1.bind_parameters([1.0, 2.0])
+        state_2 = self.param_state_1.bind_parameters([3.0, 4.0])
         assert self.general_sampler((state_1, 1000), (state_2, 2000)) == [
             {0: 3000},
             {0: 14000},
@@ -267,12 +267,12 @@ class TestGeneralSampler(TestCase):
         ]
 
     def test_param_state_sampler_input(self) -> None:
-        assert self.general_sampler(self.param_state_1, 1000, [1, 2]) == {0: 3000}
-        assert self.general_sampler(self.param_state_1, 2000, [3, 4]) == {0: 14000}
-        assert self.general_sampler(self.param_state_2, 1000, [1, 2]) == {
+        assert self.general_sampler(self.param_state_1, 1000, [1.0, 2.0]) == {0: 3000}
+        assert self.general_sampler(self.param_state_1, 2000, [3.0, 4.0]) == {0: 14000}
+        assert self.general_sampler(self.param_state_2, 1000, [1.0, 2.0]) == {
             0: (-8 + 20) * 1000 * 2
         }
-        assert self.general_sampler(self.param_state_2, 2000, [3, 4]) == {
+        assert self.general_sampler(self.param_state_2, 2000, [3.0, 4.0]) == {
             0: (-14 + 38) * 2000 * 2
         }
 

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -8,11 +8,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from collections.abc import Iterable, Sequence
 from typing import Union
 from unittest import TestCase, mock
 
 import numpy as np
+import pytest
 
 from quri_parts.circuit import (
     CONST,
@@ -329,6 +331,95 @@ class TestGeneralSampler(TestCase):
             {0: (-8 + 20) * 1000 * 2},
             {0: (-14 + 38) * 2000 * 2},
         ]
+
+    def test_error_raises_correctly(self) -> None:
+        # Test sample
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Shot expected to be integer, but got <class 'float'>. "
+                "Input value is 0.87."
+            ),
+        ):
+            self.general_sampler(self.param_circuit_1.bind_parameters([1.0, 2.0]), 0.87)  # type: ignore # noqa: E501
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("_sample() takes 3 positional arguments but 4 were given"),
+        ):
+            self.general_sampler(
+                self.param_circuit_1.bind_parameters([1.0, 2.0]), 0.87, [3.0, 4.0]  # type: ignore # noqa: E501
+            )
+
+        # Test param sample
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Shot expected to be integer, but got <class 'list'>. "
+                "Input value is [1.0, 2.0]."
+            ),
+        ):
+            self.general_sampler(self.param_circuit_1, [1.0, 2.0], 100)  # type: ignore
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Circuit parameter is expected to be an iterable or an array, "
+                "but got <class 'int'>. Input value is 909090."
+            ),
+        ):
+            self.general_sampler(self.param_circuit_1, 100, 909090)  # type: ignore
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("unsupported operand type(s) for +: 'int' and 'str'"),
+        ):
+            self.general_sampler(self.param_circuit_1, 100, "ab")  # type: ignore
+
+        # Test state sample
+        with pytest.raises(
+            ValueError,
+            match=(
+                "Shot expected to be integer, but got <class 'float'>. "
+                "Input value is 0.87."
+            ),
+        ):
+            self.general_sampler(self.param_state_1.bind_parameters([1.0, 2.0]), 0.87)  # type: ignore  # noqa: E501
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "_sample_state() takes 3 positional arguments but 4 were given"
+            ),
+        ):
+            self.general_sampler(
+                self.param_state_1.bind_parameters([1.0, 2.0]), 0.87, [3.0, 4.0]  # type: ignore    # noqa: E501
+            )
+
+        # Test param sample
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Shot expected to be integer, but got <class 'list'>. "
+                "Input value is [1.0, 2.0]."
+            ),
+        ):
+            self.general_sampler(self.param_state_1, [1.0, 2.0], 100)  # type: ignore
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Circuit parameter is expected to be an iterable or an array, "
+                "but got <class 'int'>. Input value is 909090."
+            ),
+        ):
+            self.general_sampler(self.param_state_1, 100, 909090)  # type: ignore
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape("unsupported operand type(s) for +: 'int' and 'str'"),
+        ):
+            self.general_sampler(self.param_state_1, 100, "ab")  # type: ignore
 
 
 def create_mock_backend(counts: Sequence[MeasurementCounts]) -> mock.Mock:

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -376,7 +376,7 @@ class TestGeneralSampler(TestCase):
 
         with pytest.raises(
             TypeError,
-            match=re.escape("argument 'params': Can't extract 'str' to 'Vec'"),
+            match="argument 'params': Can't extract `str` to `Vec`",
         ):
             self.general_sampler(self.param_circuit_1, 100, "ab")  # type: ignore
 
@@ -415,7 +415,7 @@ class TestGeneralSampler(TestCase):
 
         with pytest.raises(
             TypeError,
-            match="argument 'params': Can't extract 'str' to 'Vec'",
+            match="argument 'params': Can't extract `str` to `Vec`",
         ):
             self.general_sampler(self.param_state_1, 100, "ab")  # type: ignore
 

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -376,7 +376,7 @@ class TestGeneralSampler(TestCase):
 
         with pytest.raises(
             TypeError,
-            match=re.escape("unsupported operand type(s) for +: 'int' and 'str'"),
+            match=re.escape("arguments 'params': Can't extract 'str' to 'Vec'"),
         ):
             self.general_sampler(self.param_circuit_1, 100, "ab")  # type: ignore
 
@@ -415,7 +415,7 @@ class TestGeneralSampler(TestCase):
 
         with pytest.raises(
             TypeError,
-            match=re.escape("unsupported operand type(s) for +: 'int' and 'str'"),
+            match=re.escape("arguments 'params': Can't extract 'str' to 'Vec'"),
         ):
             self.general_sampler(self.param_state_1, 100, "ab")  # type: ignore
 

--- a/packages/qulacs/quri_parts/qulacs/sampler.py
+++ b/packages/qulacs/quri_parts/qulacs/sampler.py
@@ -18,9 +18,15 @@ from numpy.random import default_rng
 
 from quri_parts.circuit import ImmutableQuantumCircuit
 from quri_parts.circuit.noise import NoiseModel
-from quri_parts.core.sampling import ConcurrentSampler, MeasurementCounts, Sampler
+from quri_parts.core.sampling import (
+    ConcurrentSampler,
+    MeasurementCounts,
+    Sampler,
+    GeneralSampler,
+)
 from quri_parts.core.state import GeneralCircuitQuantumState
 from quri_parts.core.utils.concurrent import execute_concurrently
+from quri_parts.qulacs import QulacsStateT, QulacsParametricStateT
 
 from .circuit.noise import convert_circuit_with_noise_model
 from .simulator import (
@@ -85,6 +91,14 @@ def create_qulacs_vector_concurrent_sampler(
         return _sample_concurrently(circuit_shots_tuples, executor, concurrency)
 
     return sampler
+
+
+def create_qulacs_general_vector_sampler() -> (
+    GeneralSampler[QulacsStateT, QulacsParametricStateT]
+):
+    sampler = create_qulacs_vector_sampler()
+    state_sampler = create_qulacs_vector_state_sampler()
+    return GeneralSampler(sampler, state_sampler)
 
 
 def create_qulacs_stochastic_state_vector_sampler(model: NoiseModel) -> Sampler:

--- a/packages/qulacs/quri_parts/qulacs/sampler.py
+++ b/packages/qulacs/quri_parts/qulacs/sampler.py
@@ -96,8 +96,18 @@ def create_qulacs_vector_concurrent_sampler(
 def create_qulacs_general_vector_sampler() -> (
     GeneralSampler[QulacsStateT, QulacsParametricStateT]
 ):
+    """Creates a Qulacs :class:`GeneralSampler`"""
     sampler = create_qulacs_vector_sampler()
     state_sampler = create_qulacs_vector_state_sampler()
+    return GeneralSampler(sampler, state_sampler)
+
+
+def create_qulacs_general_vector_ideal_sampler() -> (
+    GeneralSampler[QulacsStateT, QulacsParametricStateT]
+):
+    """Creates an ideal Qulacs :class:`GeneralSampler`"""
+    sampler = create_qulacs_vector_ideal_sampler()
+    state_sampler = create_qulacs_ideal_vector_state_sampler()
     return GeneralSampler(sampler, state_sampler)
 
 

--- a/packages/qulacs/quri_parts/qulacs/sampler.py
+++ b/packages/qulacs/quri_parts/qulacs/sampler.py
@@ -20,13 +20,13 @@ from quri_parts.circuit import ImmutableQuantumCircuit
 from quri_parts.circuit.noise import NoiseModel
 from quri_parts.core.sampling import (
     ConcurrentSampler,
+    GeneralSampler,
     MeasurementCounts,
     Sampler,
-    GeneralSampler,
 )
 from quri_parts.core.state import GeneralCircuitQuantumState
 from quri_parts.core.utils.concurrent import execute_concurrently
-from quri_parts.qulacs import QulacsStateT, QulacsParametricStateT
+from quri_parts.qulacs import QulacsParametricStateT, QulacsStateT
 
 from .circuit.noise import convert_circuit_with_noise_model
 from .simulator import (

--- a/packages/qulacs/tests/qulacs/sampler/test_sampler.py
+++ b/packages/qulacs/tests/qulacs/sampler/test_sampler.py
@@ -443,6 +443,28 @@ class TestQulacsVectorIdealGeneralSampler(unittest.TestCase):
         ).assert_called_once_with(self.param_state_2, 600, [20.0])
         assert counts == self.unbound_state_vec_cnt
 
+    def test_call_as_param_concurrent_sampler(self) -> None:
+        counts = list(
+            self.general_sampler(
+                self.param_circuit_1,
+                [(300, [10.0, 20.0]), (100, [0.0, 0.0])],
+            )
+        )
+        assert len(counts) == 2
+        assert counts[0] == self.linear_mapped_circuit_cnt
+        assert counts[1] == self.circuit_cnt
+
+    def test_call_as_param_concurrent_state_sampler(self) -> None:
+        counts = list(
+            self.general_sampler(
+                self.param_state_1,
+                [(300, [10.0, 20.0]), (100, [0.0, 0.0])],
+            )
+        )
+        assert len(counts) == 2
+        assert counts[0] == self.linear_mapped_circuit_cnt
+        assert counts[1] == self.circuit_cnt
+
     def test_call_as_mixed_concurrent_sampler(self) -> None:
         # Call without list
         counts = self.general_sampler(


### PR DESCRIPTION
- Functions to convert (concurrent) (state) sampler into (concurrent) parametric (state) sampler implemented.
- `GeneralSampler` is implemented. It takes any of the following:
    - general_sampler(`NonParametricQuantumCircuit`, `int`)
    - general_sampler(`UnboundParametricQuantumCircuitProtocol`, `int`, `Sequence[float]`)
    - general_sampler(`UnboundParametricQuantumCircuitProtocol`, Iterable[tuple[`int`, `Sequence[float]`]])
    - general_sampler(`_StateT`, `int`)
    - general_sampler(`_ParametricStateT`, `int`, `Sequence[float]`)
    - general_sampler(`_ParametricStateT`, Iterable[tuple[`int`, `Sequence[float]`]])
    - a sequence of  mixed combinations of `(`NonParametricQuantumCircuit`, `int`)`, `(`UnboundParametricQuantumCircuitProtocol`, `int`, `Sequence[float]`)`, `(`_StateT`, `int`)`, `(`_ParametricStateT`, Iterable[tuple[`int`, `Sequence[float]`]])`