### PR TITLE
Bug fix and add tests for CliffordConversionTranspiler

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/gateset.py
+++ b/packages/circuit/quri_parts/circuit/transpile/gateset.py
@@ -188,7 +188,10 @@ class CliffordConversionTranspiler(CircuitTranspilerProtocol):
                 continue
 
             if gate.name in cache:
-                ret.extend(cache[gate.name])
+                ret.extend(
+                    QuantumGate(name=c.name, target_indices=gate.target_indices)
+                    for c in cache[gate.name]
+                )
                 continue
 
             for candidate in _equiv_clifford_table[gate.name]:

--- a/packages/circuit/quri_parts/circuit/transpile/gateset.py
+++ b/packages/circuit/quri_parts/circuit/transpile/gateset.py
@@ -172,7 +172,7 @@ class CliffordConversionTranspiler(CircuitTranspilerProtocol):
 
     def __call__(self, circuit: ImmutableQuantumCircuit) -> ImmutableQuantumCircuit:
         ret = []
-        cache: dict[str, list[QuantumGate]] = {}
+        cache: dict[str, list[str]] = {}
 
         for gate in circuit.gates:
             if gate.name not in CLIFFORD_GATE_NAMES & SINGLE_QUBIT_GATE_NAMES:
@@ -189,22 +189,21 @@ class CliffordConversionTranspiler(CircuitTranspilerProtocol):
 
             if gate.name in cache:
                 ret.extend(
-                    QuantumGate(name=c.name, target_indices=gate.target_indices)
-                    for c in cache[gate.name]
+                    QuantumGate(name=name, target_indices=gate.target_indices)
+                    for name in cache[gate.name]
                 )
                 continue
 
             for candidate in _equiv_clifford_table[gate.name]:
                 if set(candidate) <= self._gateset:
-                    expand = [
+                    cache[gate.name] = candidate
+                    ret.extend(
                         QuantumGate(name=name, target_indices=gate.target_indices)
                         for name in candidate
-                    ]
-                    cache[gate.name] = expand
-                    ret.extend(expand)
+                    )
                     break
             else:
-                cache[gate.name] = [gate]
+                cache[gate.name] = [gate.name]
                 ret.append(gate)
 
         return QuantumCircuit(circuit.qubit_count, gates=ret)

--- a/packages/circuit/tests/circuit/transpile/test_gateset.py
+++ b/packages/circuit/tests/circuit/transpile/test_gateset.py
@@ -416,3 +416,45 @@ class TestGateSetConversion:
         ]
         transpiled = GateSetConversionTranspiler(target_gateset)(_complex_circuit())
         assert _gate_kinds(transpiled) <= set(target_gateset)
+
+    def test_paulirotation_transpile(self) -> None:
+        target_gateset: list[GateNameType] = [
+            gate_names.H,
+            gate_names.S,
+            gate_names.RZ,
+            gate_names.CNOT,
+        ]
+
+        targets = (0, 2)
+        ids = (2, 2)
+        theta = np.pi / 7.0
+
+        circuit = QuantumCircuit(3)
+        circuit.add_PauliRotation_gate(targets, ids, theta)
+        transpiled = GateSetConversionTranspiler(target_gateset)(circuit)
+        assert _gate_kinds(transpiled) <= set(target_gateset)
+        assert list(transpiled.gates) == [
+            gates.S(0),
+            gates.S(0),
+            gates.S(0),
+            gates.H(0),
+            gates.S(0),
+            gates.S(0),
+            gates.S(0),
+            gates.S(2),
+            gates.S(2),
+            gates.S(2),
+            gates.H(2),
+            gates.S(2),
+            gates.S(2),
+            gates.S(2),
+            gates.CNOT(2, 0),
+            gates.RZ(0, theta),
+            gates.CNOT(2, 0),
+            gates.S(0),
+            gates.H(0),
+            gates.S(0),
+            gates.S(2),
+            gates.H(2),
+            gates.S(2),
+        ]


### PR DESCRIPTION
- Fixed a bug in `CliffordConversionTranspiler` that caused qubit indices to be reassigned since using the raw cache.
- Add test cases.