### PR TITLE
Fix PyO3 version to ^0.22.6 on CI

### DIFF
--- a/.github/actions/rust-install-cache/action.yml
+++ b/.github/actions/rust-install-cache/action.yml
@@ -48,4 +48,4 @@ runs:
 
     - name: Generate Cargo.lock
       shell: ${{ inputs.shell }}
-      run: cargo generate-lockfile --offline
+      run: cargo generate-lockfile --locked

--- a/.github/actions/rust-install-cache/action.yml
+++ b/.github/actions/rust-install-cache/action.yml
@@ -48,4 +48,4 @@ runs:
 
     - name: Generate Cargo.lock
       shell: ${{ inputs.shell }}
-      run: cargo generate-lockfile
+      run: cargo generate-lockfile --no-update

--- a/.github/actions/rust-install-cache/action.yml
+++ b/.github/actions/rust-install-cache/action.yml
@@ -48,4 +48,4 @@ runs:
 
     - name: Generate Cargo.lock
       shell: ${{ inputs.shell }}
-      run: cargo generate-lockfile --locked
+      run: cargo generate-lockfile --offline

--- a/.github/actions/rust-install-cache/action.yml
+++ b/.github/actions/rust-install-cache/action.yml
@@ -48,4 +48,4 @@ runs:
 
     - name: Generate Cargo.lock
       shell: ${{ inputs.shell }}
-      run: cargo generate-lockfile --no-update
+      run: cargo generate-lockfile --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "memoffset"
@@ -61,30 +61,30 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "portable-atomic"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831e8e819a138c36e212f3af3fd9eeffed6bf1510a805af35b0edee5ffa59433"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8730e591b14492a8945cdff32f089250b05f5accecf74aeddf9e8272ce1fa8"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e97e919d2df92eb88ca80a037969f44e5e70356559654962cbb3316d00300c6"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb57983022ad41f9e683a599f2fd13c3664d7063a3ac5714cae4b7bee7d3f206"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec480c0c51ddec81019531705acac51bcdbeae563557c982aa8263bb96880372"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -188,9 +188,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "rust/lib.rs"
 crate-type = ["rlib", "dylib"]
 
 [dependencies.pyo3]
-version = "*"
+version = "0.22.2"
 features = ["extension-module"]
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "rust/lib.rs"
 crate-type = ["rlib", "dylib"]
 
 [dependencies.pyo3]
-version = "0.22.2"
+version = "0.22.6"
 features = ["extension-module"]
 optional = true
 

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -9,7 +9,7 @@ num-complex = "0.4.6"
 quri-parts = { path = "../../", version = "0.20.3", features = ["python"] }
 
 [dependencies.pyo3]
-version = "*"
+version = "0.22.2"
 features = ["extension-module", "macros", "num-complex", "py-clone"]
 
 [lib]

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -9,7 +9,7 @@ num-complex = "0.4.6"
 quri-parts = { path = "../../", version = "0.20.3", features = ["python"] }
 
 [dependencies.pyo3]
-version = "0.22.2"
+version = "0.22.6"
 features = ["extension-module", "macros", "num-complex", "py-clone"]
 
 [lib]


### PR DESCRIPTION
- Fix pyo3 version to 0.22.6 in Cargo.toml
- Update Cargo.lock
- Fix .github/actions/rust-install-cache/action.yml not to update Cargo.lock