### PR TITLE
DeviceProperty: support transpiler only for analyze

### DIFF
--- a/packages/core/quri_parts/backend/device.py
+++ b/packages/core/quri_parts/backend/device.py
@@ -98,6 +98,8 @@ class DeviceProperty:
 
     transpiler: Optional[CircuitTranspiler] = None
     parametric_transpiler: Optional[ParametricCircuitTranspiler] = None
+    analyze_transpiler: Optional[CircuitTranspiler] = None
+    analyze_parametric_transpiler: Optional[ParametricCircuitTranspiler] = None
     noise_model: Optional[NoiseModel] = None
 
     def __init__(
@@ -114,6 +116,8 @@ class DeviceProperty:
         provider: Optional[str] = None,
         transpiler: Optional[CircuitTranspiler] = None,
         parametric_transpiler: Optional[ParametricCircuitTranspiler] = None,
+        analyze_transpiler: Optional[CircuitTranspiler] = None,
+        analyze_parametric_transpiler: Optional[ParametricCircuitTranspiler] = None,
         noise_model: Optional[NoiseModel] = None,
     ) -> None:
         self.qubit_count = qubit_count
@@ -130,6 +134,8 @@ class DeviceProperty:
         self.provider = provider
         self.transpiler = transpiler
         self.parametric_transpiler = parametric_transpiler
+        self.analyze_transpiler = analyze_transpiler
+        self.analyze_parametric_transpiler = analyze_parametric_transpiler
         self.noise_model = noise_model
 
     def gate_property(self, quantum_gate: QuantumGate) -> GateProperty:

--- a/packages/core/quri_parts/backend/devices/clifford_t_device.py
+++ b/packages/core/quri_parts/backend/devices/clifford_t_device.py
@@ -6,6 +6,14 @@ import networkx as nx
 from quri_parts.backend.device import DeviceProperty, GateProperty, QubitProperty
 from quri_parts.backend.units import TimeValue
 from quri_parts.circuit import gate_names
+from quri_parts.circuit.transpile import (
+    ParametricPauliRotationDecomposeTranspiler,
+    ParametricRX2RZHTranspiler,
+    ParametricRY2RZHTranspiler,
+    ParametricSequentialTranspiler,
+    ParametricTranspiler,
+    STARSetTranspiler,
+)
 
 
 def generate_device_property(
@@ -132,6 +140,16 @@ def generate_device_property(
     # 2d^2 physical qubits per single patch, including syndrome measurement qubits
     physical_qubit_count = (2 * code_distance**2) * total_patches
 
+    trans = STARSetTranspiler()
+    param_trans = ParametricSequentialTranspiler(
+        [
+            ParametricPauliRotationDecomposeTranspiler(),
+            ParametricRX2RZHTranspiler(),
+            ParametricRY2RZHTranspiler(),
+            ParametricTranspiler(trans),
+        ]
+    )
+
     return DeviceProperty(
         qubit_count=qubit_count,
         qubits=qubits,
@@ -146,4 +164,6 @@ def generate_device_property(
         gate_properties=gate_properties,
         physical_qubit_count=physical_qubit_count,
         background_error=(1.0 - qec_fidelity_per_qec_cycle, qec_cycle),
+        analyze_transpiler=trans,
+        analyze_parametric_transpiler=param_trans,
     )

--- a/packages/core/tests/backend/test_devices.py
+++ b/packages/core/tests/backend/test_devices.py
@@ -100,6 +100,12 @@ def test_clifford_t_device() -> None:
     assert 0.0 < estimate_circuit_fidelity(circuit, device, background_error=True) < 1.0
     assert 0.0 < estimate_circuit_latency(circuit, device).value
 
+    assert device.analyze_transpiler is not None
+    assert {
+        gate.name
+        for gate in device.analyze_transpiler(_non_star_native_circuit()).gates
+    } <= {gate_names.H, gate_names.S, gate_names.CNOT, gate_names.RZ}
+
 
 def test_nisq_iontrap_device() -> None:
     native_gates: set[gate_names.GateNameType] = {


### PR DESCRIPTION
Some DeviceProperty requires for circuit analysis a transpiler different from the original transpiler for the architecture.