### PR TITLE
Fix `QuantumCircuit.__eq__` bug

### DIFF
--- a/packages/circuit/tests/circuit/test_circuit.py
+++ b/packages/circuit/tests/circuit/test_circuit.py
@@ -104,6 +104,19 @@ class TestQuantumCircuit:
         assert isinstance(combined_circuit, QuantumCircuit)
         assert combined_circuit.gates == exp_circuit.gates
 
+    def test_compare_pauli_rot(self) -> None:
+        circuit1 = QuantumCircuit(3)
+        circuit2 = QuantumCircuit(3)
+        circuit1.add_H_gate(0)
+        circuit1.add_PauliRotation_gate([1, 2], [1, 1], 2)
+        circuit1.add_PauliRotation_gate([0, 1, 2], [3, 1, 1], -2)
+        circuit1.add_H_gate(0)
+        circuit2.add_H_gate(0)
+        circuit2.add_PauliRotation_gate([1, 2], [1, 1], 2)
+        circuit2.add_PauliRotation_gate([1, 0, 2], [1, 3, 1], -2)
+        circuit2.add_H_gate(0)
+        assert circuit1 == circuit2
+
 
 class TestQuantumCircuitDeprecation:
     def test_order_flip(self) -> None:

--- a/packages/rust/src/circuit/circuit.rs
+++ b/packages/rust/src/circuit/circuit.rs
@@ -24,7 +24,13 @@ impl PartialEq for ImmutableQuantumCircuit {
     fn eq(&self, other: &Self) -> bool {
         self.qubit_count == other.qubit_count
             && self.cbit_count == other.cbit_count
-            && &self.gates == &other.gates
+            && &self.gates.0.len() == &other.gates.0.len()
+            && self
+                .gates
+                .0
+                .iter()
+                .zip(&other.gates.0)
+                .all(|(l, r)| l.clone().into_property() == r.clone().into_property())
     }
 }
 


### PR DESCRIPTION
Implement correct comparation when the `QuantumCircuit` has some special gates, like `PauliRotation`