### PR TITLE
Enhance DeviceProperty for NISQ devices

### DIFF
--- a/packages/braket/quri_parts/braket/backend/transpiler.py
+++ b/packages/braket/quri_parts/braket/backend/transpiler.py
@@ -10,7 +10,12 @@
 
 from braket.aws import AwsDevice
 
-from quri_parts.circuit.transpile import CZ2CNOTHTranspiler, SequentialTranspiler
+from quri_parts.circuit.transpile import (
+    CircuitTranspiler,
+    CZ2CNOTHTranspiler,
+    Identity2RZTranspiler,
+    SequentialTranspiler,
+)
 
 
 class AwsDeviceTranspiler(SequentialTranspiler):
@@ -26,7 +31,7 @@ class AwsDeviceTranspiler(SequentialTranspiler):
     """
 
     def __init__(self, device: AwsDevice):
-        transpilers = []
+        transpilers: list[CircuitTranspiler] = []
         device_action = device.properties.dict()["action"]
         if "braket.ir.jaqcd.program" in device_action.keys():
             device_operation = device_action["braket.ir.jaqcd.program"][
@@ -39,4 +44,6 @@ class AwsDeviceTranspiler(SequentialTranspiler):
 
         if "cz" not in device_operation:
             transpilers.append(CZ2CNOTHTranspiler())
+        if "i" not in device_operation:
+            transpilers.append(Identity2RZTranspiler())
         super().__init__(transpilers)

--- a/packages/circuit/quri_parts/circuit/transpile/gateset.py
+++ b/packages/circuit/quri_parts/circuit/transpile/gateset.py
@@ -479,7 +479,13 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
         target_gateset: A Sequence of allowed output gate names.
     """
 
