### PR TITLE
Rounding sampling

### DIFF
--- a/packages/core/quri_parts/core/sampling/__init__.py
+++ b/packages/core/quri_parts/core/sampling/__init__.py
@@ -438,7 +438,11 @@ def sample_from_probibility_distribution(
 ) -> MeasurementCounts:
     """Sample from a probibility distribution."""
     rng = np.random.default_rng()
-    counts = rng.multinomial(n_sample, np.round(probibility_distribution, 12))
+    rounded_prob = np.round(probibility_distribution, 12)
+    norm = np.sum(rounded_prob)
+    assert np.isclose(norm, 1.0), "Probabilty does not sum to 1.0"
+    rounded_prob = rounded_prob / norm
+    counts = rng.multinomial(n_sample, rounded_prob)
     return Counter(dict(((i, count) for i, count in enumerate(counts) if count > 0)))
 
 

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -56,9 +56,6 @@ def test_sample_from_probibility_distribution() -> None:
     prob = np.array([p1, norm - p1])
     cnts = sample_from_probibility_distribution(1000, prob)
     assert sum(list(cnts.values())) == 1000
-    with pytest.raises(AssertionError, match="Probabilty does not sum to 1.0"):
-        rng = np.random.default_rng()
-        rng.multinomial(1000, prob)
 
     norm = 1.001
     p1 = 0.4

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -63,6 +63,19 @@ def test_sample_from_probibility_distribution() -> None:
     with pytest.raises(AssertionError, match="Probabilty does not sum to 1.0"):
         cnts = sample_from_probibility_distribution(1000, prob)
 
+    # Potentially dangerous case: large amount of small probabilities (p < 1e-12)
+    # When they are rounded away, sum of the rest of the probabilities slightly > 1.
+    n = 2**12
+    n_small = 2000
+    small_prob = -np.ones(n_small) * 1e-14
+    big_prob = np.ones(n - n_small) * (1 - np.sum(small_prob)) / (n - n_small)
+    prob = np.hstack([big_prob, small_prob])
+    with pytest.raises(ValueError):
+        rng = np.random.default_rng()
+        rng.multinomial(1000, prob.round(12))
+    cnts = sample_from_probibility_distribution(1000, prob)
+    assert sum(list(cnts.values())) == 1000
+
 
 def fake_sampler(circuit: NonParametricQuantumCircuit, shot: int) -> MeasurementCounts:
     cnt = 0.0

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -56,7 +56,7 @@ def test_sample_from_probibility_distribution() -> None:
     prob = np.array([p1, norm - p1])
     cnts = sample_from_probibility_distribution(1000, prob)
     assert sum(list(cnts.values())) == 1000
-    with pytest.raises():
+    with pytest.raises(AssertionError, match="Probabilty does not sum to 1.0"):
         rng = np.random.default_rng()
         rng.multinomial(1000, prob)
 

--- a/packages/core/tests/core/sampling/test_create_sampler.py
+++ b/packages/core/tests/core/sampling/test_create_sampler.py
@@ -33,6 +33,7 @@ from quri_parts.core.sampling import (
     create_parametric_sampler_from_sampler,
     create_parametric_state_sampler_from_state_sampler,
     create_sampler_from_sampling_backend,
+    sample_from_probibility_distribution,
 )
 from quri_parts.core.state import (
     CircuitQuantumState,
@@ -41,6 +42,29 @@ from quri_parts.core.state import (
     QuantumStateVector,
     quantum_state,
 )
+
+
+def test_sample_from_probibility_distribution() -> None:
+    norm = 1.0
+    p1 = 0.4
+    prob = np.array([p1, norm - p1])
+    cnts = sample_from_probibility_distribution(1000, prob)
+    assert sum(list(cnts.values())) == 1000
+
+    norm = 1.000000000002
+    p1 = 0.4
+    prob = np.array([p1, norm - p1])
+    cnts = sample_from_probibility_distribution(1000, prob)
+    assert sum(list(cnts.values())) == 1000
+    with pytest.raises():
+        rng = np.random.default_rng()
+        rng.multinomial(1000, prob)
+
+    norm = 1.001
+    p1 = 0.4
+    prob = np.array([p1, norm - p1])
+    with pytest.raises(AssertionError, match="Probabilty does not sum to 1.0"):
+        cnts = sample_from_probibility_distribution(1000, prob)
 
 
 def fake_sampler(circuit: NonParametricQuantumCircuit, shot: int) -> MeasurementCounts:


### PR DESCRIPTION
Fix rounding error in sampling.

Fix logic:
- Round off the small negative number first
- Renormalize the probability by the 1-norm so that is sums to 1.
- Checks the 1-norm to make sure it is close to 1 before sampling