### PR TITLE
Bug fix in conversion of PauliNoise to Qulacs

### DIFF
--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -309,27 +309,25 @@ def test_convert_complex_circuit() -> None:
         DepolarizingNoise(
             error_prob=0.003,
             qubit_indices=[],  # All qubits
-            target_gates=[names.X, names.CNOT]  # X or CNOT gates
+            target_gates=[names.X, names.CNOT],  # X or CNOT gates
         ),
         PhaseFlipNoise(
             error_prob=0.002,
             qubit_indices=[1, 0],  # Qubit 0 or 1
-            target_gates=[]  # All kind of gates
+            target_gates=[],  # All kind of gates
         ),
         BitPhaseFlipNoise(
             error_prob=0.001,
             qubit_indices=[],  # All qubits
             target_gates=[],  # All kind of gates
         ),
-
         # Multi qubit noise
         PauliNoise(
             pauli_list=[[1, 2], [2, 3]],
             prob_list=[0.001, 0.002],
             qubit_indices=[1, 2],  # 2 qubit gates applying to qubits (1, 2) or (2, 1)
-            target_gates=[names.CNOT]  # CNOT gates
+            target_gates=[names.CNOT],  # CNOT gates
         ),
-
         # Circuit noise
         DepthIntervalNoise([PhaseFlipNoise(0.001)], depth_interval=5),
         MeasurementNoise([BitFlipNoise(0.004), DepolarizingNoise(0.003)]),

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -318,7 +318,7 @@ def test_convert_pauli_noise() -> None:
             [
                 qulacs.gate.Pauli([1, 2], [1, 2]),
                 qulacs.gate.Pauli([1, 2], [2, 3]),
-                qulacs.gate.Identity(2),
+                qulacs.gate.Identity(1),
             ],
         ),
         qulacs.gate.Z(2),

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -338,3 +338,6 @@ def test_convert_complex_circuit() -> None:
 
     density_matrix_sampler = create_qulacs_density_matrix_sampler(model)
     counts = density_matrix_sampler(circuit, shots=1000)
+
+    print(qulacs_circuit)
+    print(counts)

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -300,44 +300,17 @@ def test_convert_complex_circuit() -> None:
     circuit.add_Z_gate(2)
 
     noises = [
-        # Single qubit noise
-        BitFlipNoise(
-            error_prob=0.004,
-            qubit_indices=[0, 2],  # Qubit 0 or 2
-            target_gates=[names.H, names.CNOT],  # H or CNOT gates
-        ),
-        DepolarizingNoise(
-            error_prob=0.003,
-            qubit_indices=[],  # All qubits
-            target_gates=[names.X, names.CNOT],  # X or CNOT gates
-        ),
-        PhaseFlipNoise(
-            error_prob=0.002,
-            qubit_indices=[1, 0],  # Qubit 0 or 1
-            target_gates=[],  # All kind of gates
-        ),
-        BitPhaseFlipNoise(
-            error_prob=0.001,
-            qubit_indices=[],  # All qubits
-            target_gates=[],  # All kind of gates
-        ),
-        # Multi qubit noise
         PauliNoise(
             pauli_list=[[1, 2], [2, 3]],
             prob_list=[0.001, 0.002],
             qubit_indices=[1, 2],  # 2 qubit gates applying to qubits (1, 2) or (2, 1)
             target_gates=[names.CNOT],  # CNOT gates
-        ),
-        # Circuit noise
-        DepthIntervalNoise([PhaseFlipNoise(0.001)], depth_interval=5),
-        MeasurementNoise([BitFlipNoise(0.004), DepolarizingNoise(0.003)]),
+        )
     ]
     model = NoiseModel(noises)
 
     qulacs_circuit = convert_circuit_with_noise_model(circuit, model)
+    for i in range(qulacs_circuit.get_gate_count()):
+        print(qulacs_circuit.get_gate(i))
 
-    density_matrix_sampler = create_qulacs_density_matrix_sampler(model)
-    counts = density_matrix_sampler(circuit, shots=1000)
-
-    print(qulacs_circuit)
-    print(counts)
+    assert False

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -291,7 +291,7 @@ def test_convert_empty_circuit() -> None:
     assert converted_readout.get_gate_count() == 1
 
 
