### PR TITLE
DeviceProperty for abstract FTQC devices

### DIFF
--- a/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
+++ b/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
@@ -21,6 +21,7 @@ def generate_device_property(
     qec_cycle: TimeValue,
     logical_error_rate: float,
     delta_sk: float,
+    clifford_gate_cycles: int = 1,
     t_gate_cycles: int = 1,
 ) -> DeviceProperty:
     """Generate DeviceInfo object for Clifford + T architecture devices.
@@ -32,6 +33,8 @@ def generate_device_property(
             error correction (without code distance dependency).
         logical_error_rate: Logical error rate per QEC cycle.
         delta_sk: Required accuracy of sk decompositon of each rotation gate.
+        clifford_gate_cycles: QEC cycles for each logical Clifford gate operation.
+        t_gate_cycles: QEC cycles for each T gate operation.
 
     Returns:
         DeviceInfo object representing the target Abstract FTQC architecture device.
@@ -45,18 +48,22 @@ def generate_device_property(
 
     qubits = list(range(logical_qubit_count))
     qubit_properties = {q: QubitProperty() for q in qubits}
+
+    clifford_gate_time = TimeValue(
+        value=clifford_gate_cycles * qec_cycle.value, unit=qec_cycle.unit
+    )
     gate_properties = [
         GateProperty(
             gate_names.H,
             [],
             gate_error=0.0,
-            gate_time=qec_cycle,
+            gate_time=clifford_gate_time,
         ),
         GateProperty(
             gate_names.S,
             [],
             gate_error=0.0,
-            gate_time=qec_cycle,
+            gate_time=clifford_gate_time,
         ),
         GateProperty(
             gate_names.T,
@@ -70,7 +77,7 @@ def generate_device_property(
             gate_names.CNOT,
             [],
             gate_error=0.0,
-            gate_time=qec_cycle,
+            gate_time=clifford_gate_time,
         ),
         GateProperty(
             gate_names.RZ,

--- a/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
+++ b/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
@@ -17,7 +17,6 @@ from quri_parts.circuit.transpile import (
 
 def generate_device_property(
     logical_qubit_count: int,
-    physical_qubit_count: int,
     qec_cycle: TimeValue,
     logical_error_rate: float,
     delta_sk: float,
@@ -28,7 +27,6 @@ def generate_device_property(
 
     Args:
         logical_qubit_count: Number of logical qubits.
-        physical_qubit_count: Number of physical qubits.
         qec_cycle: Time duration of each syndrome measurement for quantum
             error correction (without code distance dependency).
         logical_error_rate: Logical error rate per QEC cycle.
@@ -119,7 +117,6 @@ def generate_device_property(
             gate_names.CNOT,
         ],
         gate_properties=gate_properties,
-        physical_qubit_count=physical_qubit_count,
         background_error=(logical_error_rate, qec_cycle),
         analyze_transpiler=trans,
         analyze_parametric_transpiler=param_trans,

--- a/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
+++ b/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
@@ -43,8 +43,8 @@ def generate_device_property(
         https://arxiv.org/abs/2303.13181
     """
 
-    num_Ts_for_1q = ceil(3 * log2(1 / delta_sk))
-    latency_1q = t_gate_cycles * num_Ts_for_1q
+    t_counts_for_rz = ceil(3 * log2(1 / delta_sk))
+    rz_gate_cycles = t_gate_cycles * t_counts_for_rz
 
     qubits = list(range(logical_qubit_count))
     qubit_properties = {q: QubitProperty() for q in qubits}
@@ -84,7 +84,7 @@ def generate_device_property(
             [],
             gate_error=delta_sk,
             gate_time=TimeValue(
-                value=latency_1q * qec_cycle.value, unit=qec_cycle.unit
+                value=rz_gate_cycles * qec_cycle.value, unit=qec_cycle.unit
             ),
         ),
         GateProperty(
@@ -92,7 +92,7 @@ def generate_device_property(
             [],
             gate_error=delta_sk,
             gate_time=TimeValue(
-                value=latency_1q * qec_cycle.value, unit=qec_cycle.unit
+                value=rz_gate_cycles * qec_cycle.value, unit=qec_cycle.unit
             ),
         ),
     ]

--- a/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
+++ b/packages/core/quri_parts/backend/devices/abstract_ftqc_device.py
@@ -35,7 +35,7 @@ def generate_device_property(
         t_gate_cycles: QEC cycles for each T gate operation.
 
     Returns:
-        DeviceInfo object representing the target Abstract FTQC architecture device.
+        DeviceProperty object representing the target abstract FTQC architecture device.
 
     References:
         https://arxiv.org/abs/2303.13181

--- a/packages/core/tests/backend/test_devices.py
+++ b/packages/core/tests/backend/test_devices.py
@@ -7,6 +7,7 @@ from quri_parts.backend.cost_estimator import (
     estimate_circuit_latency,
 )
 from quri_parts.backend.devices import (
+    abstract_ftqc_device,
     clifford_t_device,
     nisq_iontrap_device,
     nisq_spcond_lattice,
@@ -198,3 +199,35 @@ def test_nisq_spcond_device_trans() -> None:
     tc1 = device_prop.transpiler(circuit)
     tc2 = device_prop.transpiler(tc1)
     assert tc1.gates == tc2.gates
+
+
+def test_abstract_ftqc_device() -> None:
+    device = abstract_ftqc_device.generate_device_property(
+        logical_qubit_count=16,
+        qec_cycle=TimeValue(value=1.0, unit=TimeUnit.MICROSECOND),
+        logical_error_rate=1.0e-9,
+        delta_sk=1.0e-9,
+        clifford_gate_cycles=1,
+        t_gate_cycles=2,
+    )
+    assert device.qubit_count == 16
+    assert set(device.native_gates) == {
+        gate_names.H,
+        gate_names.S,
+        gate_names.T,
+        gate_names.CNOT,
+    }
+    assert device.background_error is not None
+    error, time = device.background_error
+    assert math.isclose(1.0e-9, error)
+    assert math.isclose(1.0e3, time.in_ns())
+
+    circuit = _star_native_circuit()
+    assert 0.0 < estimate_circuit_fidelity(circuit, device, background_error=True) < 1.0
+    assert 0.0 < estimate_circuit_latency(circuit, device).value
+
+    assert device.analyze_transpiler is not None
+    assert {
+        gate.name
+        for gate in device.analyze_transpiler(_non_star_native_circuit()).gates
+    } <= {gate_names.H, gate_names.S, gate_names.CNOT, gate_names.RZ}


### PR DESCRIPTION
## Overview

- Add `DeviceProperty` factory for abstract FTQC devices such that only the following parameters are known. (Black box devices with no known architectural details such as QEC codes, floor plans, physical operations, etc.)

```python
def generate_device_property(
    logical_qubit_count: int,
    qec_cycle: TimeValue,
    logical_error_rate: float,
    delta_sk: float,
    clifford_gate_cycles: int = 1,
    t_gate_cycles: int = 1,
) -> DeviceProperty:
```

- This `DeviceProperty`, like Clifford + T and STAR, accepts Rz gates in addition to HSTCx gates and can estimate the approximate costs when RS decomposed according to `delta_sk`.
- The latency of Clifford gate or  T gate in units of QEC cycle can be specified by `clifford_gate_cycles` and `t_gate_cycles`, respectively. (Both are 1 by default.)
- The error rate for the entire circuit is calculated as the background error based on the circuit volume (the product of the number of qubits and the circuit depth weighted by the latency of each logical operation).