### PR TITLE
Bug fix in CircuitTranspiler for nisq_spcond_lattice DeviceProperty

### DIFF
--- a/packages/circuit/quri_parts/circuit/topology/square_lattice.py
+++ b/packages/circuit/quri_parts/circuit/topology/square_lattice.py
@@ -122,9 +122,12 @@ class SquareLatticeSWAPInsertionTranspiler(GateDecomposer):
         self._square_lattice = square_lattice
 
     def is_target_gate(self, gate: QuantumGate) -> bool:
-        return gate.name in gate_names.TWO_QUBIT_GATE_NAMES
+        return len(gate.control_indices) + len(gate.target_indices) > 1
 
     def decompose(self, gate: QuantumGate) -> Sequence[QuantumGate]:
+        if gate.name not in {gate_names.CNOT, gate_names.SWAP, gate_names.CZ}:
+            raise ValueError(f"Unsupported multi qubit gate: {gate.name}")
+
         qubit_a, qubit_b = tuple(gate.control_indices) + tuple(gate.target_indices)
 
         if self._square_lattice.is_adjacent(qubit_a, qubit_b):

--- a/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
+++ b/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
@@ -92,6 +92,7 @@ def generate_device_property(
 
     trans = SequentialTranspiler(
         [
+            GateSetConversionTranspiler(native_gates),
             SquareLatticeSWAPInsertionTranspiler(lattice),
             GateSetConversionTranspiler(native_gates),
         ]

--- a/packages/core/tests/backend/test_devices.py
+++ b/packages/core/tests/backend/test_devices.py
@@ -167,3 +167,30 @@ def test_nisq_spcond_device() -> None:
         0.0 < estimate_circuit_fidelity(circuit, device, background_error=False) < 1.0
     )
     assert 0.0 < estimate_circuit_latency(circuit, device).value
+
+
+def test_nisq_spcond_device_trans() -> None:
+    native_gates: set[gate_names.GateNameType] = {
+        gate_names.RZ,
+        gate_names.SqrtX,
+        gate_names.X,
+        gate_names.CNOT,
+    }
+
+    device_prop = nisq_spcond_lattice.generate_device_property(
+        lattice=SquareLattice(4, 4),
+        native_gates=native_gates,
+        gate_error_1q=1e-3,
+        gate_error_2q=1e-2,
+        gate_error_meas=1e-2,
+        gate_time_1q=TimeValue(60, TimeUnit.NANOSECOND),
+        gate_time_2q=TimeValue(660, TimeUnit.NANOSECOND),
+        gate_time_meas=TimeValue(1.4, TimeUnit.MICROSECOND),
+    )
+
+    circuit = QuantumCircuit(4)
+    circuit.add_PauliRotation_gate((2, 0), (3, 3), 0.1)
+
+    tc1 = device_prop.transpiler(circuit)
+    tc2 = device_prop.transpiler(tc1)
+    assert tc1.gates == tc2.gates

--- a/packages/core/tests/backend/test_devices.py
+++ b/packages/core/tests/backend/test_devices.py
@@ -191,6 +191,7 @@ def test_nisq_spcond_device_trans() -> None:
     circuit = QuantumCircuit(4)
     circuit.add_PauliRotation_gate((2, 0), (3, 3), 0.1)
 
+    assert device_prop.transpiler is not None
     tc1 = device_prop.transpiler(circuit)
     tc2 = device_prop.transpiler(tc1)
     assert tc1.gates == tc2.gates


### PR DESCRIPTION
- Fixed a bug in transpiler of nisq_spcond_lattice `DeviceProperty`
- Fixed `SquareLatticeSWAPInsertionTranspiler` to raise an error for unsupported multiple qubit gates