-def test_convert_complex_circuit() -> None:
+def test_convert_pauli_noise() -> None:
     circuit = QuantumCircuit(3)
     circuit.add_H_gate(2)
     circuit.add_X_gate(0)

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -321,14 +321,9 @@ def test_convert_pauli_noise() -> None:
                 qulacs.gate.Identity(2),
             ],
         ),
-        qulacs.gate.Z(1),
+        qulacs.gate.Z(2),
     ]
 
     assert converted.get_gate_count() == len(expected_gates)
     for i, expected_gate in enumerate(expected_gates):
-        assert gates_equal(converted.get_gate(i), expected_gate)
-
-    expected = qulacs.QuantumCircuit(3)
-    for gate in expected_gates:
-        expected.add_gate(gate)
-    assert density_matrix_equal(converted, expected)
+        assert converted.get_gate(i).to_json() == expected_gate.to_json()

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -314,11 +314,10 @@ def test_convert_pauli_noise() -> None:
         qulacs.gate.X(0),
         qulacs.gate.CNOT(2, 1),
         qulacs.gate.Probabilistic(
-            [0.001, 0.002, 0.997],
+            [0.001, 0.002],
             [
                 qulacs.gate.Pauli([1, 2], [1, 2]),
                 qulacs.gate.Pauli([1, 2], [2, 3]),
-                qulacs.gate.Identity(1),
             ],
         ),
         qulacs.gate.Z(2),

--- a/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_noise_model_qulacs.py
@@ -337,6 +337,4 @@ def test_convert_complex_circuit() -> None:
     qulacs_circuit = convert_circuit_with_noise_model(circuit, model)
 
     density_matrix_sampler = create_qulacs_density_matrix_sampler(model)
-    counts = density_matrix_sampler(qulacs_circuit, shots=1000)
-
-    print(counts)
+    counts = density_matrix_sampler(circuit, shots=1000)

--- a/packages/rust/src/qulacs/noise.rs
+++ b/packages/rust/src/qulacs/noise.rs
@@ -24,7 +24,6 @@ fn convert_add_pauli_noise<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     let module = py.import_bound("qulacs.gate")?;
     let mut probs = pauli_noise.prob_list.clone();
-    let paulies = pauli_noise.pauli_list.clone();
     let mut gates = vec![];
     for pauli in &pauli_noise.pauli_list {
         gates.push(
@@ -41,7 +40,7 @@ fn convert_add_pauli_noise<'py>(
     let prob_gate = py
         .import_bound("qulacs.gate")?
         .getattr("Probabilistic")?
-        .call1((probs, paulies))?;
+        .call1((probs, gates))?;
     qulacs_circuit.call_method1("add_gate", (prob_gate,))?;
     Ok(qulacs_circuit)
 }

--- a/packages/rust/src/qulacs/noise.rs
+++ b/packages/rust/src/qulacs/noise.rs
@@ -18,7 +18,7 @@ fn make_dense_matrix<'py>(
 
 fn convert_add_pauli_noise<'py>(
     py: Python<'py>,
-    qubits: &Vec<usize>,
+    _qubits: &Vec<usize>,
     pauli_noise: &GateNoiseInstruction,
     qulacs_circuit: Bound<'py, PyAny>,
 ) -> PyResult<Bound<'py, PyAny>> {
@@ -34,7 +34,11 @@ fn convert_add_pauli_noise<'py>(
     }
     let psum: f64 = probs.iter().sum();
     if psum < 1.0 {
-        gates.push(module.getattr("Identity")?.call1((qubits.len(),))?);
+        gates.push(
+            module
+                .getattr("Identity")?
+                .call1((pauli_noise.qubit_indices[0],))?,
+        );
         probs.push(1.0 - psum);
     }
     let prob_gate = py

--- a/packages/rust/src/qulacs/noise.rs
+++ b/packages/rust/src/qulacs/noise.rs
@@ -29,7 +29,7 @@ fn convert_add_pauli_noise<'py>(
         gates.push(
             module
                 .getattr("Pauli")?
-                .call1((qubits.clone(), pauli.clone()))?,
+                .call1((pauli_noise.qubit_indices.clone(), pauli.clone()))?,
         );
     }
     let psum: f64 = probs.iter().sum();


### PR DESCRIPTION
- Fixed a bug in the conversion of PauliNoise to Qulacs
- Add a test case
- Stop adding an Identity gate to make the sum of probability of the Probabilistic gate for PauliNoise to 1 since current Qulacs does not seem to require that