-    def __init__(self, target_gateset: Iterable[GateNameType], epsilon: float = 1.0e-9):
+    def __init__(
+        self,
+        target_gateset: Iterable[GateNameType],
+        epsilon: float = 1.0e-9,
+        validation: bool = True,
+    ):
+        self._validation = validation
         self._epsilon = epsilon
         self._gateset = set(target_gateset)
         self._target_clifford = cast(
@@ -588,5 +594,6 @@ class GateSetConversionTranspiler(CircuitTranspilerProtocol):
 
     def __call__(self, circuit: ImmutableQuantumCircuit) -> ImmutableQuantumCircuit:
         tr_circuit = self._decomposer(circuit)
-        self._validate(tr_circuit)
+        if self._validation:
+            self._validate(tr_circuit)
         return tr_circuit

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -34,7 +34,6 @@ networkx = "*"
 
 [tool.poetry.group.dev.dependencies]
 quri-parts-circuit = {path = "../circuit", develop = true}
-
 quri-parts-qulacs = {path = "../qulacs", develop = true}
 pytest = "^7.0.1"
 flake8 = "^4.0.1"

--- a/packages/core/quri_parts/backend/cost_estimator.py
+++ b/packages/core/quri_parts/backend/cost_estimator.py
@@ -2,7 +2,6 @@ from collections.abc import Collection, Mapping
 from typing import Callable, cast
 
 from quri_parts.circuit import NonParametricQuantumCircuit, QuantumGate
-from quri_parts.circuit.gate_names import GateNameType
 
 from .device import DeviceProperty
 from .units import TimeUnit, TimeValue
@@ -36,7 +35,7 @@ def _gate_kind_weighted_depth(
 def _estimate_gate_latency(
     circuit: NonParametricQuantumCircuit,
     device: DeviceProperty,
-    kinds: Collection[GateNameType] = [],
+    kinds: Collection[str] = [],
 ) -> TimeValue:
     latency = 0.0
     for gate in circuit.gates:
@@ -80,7 +79,7 @@ def estimate_circuit_latency(
 def _estimate_gate_fidelity(
     circuit: NonParametricQuantumCircuit,
     device: DeviceProperty,
-    kinds: Collection[GateNameType] = [],
+    kinds: Collection[str] = [],
 ) -> float:
     fidelity = 1.0
     for gate in circuit.gates:

--- a/packages/core/quri_parts/backend/device.py
+++ b/packages/core/quri_parts/backend/device.py
@@ -5,7 +5,7 @@ from typing import Optional
 import networkx as nx
 
 from quri_parts.circuit import QuantumGate
-from quri_parts.circuit.gate_names import GateNameType, is_non_parametric_gate_name
+from quri_parts.circuit.gate_names import is_parametric_gate_name
 from quri_parts.circuit.noise import NoiseModel
 from quri_parts.circuit.transpile import CircuitTranspiler, ParametricCircuitTranspiler
 
@@ -42,7 +42,7 @@ class GateProperty:
     """Noise property of a gate.
 
     Args:
-        gate (GateNameType): gate name
+        gate (str): gate name
         qubits (Sequence[int]): target qubits for the gate. The order is control_index0,
             control_index1, ..., target_index0, ...
         gate_error (float, optional): 1 - fidelity of the gate operation
@@ -50,7 +50,7 @@ class GateProperty:
         name (str, optional): name of the gate
     """
 
-    gate: GateNameType
+    gate: str
     qubits: Sequence[int]
     gate_error: Optional[float] = None
     gate_time: Optional[TimeValue] = None
@@ -67,7 +67,7 @@ class DeviceProperty:
         qubit_graph (newtorkx.Graph): Topology of qubit connections.
         qubit_properties (Mapping[int, QubitProperty]): Mapping from qubit index to
             QubitProperty.
-        native_gates (Collection[GateNameType]): Names of supported gates.
+        native_gates (Collection[str]): Names of supported gates.
         gate_properties (Collection[GateProperty]): Collection of GateProperty.
         physical_qubit_count: (int, optional): Number of physical qubits.
         background_error: (tuple[float, TimeValue], optional): The errors that
@@ -89,8 +89,8 @@ class DeviceProperty:
     qubits: Sequence[int]
     qubit_graph: nx.Graph
     qubit_properties: Mapping[int, QubitProperty]
-    native_gates: Sequence[GateNameType]
-    _gate_properties: Mapping[tuple[GateNameType, tuple[int, ...]], GateProperty]
+    native_gates: Sequence[str]
+    _gate_properties: Mapping[tuple[str, tuple[int, ...]], GateProperty]
     physical_qubit_count: Optional[int] = None
     background_error: Optional[tuple[float, TimeValue]] = None
     name: Optional[str] = None
@@ -108,7 +108,7 @@ class DeviceProperty:
         qubits: Sequence[int],
         qubit_graph: nx.Graph,
         qubit_properties: Mapping[int, QubitProperty],
-        native_gates: Collection[GateNameType],
+        native_gates: Collection[str],
         gate_properties: Collection[GateProperty],
         physical_qubit_count: Optional[int] = None,
         background_error: Optional[tuple[float, TimeValue]] = None,
@@ -146,7 +146,7 @@ class DeviceProperty:
         GateProperty for the kind of the quantum gate is searched.
         """
 
-        if not is_non_parametric_gate_name(quantum_gate.name):
+        if is_parametric_gate_name(quantum_gate.name):
             raise ValueError(f"Unsupported gate kind: {quantum_gate.name}")
         gate = (
             quantum_gate.name,

--- a/packages/core/quri_parts/backend/devices/nisq_iontrap_device.py
+++ b/packages/core/quri_parts/backend/devices/nisq_iontrap_device.py
@@ -1,18 +1,20 @@
+import warnings
 from collections.abc import Collection
-from typing import Optional
+from typing import Optional, cast
 
 import networkx as nx
 
 from quri_parts.backend.device import DeviceProperty, GateProperty, QubitProperty
 from quri_parts.backend.units import TimeValue
-from quri_parts.circuit import gate_names
-from quri_parts.circuit.gate_names import GateNameType
-from quri_parts.circuit.transpile import GateSetConversionTranspiler
+from quri_parts.circuit import gate_names, noise
+from quri_parts.circuit.gate_names import GateNameType, NonParametricGateNameType
+from quri_parts.circuit.transpile import CircuitTranspiler, GateSetConversionTranspiler
 
 
 def generate_device_property(
     qubit_count: int,
-    native_gates: Collection[GateNameType],
+    native_gates_1q: Collection[str],
+    native_gates_2q: Collection[str],
     gate_error_1q: float,
     gate_error_2q: float,
     gate_error_meas: float,
@@ -21,6 +23,7 @@ def generate_device_property(
     gate_time_meas: TimeValue,
     t1: Optional[TimeValue] = None,
     t2: Optional[TimeValue] = None,
+    transpiler: Optional[CircuitTranspiler] = None,
 ) -> DeviceProperty:
     """Generate DeviceProperty object for a typical NISQ trapped ion device.
 
@@ -29,7 +32,8 @@ def generate_device_property(
 
     Args:
         qubit_count: Number of qubits.
-        native_gates: Native gates supported by the device.
+        native_gates_1q: Single qubit native gates supported by the device.
+        native_gates_2q: Two qubit native gates supported by the device.
         gate_error_1q: Error rate of single qubit gate operations.
         gate_error_2q: Error rate of two qubit gate operations.
         gate_error_meas: Error rate of readout operations.
@@ -38,27 +42,23 @@ def generate_device_property(
         gate_time_meas: Latency of readout operations.
         t1: T1 coherence time.
         t2: T2 coherence time.
+        transpiler: CircuitTranspiler to adapt the circuit to the device. If not
+            specified, default transpiler is used.
     """
-
-    native_gate_set = set(native_gates)
-    gates_1q = native_gate_set & gate_names.SINGLE_QUBIT_GATE_NAMES
-    gates_2q = native_gate_set & gate_names.TWO_QUBIT_GATE_NAMES
-
-    if gates_1q | gates_2q != native_gate_set:
-        raise ValueError(
-            "Only single and two qubit gates are supported as native gates"
+    if t1 is not None or t2 is not None:
+        warnings.warn(
+            "The t1 t2 error is not yet supported and is not reflected in the "
+            "fidelity estimation or noise model."
         )
+
+    gates_1q = set(native_gates_1q)
+    gates_2q = set(native_gates_2q)
+    native_gates = gates_1q | gates_2q
+    meas = native_gates & {gate_names.Measurement}
 
     qubits = list(range(qubit_count))
     qubit_properties = {q: QubitProperty() for q in qubits}
-    gate_properties = [
-        GateProperty(
-            gate_names.Measurement,
-            (),
-            gate_error=gate_error_meas,
-            gate_time=gate_time_meas,
-        )
-    ]
+    gate_properties = []
     gate_properties.extend(
         [
             GateProperty(name, (), gate_error=gate_error_1q, gate_time=gate_time_1q)
@@ -69,6 +69,32 @@ def generate_device_property(
         [
             GateProperty(name, (), gate_error=gate_error_2q, gate_time=gate_time_2q)
             for name in gates_2q
+        ]
+    )
+    gate_properties.extend(
+        [
+            GateProperty(name, (), gate_error=gate_error_meas, gate_time=gate_time_meas)
+            for name in meas
+        ]
+    )
+
+    transpiler = (
+        transpiler
+        if transpiler is not None
+        else GateSetConversionTranspiler(cast(Collection[GateNameType], native_gates))
+    )
+
+    noise_model = noise.NoiseModel(
+        [
+            noise.DepolarizingNoise(
+                error_prob=gate_error_1q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_1q)),
+            ),
+            noise.DepolarizingNoise(
+                error_prob=gate_error_2q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_2q)),
+            ),
+            noise.MeasurementNoise([noise.BitFlipNoise(error_prob=gate_error_meas)]),
         ]
     )
 
@@ -82,5 +108,6 @@ def generate_device_property(
         physical_qubit_count=qubit_count,
         # TODO Calculate backgraound error from t1 and t2
         background_error=None,
-        transpiler=GateSetConversionTranspiler(native_gates),
+        transpiler=transpiler,
+        noise_model=noise_model,
     )

--- a/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
+++ b/packages/core/quri_parts/backend/devices/nisq_spcond_lattice.py
@@ -1,17 +1,19 @@
+import warnings
 from collections.abc import Collection
-from typing import Optional
+from typing import Optional, cast
 
 import networkx as nx
 
 from quri_parts.backend.device import DeviceProperty, GateProperty, QubitProperty
 from quri_parts.backend.units import TimeValue
-from quri_parts.circuit import gate_names
-from quri_parts.circuit.gate_names import GateNameType
+from quri_parts.circuit import gate_names, noise
+from quri_parts.circuit.gate_names import GateNameType, NonParametricGateNameType
 from quri_parts.circuit.topology import (
     SquareLattice,
     SquareLatticeSWAPInsertionTranspiler,
 )
 from quri_parts.circuit.transpile import (
+    CircuitTranspiler,
     GateSetConversionTranspiler,
     SequentialTranspiler,
 )
@@ -19,7 +21,8 @@ from quri_parts.circuit.transpile import (
 
 def generate_device_property(
     lattice: SquareLattice,
-    native_gates: Collection[GateNameType],
+    native_gates_1q: Collection[str],
+    native_gates_2q: Collection[str],
     gate_error_1q: float,
     gate_error_2q: float,
     gate_error_meas: float,
@@ -28,6 +31,7 @@ def generate_device_property(
     gate_time_meas: TimeValue,
     t1: Optional[TimeValue] = None,
     t2: Optional[TimeValue] = None,
+    transpiler: Optional[CircuitTranspiler] = None,
 ) -> DeviceProperty:
     """Generate DeviceProperty object for a typical NISQ superconducting qubit
     device.
@@ -38,7 +42,8 @@ def generate_device_property(
 
     Args:
         lattice: SquareLattice instance representing the device qubits connectivity.
-        native_gates: Native gates supported by the device.
+        native_gates_1q: Single qubit native gates supported by the device.
+        native_gates_2q: Two qubit native gates supported by the device.
         gate_error_1q: Error rate of single qubit gate operations.
         gate_error_2q: Error rate of two qubit gate operations.
         gate_error_meas: Error rate of readout operations.
@@ -47,28 +52,24 @@ def generate_device_property(
         gate_time_meas: Latency of readout operations.
         t1: T1 coherence time.
         t2: T2 coherence time.
+        transpiler: CircuitTranspiler to adapt the circuit to the device. If not
+            specified, default transpiler is used.
     """
-
-    native_gate_set = set(native_gates)
-    gates_1q = native_gate_set & gate_names.SINGLE_QUBIT_GATE_NAMES
-    gates_2q = native_gate_set & gate_names.TWO_QUBIT_GATE_NAMES
-
-    if gates_1q | gates_2q != native_gate_set:
-        raise ValueError(
-            "Only single and two qubit gates are supported as native gates"
+    if t1 is not None or t2 is not None:
+        warnings.warn(
+            "The t1 t2 error is not yet supported and is not reflected in the "
+            "fidelity estimation or noise model."
         )
+
+    gates_1q = set(native_gates_1q)
+    gates_2q = set(native_gates_2q)
+    native_gates = gates_1q | gates_2q
+    meas = native_gates & {gate_names.Measurement}
 
     qubits = list(lattice.qubits)
     qubit_count = len(qubits)
     qubit_properties = {q: QubitProperty() for q in qubits}
-    gate_properties = [
-        GateProperty(
-            gate_names.Measurement,
-            (),
-            gate_error=gate_error_meas,
-            gate_time=gate_time_meas,
-        )
-    ]
+    gate_properties = []
     gate_properties.extend(
         [
             GateProperty(name, (), gate_error=gate_error_1q, gate_time=gate_time_1q)
@@ -81,6 +82,12 @@ def generate_device_property(
             for name in gates_2q
         ]
     )
+    gate_properties.extend(
+        [
+            GateProperty(name, (), gate_error=gate_error_meas, gate_time=gate_time_meas)
+            for name in meas
+        ]
+    )
 
     graph = nx.grid_2d_graph(lattice.xsize, lattice.ysize)
     mapping = {
@@ -90,11 +97,33 @@ def generate_device_property(
     }
     graph = nx.relabel_nodes(graph, mapping)
 
-    trans = SequentialTranspiler(
+    transpiler = (
+        transpiler
+        if transpiler is not None
+        else SequentialTranspiler(
+            [
+                GateSetConversionTranspiler(
+                    cast(Collection[GateNameType], native_gates)
+                ),
+                SquareLatticeSWAPInsertionTranspiler(lattice),
+                GateSetConversionTranspiler(
+                    cast(Collection[GateNameType], native_gates)
+                ),
+            ]
+        )
+    )
+
+    noise_model = noise.NoiseModel(
         [
-            GateSetConversionTranspiler(native_gates),
-            SquareLatticeSWAPInsertionTranspiler(lattice),
-            GateSetConversionTranspiler(native_gates),
+            noise.DepolarizingNoise(
+                error_prob=gate_error_1q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_1q)),
+            ),
+            noise.DepolarizingNoise(
+                error_prob=gate_error_2q,
+                target_gates=list(cast(set[NonParametricGateNameType], gates_2q)),
+            ),
+            noise.MeasurementNoise([noise.BitFlipNoise(error_prob=gate_error_meas)]),
         ]
     )
 
@@ -108,5 +137,6 @@ def generate_device_property(
         physical_qubit_count=qubit_count,
         # TODO Calculate backgraound error from t1 and t2
         background_error=None,
-        transpiler=trans,
+        transpiler=transpiler,
+        noise_model=noise_model,
     )

--- a/packages/core/tests/backend/test_devices.py
+++ b/packages/core/tests/backend/test_devices.py
@@ -117,7 +117,8 @@ def test_nisq_iontrap_device() -> None:
 
     device = nisq_iontrap_device.generate_device_property(
         qubit_count=16,
-        native_gates=native_gates,
+        native_gates_1q=native_gates & gate_names.SINGLE_QUBIT_GATE_NAMES,
+        native_gates_2q=native_gates & gate_names.TWO_QUBIT_GATE_NAMES,
         gate_error_1q=1.0e-5,
         gate_error_2q=1.0e-3,
         gate_error_meas=1.0e-3,
@@ -148,7 +149,8 @@ def test_nisq_spcond_device() -> None:
 
     device = nisq_spcond_lattice.generate_device_property(
         lattice=SquareLattice(4, 4),
-        native_gates=native_gates,
+        native_gates_1q=native_gates & gate_names.SINGLE_QUBIT_GATE_NAMES,
+        native_gates_2q=native_gates & gate_names.TWO_QUBIT_GATE_NAMES,
         gate_error_1q=1.0e-4,
         gate_error_2q=1.0e-2,
         gate_error_meas=1.0e-2,
@@ -179,7 +181,8 @@ def test_nisq_spcond_device_trans() -> None:
 
     device_prop = nisq_spcond_lattice.generate_device_property(
         lattice=SquareLattice(4, 4),
-        native_gates=native_gates,
+        native_gates_1q=native_gates & gate_names.SINGLE_QUBIT_GATE_NAMES,
+        native_gates_2q=native_gates & gate_names.TWO_QUBIT_GATE_NAMES,
         gate_error_1q=1e-3,
         gate_error_2q=1e-2,
         gate_error_meas=1e-2,

--- a/packages/qiskit/quri_parts/qiskit/circuit/circuit_converter.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/circuit_converter.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 from collections.abc import Mapping, Sequence
-from typing import Callable, Optional, Type
+from typing import Callable, Optional, Type, Union
 
 import numpy as np
 import qiskit.circuit.library as qgate
@@ -41,6 +41,7 @@ from quri_parts.circuit.transpile import (
     PauliRotationDecomposeTranspiler,
     SequentialTranspiler,
 )
+from quri_parts.qiskit.circuit.gate_names import ECR, QiskitTwoQubitGateNameType
 
 QiskitCircuitConverter: TypeAlias = Callable[
     [ImmutableQuantumCircuit, Optional[CircuitTranspiler]], QuantumCircuit
@@ -75,9 +76,12 @@ _single_qubit_rotation_gate_qiskit: Mapping[SingleQubitGateNameType, Type[Gate]]
     gate_names.RZ: qgate.RZGate,
 }
 
-_two_qubit_gate_qiskit: Mapping[TwoQubitGateNameType, Type[Gate]] = {
+_two_qubit_gate_qiskit: Mapping[
+    Union[TwoQubitGateNameType, QiskitTwoQubitGateNameType], Type[Gate]
+] = {
     gate_names.CNOT: qgate.CXGate,
     gate_names.CZ: qgate.CZGate,
+    ECR: qgate.ECRGate,
     gate_names.SWAP: qgate.SwapGate,
 }
 

--- a/packages/qiskit/quri_parts/qiskit/circuit/gate_names.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/gate_names.py
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+from typing_extensions import TypeAlias
+
+QiskitGateNameType: TypeAlias = Literal["ECR"]
+
+QiskitTwoQubitGateNameType: TypeAlias = Literal["ECR"]
+
+ECR: Literal["ECR"] = "ECR"

--- a/packages/qiskit/quri_parts/qiskit/circuit/gates.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/gates.py
@@ -1,0 +1,41 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+from quri_parts.circuit import QuantumGate
+from quri_parts.qiskit.circuit import gate_names
+
+
+class ECRFactory:
+    name: Literal["ECR"] = gate_names.ECR
+
+    def __call__(self, target_index1: int, target_index2: int) -> QuantumGate:
+        return QuantumGate(
+            name=self.name,
+            target_indices=(target_index1, target_index2),
+        )
+
+
+ECR = ECRFactory()
+r"""IBM Quantum native gate ECR defined as follows.
+
+.. math::
+    ECR = \frac{1}{\sqrt{2}}
+    \begin{pmatrix}
+        0 & 1 & 0 & i \\
+        1 & 0 & -i & 0 \\
+        0 & i & 0 & 1 \\
+        -i & 0 & 1 & 0
+    \end{pmatrix}
+
+Ref:
+    https://docs.quantum.ibm.com/api/qiskit/qiskit.circuit.library.ECRGate
+"""

--- a/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 from collections.abc import Mapping, Sequence
-from typing import Optional
+from typing import Optional, Union
 
 from qiskit import transpile
 from qiskit.providers import Backend
@@ -18,8 +18,9 @@ from quri_parts.circuit import ImmutableQuantumCircuit, gate_names
 from quri_parts.circuit.gate_names import GateNameType
 from quri_parts.circuit.transpile import CircuitTranspilerProtocol
 from quri_parts.qiskit.circuit import circuit_from_qiskit, convert_circuit
+from quri_parts.qiskit.circuit.gate_names import ECR, QiskitGateNameType
 
-_qp_qiskit_gate_name_map: Mapping[GateNameType, str] = {
+_qp_qiskit_gate_name_map: Mapping[Union[GateNameType, QiskitGateNameType], str] = {
     gate_names.Identity: "id",
     gate_names.X: "x",
     gate_names.Y: "y",
@@ -37,8 +38,10 @@ _qp_qiskit_gate_name_map: Mapping[GateNameType, str] = {
     gate_names.U3: "u",
     gate_names.CNOT: "cx",
     gate_names.CZ: "cz",
+    ECR: "ecr",
     gate_names.SWAP: "swap",
     gate_names.TOFFOLI: "ccx",
+    gate_names.Measurement: "measure",
 }
 
 
@@ -63,7 +66,7 @@ class QiskitTranspiler(CircuitTranspilerProtocol):
     def __init__(
         self,
         backend: Optional[Backend] = None,
-        basis_gates: Optional[Sequence[GateNameType]] = None,
+        basis_gates: Optional[Sequence[Union[GateNameType, QiskitGateNameType]]] = None,
         optimization_level: Optional[int] = None,
     ):
         self._basis_gates: Optional[list[str]] = None

--- a/packages/quantinuum/quri_parts/quantinuum/circuit/transpile/__init__.py
+++ b/packages/quantinuum/quri_parts/quantinuum/circuit/transpile/__init__.py
@@ -10,10 +10,11 @@
 
 from typing import Callable
 
+from quri_parts.circuit import gate_names
 from quri_parts.circuit.transpile import (
     CircuitTranspiler,
+    GateSetConversionTranspiler,
     ParallelDecomposer,
-    RotationSetTranspiler,
     SequentialTranspiler,
 )
 
@@ -33,7 +34,10 @@ from .quantinuum_native_transpiler import (
 QuantinuumSetTranspiler: Callable[[], CircuitTranspiler] = lambda: SequentialTranspiler(
     [
         CZ2RZZZTranspiler(),
-        RotationSetTranspiler(),
+        GateSetConversionTranspiler(
+            [gate_names.RX, gate_names.RY, gate_names.RZ, gate_names.CNOT],
+            validation=False,
+        ),
         CNOTRZ2RZZTranspiler(),
         ParallelDecomposer(
             [

--- a/packages/qulacs/pyproject.toml
+++ b/packages/qulacs/pyproject.toml
@@ -29,7 +29,7 @@ python = "^3.9.8"
 typing-extensions = "^4.1.1"
 quri-parts-circuit = "*"
 quri-parts-core = "*"
-Qulacs = ">=0.5.6"
+qulacs = ">=0.5.6"
 quri-parts-rust = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/packages/qulacs/tests/qulacs/circuit/test_convert_circuit.py
+++ b/packages/qulacs/tests/qulacs/circuit/test_convert_circuit.py
@@ -194,6 +194,7 @@ def test_convert_pauli_rotation_gate() -> None:
 def test_convert_circuit() -> None:
     circuit = QuantumCircuit(3)
     original_gates = [
+        gates.Identity(0),
         gates.X(1),
         gates.H(2),
         gates.CNOT(0, 2),
@@ -207,6 +208,7 @@ def test_convert_circuit() -> None:
     assert converted.get_qubit_count() == 3
 
     expected_gates = [
+        qulacs.gate.Identity(0),
         qulacs.gate.X(1),
         qulacs.gate.H(2),
         qulacs.gate.CNOT(0, 2),

--- a/packages/rust/src/qulacs/mod.rs
+++ b/packages/rust/src/qulacs/mod.rs
@@ -12,7 +12,11 @@ pub fn convert_add_gate<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     match gate {
         QuantumGate::Identity(q1) => {
-            qulacs_circuit.call_method1("add_Identity_gate", (*q1,))?;
+            let identity_gate = py
+                .import_bound("qulacs.gate")?
+                .getattr("Identity")?
+                .call1((*q1,))?;
+            qulacs_circuit.call_method1("add_gate", (identity_gate,))?;
         }
         QuantumGate::X(q1) => {
             qulacs_circuit.call_method1("add_X_gate", (*q1,))?;


### PR DESCRIPTION
### Extended functionality needed on the QURI Parts side to use NISQ devices with QURI VM

**Added new foundation gate for Qiskit**
- Added ECR gate

**Changed gate name type**
- Relaxed type constraint from GateNameType to str in DeviceProperty to accommodate each backend foundation gate
- Accompanying change to specify each qubit number of the underlying gate when creating a typical NISQ device

**Improved customizability of transpiler specification and optional features**
- User-specified transpilers can now be used when creating DeviceProperty
- Gate set conversion transpilers can now choose not to perform post-conversion verification
  - Gates that are not to be converted can now be passed through bare

**Fixed problems where necessary changes in previous PRs were being overwritten, etc.**
- Convert to rz gates for devices that do not support i-gates in Braket
- Provide noise models for typical ion trap/superconducting devices
- Bug fix in conversion of Identity gate to Qulacs