### PR TITLE
Convert Identity to RZ when braket backend device does not support i gate

### DIFF
--- a/packages/braket/quri_parts/braket/backend/transpiler.py
+++ b/packages/braket/quri_parts/braket/backend/transpiler.py
@@ -10,7 +10,12 @@
 
 from braket.aws import AwsDevice
 
-from quri_parts.circuit.transpile import CZ2CNOTHTranspiler, SequentialTranspiler
+from quri_parts.circuit.transpile import (
+    CircuitTranspiler,
+    CZ2CNOTHTranspiler,
+    Identity2RZTranspiler,
+    SequentialTranspiler,
+)
 
 
 class AwsDeviceTranspiler(SequentialTranspiler):
@@ -26,7 +31,7 @@ class AwsDeviceTranspiler(SequentialTranspiler):
     """
 
     def __init__(self, device: AwsDevice):
-        transpilers = []
+        transpilers: list[CircuitTranspiler] = []
         device_action = device.properties.dict()["action"]
         if "braket.ir.jaqcd.program" in device_action.keys():
             device_operation = device_action["braket.ir.jaqcd.program"][
@@ -39,4 +44,6 @@ class AwsDeviceTranspiler(SequentialTranspiler):
 
         if "cz" not in device_operation:
             transpilers.append(CZ2CNOTHTranspiler())
+        if "i" not in device_operation:
+            transpilers.append(Identity2RZTranspiler())
         super().__init__(transpilers)


### PR DESCRIPTION
- For Braket devices, modified to convert Identity gate to RZ gate on the QURI Parts side when i gate is not supported by the backend device