### PR TITLE
Noise model for nisq devices

### DIFF
--- a/packages/core/quri_parts/backend/devices/nisq_iontrap_device.py
+++ b/packages/core/quri_parts/backend/devices/nisq_iontrap_device.py
@@ -1,12 +1,12 @@
 from collections.abc import Collection
-from typing import Optional
+from typing import Optional, cast
 
 import networkx as nx
 
 from quri_parts.backend.device import DeviceProperty, GateProperty, QubitProperty
 from quri_parts.backend.units import TimeValue
-from quri_parts.circuit import gate_names
-from quri_parts.circuit.gate_names import GateNameType
+from quri_parts.circuit import gate_names, noise
+from quri_parts.circuit.gate_names import GateNameType, NonParametricGateNameType
 from quri_parts.circuit.transpile import GateSetConversionTranspiler
 
 
@@ -72,6 +72,20 @@ def generate_device_property(
         ]
     )
 
+    noise_model = noise.NoiseModel(
+        [
+            noise.DepolarizingNoise(
+                error_prob=gate_error_1q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_1q)),
+            ),
+            noise.DepolarizingNoise(
+                error_prob=gate_error_2q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_2q)),
+            ),
+            noise.MeasurementNoise([noise.BitFlipNoise(error_prob=gate_error_meas)]),
+        ]
+    )
+
     return DeviceProperty(
         qubit_count=qubit_count,
         qubits=qubits,
@@ -83,4 +97,5 @@ def generate_device_property(
         # TODO Calculate backgraound error from t1 and t2
         background_error=None,
         transpiler=GateSetConversionTranspiler(native_gates),
+        noise_model=noise_model,
     )

--- a/packages/core/quri_parts/backend/devices/nisq_iontrap_device.py
+++ b/packages/core/quri_parts/backend/devices/nisq_iontrap_device.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Collection
 from typing import Optional, cast
 
@@ -39,6 +40,11 @@ def generate_device_property(
         t1: T1 coherence time.
         t2: T2 coherence time.
     """
+    if t1 is not None or t2 is not None:
+        warnings.warn(
+            "The t1 t2 error is not yet supported and is not reflected in the "
+            "fidelity estimation or noise model."
+        )
 
     native_gate_set = set(native_gates)
     gates_1q = native_gate_set & gate_names.SINGLE_QUBIT_GATE_NAMES

--- a/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
+++ b/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
@@ -1,12 +1,12 @@
 from collections.abc import Collection
-from typing import Optional
+from typing import Optional, cast
 
 import networkx as nx
 
 from quri_parts.backend.device import DeviceProperty, GateProperty, QubitProperty
 from quri_parts.backend.units import TimeValue
-from quri_parts.circuit import gate_names
-from quri_parts.circuit.gate_names import GateNameType
+from quri_parts.circuit import gate_names, noise
+from quri_parts.circuit.gate_names import GateNameType, NonParametricGateNameType
 from quri_parts.circuit.topology import (
     SquareLattice,
     SquareLatticeSWAPInsertionTranspiler,
@@ -98,6 +98,20 @@ def generate_device_property(
         ]
     )
 
+    noise_model = noise.NoiseModel(
+        [
+            noise.DepolarizingNoise(
+                error_prob=gate_error_1q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_1q)),
+            ),
+            noise.DepolarizingNoise(
+                error_prob=gate_error_2q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_2q)),
+            ),
+            noise.MeasurementNoise([noise.BitFlipNoise(error_prob=gate_error_meas)]),
+        ]
+    )
+
     return DeviceProperty(
         qubit_count=qubit_count,
         qubits=qubits,
@@ -109,4 +123,5 @@ def generate_device_property(
         # TODO Calculate backgraound error from t1 and t2
         background_error=None,
         transpiler=trans,
+        noise_model=noise_model,
     )

--- a/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
+++ b/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Collection
 from typing import Optional, cast
 
@@ -48,6 +49,11 @@ def generate_device_property(
         t1: T1 coherence time.
         t2: T2 coherence time.
     """
+    if t1 is not None or t2 is not None:
+        warnings.warn(
+            "The t1 t2 error is not yet supported and is not reflected in the "
+            "fidelity estimation or noise model."
+        )
 
     native_gate_set = set(native_gates)
     gates_1q = native_gate_set & gate_names.SINGLE_QUBIT_GATE_NAMES


### PR DESCRIPTION
- Add `NoiseModel` to typical NISQ `DeviceProperty`s
  - Apply `DepolarizingNoise` for 1 and 2 qubit gates, `BitFlipNoise` for `Measurement`
- Currently, t1 / t2 is not even reflected in the idling error during circuit fidelity estimation, so it is not included in the noise model
  - Changed to display a warning when a value other than `None` (default value) is passed for t1 / t2 when creating a `DeviceProperty`