### PR TITLE
add a measurement instruction for all qubits when converting QURI Parts quantum circuits to OpenQASM3

### DIFF
--- a/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
+++ b/packages/openqasm/quri_parts/openqasm/circuit/__init__.py
@@ -45,6 +45,7 @@ OpenQASMTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspil
 _HEADER = """OPENQASM 3;
 include "stdgates.inc";"""
 _QUBIT_VAR_NAME = "q"
+_BIT_VAR_NAME = "c"
 
 # For information on "stdgates.inc", see https://arxiv.org/abs/2104.14722v2
 
@@ -105,9 +106,11 @@ def convert_to_qasm(circuit: "ImmutableQuantumCircuit", text_io: io.TextIOBase) 
     """
     text_io.write(_HEADER + "\n")
     text_io.write(f"qubit[{int(circuit.qubit_count)}] {_QUBIT_VAR_NAME};\n")
+    text_io.write(f"bit[{int(circuit.qubit_count)}] {_BIT_VAR_NAME};\n")
     for gate in circuit.gates:
         text_io.write("\n")
         text_io.write(convert_gate_to_qasm_line(gate))
+    text_io.write(f"\n{_BIT_VAR_NAME} = measure {_QUBIT_VAR_NAME};")
 
 
 def convert_to_qasm_str(circuit: "ImmutableQuantumCircuit") -> str:

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
@@ -11,6 +11,7 @@
 import io
 
 from quri_parts.circuit import QuantumCircuit, gates
+
 from quri_parts.openqasm.circuit import convert_gate_to_qasm_line, convert_to_qasm
 
 
@@ -124,8 +125,10 @@ class TestConvertToQasm:
         expected = """OPENQASM 3;
 include "stdgates.inc";
 qubit[7] q;
+bit[7] c;
 
 x q[0];
-z q[6];"""
+z q[6];
+c = measure q;"""
 
         assert actual == expected

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_convert_circuit.py
@@ -11,7 +11,6 @@
 import io
 
 from quri_parts.circuit import QuantumCircuit, gates
-
 from quri_parts.openqasm.circuit import convert_gate_to_qasm_line, convert_to_qasm
 
 

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_transpile.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_transpile.py
@@ -13,6 +13,7 @@ from quri_parts.circuit.transpile import (
     PauliRotationDecomposeTranspiler,
     SequentialTranspiler,
 )
+
 from quri_parts.openqasm.circuit import OpenQASMTranspiler
 
 

--- a/packages/openqasm/tests/openqasm/circuit/test_openqasm_transpile.py
+++ b/packages/openqasm/tests/openqasm/circuit/test_openqasm_transpile.py
@@ -13,7 +13,6 @@ from quri_parts.circuit.transpile import (
     PauliRotationDecomposeTranspiler,
     SequentialTranspiler,
 )
-
 from quri_parts.openqasm.circuit import OpenQASMTranspiler
 
 


### PR DESCRIPTION
In `quri-parts-openqasm`, when converting QURI Parts to OpenQASM 3, the `measure` instruction was not added.
As a result, there were cases where the converted OpenQASM 3 could not be executed on a quantum computer due to the lack of measurements.
Referring to `quri-parts-qiskit`, which adds `measure_all` during conversion, I modified the conversion process to add `c = measure q;` when converting QURI Parts quantum circuits to OpenQASM 3.