### PR TITLE
Fixed a bug that CliffrodRZSetTranspiler generates T or TDag gates

### DIFF
--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -189,7 +189,7 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
                 FuseRotationTranspiler(),
                 RX2NamedTranspiler(epsilon),
                 RY2NamedTranspiler(epsilon),
-                RZ2NamedTranspiler(epsilon),
+                RZ2NamedTranspiler(epsilon, allow_t_tdag=False),
                 IdentityEliminationTranspiler(),
             ]
         )

--- a/packages/circuit/quri_parts/circuit/transpile/__init__.py
+++ b/packages/circuit/quri_parts/circuit/transpile/__init__.py
@@ -187,8 +187,6 @@ class CliffordRZSetTranspiler(SequentialTranspiler):
                     ]
                 ),
                 FuseRotationTranspiler(),
-                RX2NamedTranspiler(epsilon),
-                RY2NamedTranspiler(epsilon),
                 RZ2NamedTranspiler(epsilon, allow_t_tdag=False),
                 IdentityEliminationTranspiler(),
             ]

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -258,11 +258,11 @@ class RZ2NamedTranspiler(GateKindDecomposer):
         elif self._is_close(theta, np.pi / 2.0):
             return [gates.S(target)]
         elif self._is_close(theta, 3.0 * np.pi / 4.0):
-            return [gates.S(target), gates.T(target)]
+            return [gates.S(target), gates.T(target)] if self._allow_t_tdag else [gate]
         elif self._is_close(theta, np.pi):
             return [gates.Z(target)]
         elif self._is_close(theta, 5.0 * np.pi / 4.0):
-            return [gates.Z(target), gates.T(target)]
+            return [gates.Z(target), gates.T(target)] if self._allow_t_tdag else [gate]
         elif self._is_close(theta, 3.0 * np.pi / 2.0):
             return [gates.Sdag(target)]
         elif self._is_close(theta, 7.0 * np.pi / 4.0):

--- a/packages/circuit/quri_parts/circuit/transpile/fuse.py
+++ b/packages/circuit/quri_parts/circuit/transpile/fuse.py
@@ -236,8 +236,9 @@ class RZ2NamedTranspiler(GateKindDecomposer):
     """Convert RZ gate to Identity, Z, S, Sdag, T, or Tdag gate if it is
     equivalent to a sequence of these gates."""
 
-    def __init__(self, epsilon: float = 1.0e-9):
+    def __init__(self, epsilon: float = 1.0e-9, allow_t_tdag: bool = True):
         self._epsilon = epsilon
+        self._allow_t_tdag = allow_t_tdag
 
     @property
     def target_gate_names(self) -> Sequence[str]:
@@ -253,7 +254,7 @@ class RZ2NamedTranspiler(GateKindDecomposer):
         if self._is_close(theta, 0.0) or self._is_close(theta, 2.0 * np.pi):
             return [gates.Identity(target)]
         elif self._is_close(theta, np.pi / 4.0):
-            return [gates.T(target)]
+            return [gates.T(target)] if self._allow_t_tdag else [gate]
         elif self._is_close(theta, np.pi / 2.0):
             return [gates.S(target)]
         elif self._is_close(theta, 3.0 * np.pi / 4.0):
@@ -265,7 +266,7 @@ class RZ2NamedTranspiler(GateKindDecomposer):
         elif self._is_close(theta, 3.0 * np.pi / 2.0):
             return [gates.Sdag(target)]
         elif self._is_close(theta, 7.0 * np.pi / 4.0):
-            return [gates.Tdag(target)]
+            return [gates.Tdag(target)] if self._allow_t_tdag else [gate]
         else:
             return [gate]
 

--- a/packages/circuit/tests/circuit/transpile/test_gateset.py
+++ b/packages/circuit/tests/circuit/transpile/test_gateset.py
@@ -26,6 +26,7 @@ from quri_parts.circuit import (
 from quri_parts.circuit.gate_names import CliffordGateNameType, GateNameType
 from quri_parts.circuit.transpile import (
     CliffordConversionTranspiler,
+    CliffordRZSetTranspiler,
     GateSetConversionTranspiler,
     ParametricRX2RZHTranspiler,
     ParametricRY2RZHTranspiler,
@@ -505,3 +506,27 @@ class TestGateSetConversion:
             gates.H(2),
             gates.S(2),
         ]
+
+
+class TestTypicalGateSetConversion:
+    def test_clifford_rz_set_transpile(self) -> None:
+        circuit = QuantumCircuit(3)
+        circuit.add_H_gate(0)
+        circuit.add_CNOT_gate(0, 1)
+        circuit.add_RZ_gate(0, 0.5 * np.pi)
+        circuit.add_RZ_gate(1, 0.25 * np.pi)
+        circuit.add_RZ_gate(2, 0.5 * np.pi)
+        circuit.add_RZ_gate(2, 0.25 * np.pi)
+
+        transpiler = CliffordRZSetTranspiler()
+        transpiled_circuit = transpiler(circuit)
+
+        expected_gates = [
+            gates.H(0),
+            gates.CNOT(0, 1),
+            gates.S(0),
+            gates.RZ(1, 0.25 * np.pi),
+            gates.RZ(2, 0.75 * np.pi),
+        ]
+
+        assert list(transpiled_circuit.gates) == expected_gates


### PR DESCRIPTION
- Fixed a bug that caused the `CliffordRZSetTranspiler` to generate a `T` / `TDag` gates
- Added option to `RZ2NamedTranspiler` to generate `T` / `TDag` gates or not