### PR TITLE
Braket saving

### DIFF
--- a/docs/tutorials/sampling_backends/sampling_real_braket.ipynb
+++ b/docs/tutorials/sampling_backends/sampling_real_braket.ipynb
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "70104976",
    "metadata": {
     "scrolled": true
@@ -104,7 +104,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{3: 432, 5: 425, 11: 79, 13: 64}\n"
+      "{5: 423, 3: 436, 13: 64, 11: 77}\n"
      ]
     }
    ],
@@ -119,6 +119,7 @@
     "circuit.add_Y_gate(2)\n",
     "circuit.add_CNOT_gate(1, 2)\n",
     "circuit.add_RX_gate(3, pi/4)\n",
+    "\n",
     "\n",
     "backend = BraketSamplingBackend(device, qubit_mapping={0: 3, 1: 2, 2: 0, 3: 1})\n",
     "sampler = create_sampler_from_sampling_backend(backend)\n",
@@ -181,11 +182,110 @@
     "\n",
     "The transpilation performed by default depends on the backend; in the case of `BraketSamplingBackend`, it uses `quri_parts.braket.circuit.BraketTranspiler` for all devices, and also performs some device-specific transpilation defined in `quri_parts.braket.backend.transpiler`. It is possible to change the former one (device-independent transpilation) by supplying `circuit_transpiler` argument to `BraketSamplingBackend`."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10bc68f1",
+   "metadata": {},
+   "source": [
+    "## Data saving"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b27bebf8",
+   "metadata": {},
+   "source": [
+    "Data saving can be turned on by setting `save_data_while_sampling` in the `BraketSamplingBackend` to True."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c00c4629",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{5: 433, 3: 420, 13: 78, 11: 69}\n",
+      "{3: 4830, 5: 4794, 13: 203, 11: 173}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from numpy import pi\n",
+    "from quri_parts.circuit import QuantumCircuit\n",
+    "from quri_parts.core.sampling import create_sampler_from_sampling_backend\n",
+    "\n",
+    "circuit_1 = QuantumCircuit(4)\n",
+    "circuit_1.add_X_gate(0)\n",
+    "circuit_1.add_H_gate(1)\n",
+    "circuit_1.add_Y_gate(2)\n",
+    "circuit_1.add_CNOT_gate(1, 2)\n",
+    "circuit_1.add_RX_gate(3, pi/4)\n",
+    "\n",
+    "\n",
+    "circuit_2 = QuantumCircuit(4)\n",
+    "circuit_2.add_X_gate(0)\n",
+    "circuit_2.add_H_gate(1)\n",
+    "circuit_2.add_Y_gate(2)\n",
+    "circuit_2.add_CNOT_gate(1, 2)\n",
+    "circuit_2.add_RX_gate(3, pi/8)\n",
+    "\n",
+    "qubit_mapping = {0: 3, 1: 2, 2: 0, 3: 1}\n",
+    "\n",
+    "backend = BraketSamplingBackend(\n",
+    "    device, qubit_mapping=qubit_mapping, save_data_while_sampling=True\n",
+    ")\n",
+    "sampler = create_sampler_from_sampling_backend(backend)\n",
+    "sampling_result_1 = sampler(circuit_1, 1000)\n",
+    "print(sampling_result_1)\n",
+    "sampling_result_2 = sampler(circuit_2, 10000)\n",
+    "print(sampling_result_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63c1f779",
+   "metadata": {},
+   "source": [
+    "Now, we can replay the above experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "d1eb6543",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{5: 433, 3: 420, 13: 78, 11: 69}\n",
+      "{3: 4830, 5: 4794, 13: 203, 11: 173}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from quri_parts.braket.backend.saved_sampling import BraketSavedDataSamplingBackend\n",
+    "\n",
+    "replay_backend = BraketSavedDataSamplingBackend(\n",
+    "    device, backend.jobs_json, qubit_mapping=qubit_mapping\n",
+    ")\n",
+    "replay_sampler = create_sampler_from_sampling_backend(replay_backend)\n",
+    "replay_sampling_result_1 = replay_sampler(circuit_1, 1000)\n",
+    "print(replay_sampling_result_1)\n",
+    "replay_sampling_result_2 = replay_sampler(circuit_2, 10000)\n",
+    "print(replay_sampling_result_2)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -199,7 +299,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/packages/braket/quri_parts/braket/backend/__init__.py
+++ b/packages/braket/quri_parts/braket/backend/__init__.py
@@ -10,10 +10,18 @@
 
 from .device import device_connectivity_graph
 from .sampling import BraketSamplingBackend, BraketSamplingJob, BraketSamplingResult
+from .saved_sampling import (
+    BraketSavedDataSamplingBackend,
+    BraketSavedDataSamplingJob,
+    BraketSavedDataSamplingResult,
+)
 
 __all__ = [
     "BraketSamplingBackend",
     "BraketSamplingJob",
     "BraketSamplingResult",
     "device_connectivity_graph",
+    "BraketSavedDataSamplingBackend",
+    "BraketSavedDataSamplingJob",
+    "BraketSavedDataSamplingResult",
 ]

--- a/packages/braket/quri_parts/braket/backend/sampling.py
+++ b/packages/braket/quri_parts/braket/backend/sampling.py
@@ -203,12 +203,8 @@ class BraketSamplingBackend(SamplingBackend):
         """Convert saved data to a list of BraketSavedDataSamplingJob
         objects."""
         job_list = []
-        for (
-            circuit_program_str,
-            n_shots,
-            braket_runtime_sampling_job,
-        ) in self._saved_data:
-            result = braket_runtime_sampling_job._braket_task.result()
+        for circuit_program_str, n_shots, braket_sampling_job in self._saved_data:
+            result = braket_sampling_job._braket_task.result()
             counter = result.measurement_counts
             saved_sampling_result = BraketSavedDataSamplingResult(raw_data=counter)
             saved_sampling_job = BraketSavedDataSamplingJob(

--- a/packages/braket/quri_parts/braket/backend/sampling.py
+++ b/packages/braket/quri_parts/braket/backend/sampling.py
@@ -221,6 +221,6 @@ class BraketSamplingBackend(SamplingBackend):
 
     @property
     def jobs_json(self) -> str:
-        """Encodes the list of QiskitSavedDataSamplingJob objects to a json
+        """Encodes the list of BraketSavedDataSamplingJob objects to a json
         string."""
         return encode_saved_data_job_sequence_to_json(self.jobs)

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -69,9 +69,9 @@ class BraketSavedDataSamplingJob(SamplingJob):
     """An object that represents a saved sampling job.
 
     Args:
-        circuit_program_str: A string that represents the circuit used in a sampling job.
-            Note that it should take in the program string of a braket quantum circuit.
-            It can be accessed by `braket_circuit.to_ir().json()`.
+        circuit_program_str: A string that represents the circuit used in a sampling
+            job. Note that it should take in the program string of a braket quantum
+            circuit. It can be accessed by `braket_circuit.to_ir().json()`.
         n_shots: The total shots of a sampling job.
         saved_result: A `BraketSavedDataSamplingResult` instance that represents the
             result when (circuit_str, n_shots) is passed into the sampler.

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -69,7 +69,7 @@ class BraketSavedDataSamplingJob(SamplingJob):
     """An object that represents a saved sampling job.
 
     Args:
-        circuit_qasm: A string that represents the circuit used in a sampling job.
+        circuit_program_str: A string that represents the circuit used in a sampling job.
             Note that it should take in the program string of a braket quantum circuit.
             It can be accessed by `braket_circuit.to_ir().json()`.
         n_shots: The total shots of a sampling job.

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -16,7 +16,6 @@ from braket.aws import AwsDevice
 from braket.devices import Device
 from pydantic.dataclasses import dataclass
 from pydantic.json import pydantic_encoder
-from qiskit.providers.backend import Backend
 from typing_extensions import TypeAlias
 
 from quri_parts.backend import (

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -41,12 +41,12 @@ SavedDataType: TypeAlias = dict[tuple[str, int], list["BraketSavedDataSamplingJo
 
 @dataclass
 class BraketSavedDataSamplingResult(SamplingResult):
-    """An object that holds a sampling count from qiskit backend output and
+    """An object that holds a sampling count from Braket backend output and
     converts it into quri-parts sampling count.
 
     The `raw_data` should take in the output of
-    `qiskit_result.get_counts()`, which is a counter that uses str as
-    its key.
+    `braket_task.result().measurement_counts`, which is a counter that
+    uses str as its key.
     """
 
     raw_data: dict[str, int]
@@ -70,10 +70,10 @@ class BraketSavedDataSamplingJob(SamplingJob):
 
     Args:
         circuit_qasm: A string that represents the circuit used in a sampling job.
-            Note that it should take in the qasm string of a qiskit quantum circuit.
-            It can be accessed by `qiskit.qasm3.dumps(qiskit_circuit)`.
+            Note that it should take in the program string of a braket quantum circuit.
+            It can be accessed by `braket_circuit.to_ir().json()`.
         n_shots: The total shots of a sampling job.
-        saved_result: A `QiskitSavedDataSamplingResult` instance that represents the
+        saved_result: A `BraketSavedDataSamplingResult` instance that represents the
             result when (circuit_str, n_shots) is passed into the sampler.
     """
 
@@ -116,7 +116,7 @@ class BraketSavedDataSamplingBackend(SamplingBackend):
 
         2-a: Create sampling backend and sampler with saved data.
 
-        >>> saved_data_sampling_backend = QiskitSavedDataSamplingBackend(
+        >>> saved_data_sampling_backend = BraketSavedDataSamplingBackend(
         ...     backend = backend_device,
         ...     saved_data = experiment_json_str
         ... )
@@ -135,15 +135,14 @@ class BraketSavedDataSamplingBackend(SamplingBackend):
         >>> replayed_sampling_count_3 = sampler(circuit_3, n_shots_3)
 
     Args:
-        backend: A Qiskit :class:`qiskit.providers.backend.Backend`
-            for circuit execution.
-        saved_data: A json string output by the `.json_str` property of
-            `:class:`~quri_parts.qiskit.backend.QiskitSamplingBackend`.
+        backend: A Braket :class:`braket.devices.Device` for circuit execution.
+        saved_data: A json string output by the `.jobs_json` property of
+            `:class:`~quri_parts.braket.backend.BraketSamplingBackend`.
         circuit_converter: A function converting
             :class:`~quri_parts.circuit.ImmutableQuantumCircuit` to
-            a Qiskit :class:`qiskit.circuit.QuantumCircuit`.
+            a Braket :class:`braket.circuits.Circuit`.
         circuit_transpiler: A transpiler applied to the circuit before running it.
-            :class:`~QiskitSetTranspiler` is used when not specified.
+            :class:`~BraketSetTranspiler` is used when not specified.
         enable_shots_roundup: If True, when a number of shots specified to
             :meth:`~sample` is smaller than the minimum number of shots supported by
             the device, it is rounded up to the minimum. In this case, it is possible
@@ -158,7 +157,7 @@ class BraketSavedDataSamplingBackend(SamplingBackend):
             2 → 5, 3 → 0, then the ``qubit_mapping`` should be
             ``{0: 4, 1: 2, 2: 5, 3: 0}``.
         run_kwargs: Additional keyword arguments for
-            :meth:`qiskit.providers.backend.Backend.run` method.
+            :meth:`braket.devices.Device.run` method.
     """
 
     def __init__(

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -135,7 +135,7 @@ class BraketSavedDataSamplingBackend(SamplingBackend):
         >>> replayed_sampling_count_3 = sampler(circuit_3, n_shots_3)
 
     Args:
-        backend: A Braket :class:`braket.devices.Device` for circuit execution.
+        device: A Braket :class:`braket.devices.Device` for circuit execution.
         saved_data: A json string output by the `.jobs_json` property of
             `:class:`~quri_parts.braket.backend.BraketSamplingBackend`.
         circuit_converter: A function converting

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -86,8 +86,8 @@ class BraketSavedDataSamplingJob(SamplingJob):
 
 
 class BraketSavedDataSamplingBackend(SamplingBackend):
-    """A Qiskit backend for replaying saved sampling experiments. When a
-    sampler is created with a QiskitSavedDataSamplingBackend object, the
+    """A Braket backend for replaying saved sampling experiments. When a
+    sampler is created with a BraketSavedDataSamplingBackend object, the
     sequence of (circuit, n_shots) pairs should be passed in to the sampler the
     same order as the orginal experiment.
 
@@ -96,8 +96,8 @@ class BraketSavedDataSamplingBackend(SamplingBackend):
 
         1-a: Sampling mode with data saving
 
-        >>> backend_device = AerSimulator()
-        >>> sampling_backend = QiskitSamplingBackend(
+        >>> backend_device = LocalSimulator()
+        >>> sampling_backend = BraketSamplingBackend(
         ...     backend_device, save_data_while_sampling=True
         ... )
         >>> sampler = create_sampler_from_sampling_backend(sampling_backend)

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -9,14 +9,13 @@
 # limitations under the License.
 
 import json
-from collections import defaultdict, Counter
+from collections import defaultdict
 from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
 
-import numpy as np
-
+from braket.aws import AwsDevice
+from braket.devices import Device
 from pydantic.dataclasses import dataclass
 from pydantic.json import pydantic_encoder
-from qiskit import qasm3
 from qiskit.providers.backend import Backend
 from typing_extensions import TypeAlias
 
@@ -28,13 +27,15 @@ from quri_parts.backend import (
     SamplingResult,
 )
 from quri_parts.backend.qubit_mapping import BackendQubitMapping, QubitMappedSamplingJob
+from quri_parts.braket.circuit import (
+    BraketCircuitConverter,
+    BraketSetTranspiler,
+    convert_circuit,
+)
 from quri_parts.circuit import ImmutableQuantumCircuit
 from quri_parts.circuit.transpile import CircuitTranspiler, SequentialTranspiler
-from quri_parts.braket.circuit import convert_circuit, BraketCircuitConverter, BraketSetTranspiler
-from braket.aws import AwsDevice
-from braket.devices import Device
-from .transpiler import AwsDeviceTranspiler
 
+from .transpiler import AwsDeviceTranspiler
 
 SavedDataType: TypeAlias = dict[tuple[str, int], list["BraketSavedDataSamplingJob"]]
 
@@ -62,7 +63,6 @@ class BraketSavedDataSamplingResult(SamplingResult):
         for result in self.raw_data:
             measurements[int(result[::-1], 2)] = self.raw_data[result]
         return measurements
-
 
 
 @dataclass
@@ -202,7 +202,6 @@ class BraketSavedDataSamplingBackend(SamplingBackend):
                 self._min_shots = min
             if max > 0:
                 self._max_shots = max
-        
 
         # saving mode
         self._saved_data = self._load_data(saved_data)

--- a/packages/braket/quri_parts/braket/backend/saved_sampling.py
+++ b/packages/braket/quri_parts/braket/backend/saved_sampling.py
@@ -1,0 +1,274 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from collections import defaultdict, Counter
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
+
+import numpy as np
+
+from pydantic.dataclasses import dataclass
+from pydantic.json import pydantic_encoder
+from qiskit import qasm3
+from qiskit.providers.backend import Backend
+from typing_extensions import TypeAlias
+
+from quri_parts.backend import (
+    CompositeSamplingJob,
+    SamplingBackend,
+    SamplingCounts,
+    SamplingJob,
+    SamplingResult,
+)
+from quri_parts.backend.qubit_mapping import BackendQubitMapping, QubitMappedSamplingJob
+from quri_parts.circuit import ImmutableQuantumCircuit
+from quri_parts.circuit.transpile import CircuitTranspiler, SequentialTranspiler
+from quri_parts.braket.circuit import convert_circuit, BraketCircuitConverter, BraketSetTranspiler
+from braket.aws import AwsDevice
+from braket.devices import Device
+from .transpiler import AwsDeviceTranspiler
+
+
+SavedDataType: TypeAlias = dict[tuple[str, int], list["BraketSavedDataSamplingJob"]]
+
+
+@dataclass
+class BraketSavedDataSamplingResult(SamplingResult):
+    """An object that holds a sampling count from qiskit backend output and
+    converts it into quri-parts sampling count.
+
+    The `raw_data` should take in the output of
+    `qiskit_result.get_counts()`, which is a counter that uses str as
+    its key.
+    """
+
+    raw_data: dict[str, int]
+
+    @property
+    def counts(self) -> SamplingCounts:
+        """Convert the raw data to quri-parts sampling count.
+
+        The quri-parts sampling count is a counter that uses int as its
+        key.
+        """
+        measurements: MutableMapping[int, int] = {}
+        for result in self.raw_data:
+            measurements[int(result[::-1], 2)] = self.raw_data[result]
+        return measurements
+
+
+
+@dataclass
+class BraketSavedDataSamplingJob(SamplingJob):
+    """An object that represents a saved sampling job.
+
+    Args:
+        circuit_qasm: A string that represents the circuit used in a sampling job.
+            Note that it should take in the qasm string of a qiskit quantum circuit.
+            It can be accessed by `qiskit.qasm3.dumps(qiskit_circuit)`.
+        n_shots: The total shots of a sampling job.
+        saved_result: A `QiskitSavedDataSamplingResult` instance that represents the
+            result when (circuit_str, n_shots) is passed into the sampler.
+    """
+
+    circuit_program_str: str
+    n_shots: int
+    saved_result: BraketSavedDataSamplingResult
+
+    def result(self) -> Union[BraketSavedDataSamplingResult]:
+        return self.saved_result
+
+
+class BraketSavedDataSamplingBackend(SamplingBackend):
+    """A Qiskit backend for replaying saved sampling experiments. When a
+    sampler is created with a QiskitSavedDataSamplingBackend object, the
+    sequence of (circuit, n_shots) pairs should be passed in to the sampler the
+    same order as the orginal experiment.
+
+    Example:
+        1. Sampling experiment
+
+        1-a: Sampling mode with data saving
+
+        >>> backend_device = AerSimulator()
+        >>> sampling_backend = QiskitSamplingBackend(
+        ...     backend_device, save_data_while_sampling=True
+        ... )
+        >>> sampler = create_sampler_from_sampling_backend(sampling_backend)
+
+        1-b: Perform sampling experiments
+
+        >>> sampling_count_1 = sampler(circuit_1, n_shots_1)
+        >>> sampling_count_2 = sampler(circuit_2, n_shots_2)
+        >>> sampling_count_3 = sampler(circuit_3, n_shots_3)
+
+        1-c: Dump sampling data
+
+        >>> experiment_json_str = sampling_backend.jobs_json()
+
+        2. Replay sampling experiment
+
+        2-a: Create sampling backend and sampler with saved data.
+
+        >>> saved_data_sampling_backend = QiskitSavedDataSamplingBackend(
+        ...     backend = backend_device,
+        ...     saved_data = experiment_json_str
+        ... )
+
+        >>> saved_data_sampler = create_sampler_from_sampling_backend(
+        ...    saved_data_sampling_backend
+        ... )
+
+        2-b: Replay sampling experiment.
+
+        (circuit, n_shots) pairs are passed in to the `saved_data_sampler`
+        the same order as they were passed in to the `sampler`.
+
+        >>> replayed_sampling_count_1 = sampler(circuit_1, n_shots_1)
+        >>> replayed_sampling_count_2 = sampler(circuit_2, n_shots_2)
+        >>> replayed_sampling_count_3 = sampler(circuit_3, n_shots_3)
+
+    Args:
+        backend: A Qiskit :class:`qiskit.providers.backend.Backend`
+            for circuit execution.
+        saved_data: A json string output by the `.json_str` property of
+            `:class:`~quri_parts.qiskit.backend.QiskitSamplingBackend`.
+        circuit_converter: A function converting
+            :class:`~quri_parts.circuit.ImmutableQuantumCircuit` to
+            a Qiskit :class:`qiskit.circuit.QuantumCircuit`.
+        circuit_transpiler: A transpiler applied to the circuit before running it.
+            :class:`~QiskitSetTranspiler` is used when not specified.
+        enable_shots_roundup: If True, when a number of shots specified to
+            :meth:`~sample` is smaller than the minimum number of shots supported by
+            the device, it is rounded up to the minimum. In this case, it is possible
+            that shots more than specified are used. If it is strictly not allowed to
+            exceed the specified shot count, set this argument to False.
+        qubit_mapping: If specified, indices of qubits in the circuit are remapped
+            before running it on the backend. It can be used when you want to use
+            specific backend qubits, e.g. those with high fidelity.
+            The mapping should be specified with "from" qubit
+            indices as keys and "to" qubit indices as values. For example, if
+            you want to map qubits 0, 1, 2, 3 to backend qubits as 0 → 4, 1 → 2,
+            2 → 5, 3 → 0, then the ``qubit_mapping`` should be
+            ``{0: 4, 1: 2, 2: 5, 3: 0}``.
+        run_kwargs: Additional keyword arguments for
+            :meth:`qiskit.providers.backend.Backend.run` method.
+    """
+
+    def __init__(
+        self,
+        device: Device,
+        saved_data: str,
+        circuit_converter: BraketCircuitConverter = convert_circuit,
+        circuit_transpiler: Optional[CircuitTranspiler] = BraketSetTranspiler(),
+        enable_shots_roundup: bool = True,
+        qubit_mapping: Optional[Mapping[int, int]] = None,
+        run_kwargs: Mapping[str, Any] = {},
+    ):
+        self._device = device
+        self._circuit_converter = circuit_converter
+
+        self._qubit_mapping = None
+        if qubit_mapping is not None:
+            self._qubit_mapping = BackendQubitMapping(qubit_mapping)
+
+        if circuit_transpiler is None:
+            circuit_transpiler = BraketSetTranspiler()
+        if isinstance(device, AwsDevice):
+            circuit_transpiler = SequentialTranspiler(
+                [circuit_transpiler, AwsDeviceTranspiler(device)]
+            )
+        if self._qubit_mapping:
+            circuit_transpiler = SequentialTranspiler(
+                [circuit_transpiler, self._qubit_mapping.circuit_transpiler]
+            )
+        self._circuit_transpiler = circuit_transpiler
+
+        self._enable_shots_roundup = enable_shots_roundup
+        self._run_kwargs = run_kwargs
+
+        self._min_shots = 1
+        self._max_shots: Optional[int] = None
+        if isinstance(device, AwsDevice):
+            min, max = device.properties.service.shotsRange
+            if min > 0:
+                self._min_shots = min
+            if max > 0:
+                self._max_shots = max
+        
+
+        # saving mode
+        self._saved_data = self._load_data(saved_data)
+        self._replay_memory = {k: 0 for k in self._saved_data}
+
+    def sample(self, circuit: ImmutableQuantumCircuit, n_shots: int) -> SamplingJob:
+        if not n_shots >= 1:
+            raise ValueError("n_shots should be a positive integer.")
+        if self._max_shots is not None and n_shots > self._max_shots:
+            shot_dist = [self._max_shots] * (n_shots // self._max_shots)
+            remaining = n_shots % self._max_shots
+            if remaining > 0:
+                if remaining >= self._min_shots:
+                    shot_dist.append(remaining)
+                elif self._enable_shots_roundup:
+                    shot_dist.append(self._min_shots)
+        else:
+            if n_shots >= self._min_shots or self._enable_shots_roundup:
+                shot_dist = [max(n_shots, self._min_shots)]
+            else:
+                raise ValueError(
+                    f"n_shots is smaller than minimum shot count ({self._min_shots}) "
+                    "supported by the device. Try larger n_shots or use "
+                    "enable_shots_roundup=True when creating the backend."
+                )
+
+        braket_circuit = self._circuit_converter(circuit, self._circuit_transpiler)
+        program_str = braket_circuit.to_ir().json()
+        jobs: list[SamplingJob] = []
+
+        for s in shot_dist:
+            if (key := (program_str, s)) in self._saved_data:
+                data_position = self._replay_memory[key]
+                try:
+                    jobs.append(self._saved_data[key][data_position])
+                    self._replay_memory[key] += 1
+                except IndexError:
+                    raise ValueError("Replay of this experiment is over")
+            else:
+                raise KeyError("This experiment is not in the saved data.")
+
+        if self._qubit_mapping is not None:
+            jobs = [QubitMappedSamplingJob(job, self._qubit_mapping) for job in jobs]
+        return jobs[0] if len(jobs) == 1 else CompositeSamplingJob(jobs)
+
+    def _load_data(self, json_str: str) -> SavedDataType:
+        saved_data = defaultdict(list)
+        saved_data_seq = decode_json_to_saved_data_sequence(json_str)
+        for job in saved_data_seq:
+            circuit_program = job.circuit_program_str
+            n_shots = job.n_shots
+            saved_data[(circuit_program, n_shots)].append(job)
+        return saved_data
+
+
+def decode_json_to_saved_data_sequence(
+    json_str: str,
+) -> Sequence[BraketSavedDataSamplingJob]:
+    saved_jobs = []
+    saved_data_seq = json.loads(json_str)
+    for job_dict in saved_data_seq:
+        saved_jobs.append(BraketSavedDataSamplingJob(**job_dict))
+    return saved_jobs
+
+
+def encode_saved_data_job_sequence_to_json(
+    saved_data_seq: Sequence[BraketSavedDataSamplingJob],
+) -> str:
+    return json.dumps(saved_data_seq, default=pydantic_encoder)

--- a/packages/braket/tests/braket/backend/test_saved_data.py
+++ b/packages/braket/tests/braket/backend/test_saved_data.py
@@ -1,0 +1,138 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+from typing import Any, Optional
+
+import pytest
+from braket.circuits import Circuit
+from braket.devices import LocalSimulator
+
+from quri_parts.backend import CompositeSamplingJob
+from quri_parts.braket.backend.saved_sampling import (
+    BraketSavedDataSamplingBackend,
+    BraketSavedDataSamplingJob,
+    BraketSavedDataSamplingResult,
+)
+from quri_parts.circuit import ImmutableQuantumCircuit, QuantumCircuit
+from quri_parts.circuit.transpile import CircuitTranspiler
+
+
+def circuit_converter(
+    _: ImmutableQuantumCircuit, transpiler: Optional[CircuitTranspiler] = None
+) -> Circuit:
+    circuit = Circuit()
+    circuit.h(0)
+    circuit.i(1)
+    circuit.h(2)
+    circuit.i(3)
+    return circuit
+
+
+def circuit_transpiler(_: ImmutableQuantumCircuit) -> ImmutableQuantumCircuit:
+    circuit = QuantumCircuit(4)
+    circuit.add_X_gate(0)
+    circuit.add_H_gate(1)
+    circuit.add_Z_gate(2)
+    circuit.add_Y_gate(3)
+    return circuit
+
+
+def get_program_str() -> str:
+    circuit = circuit_converter(QuantumCircuit(4))
+    return str(circuit.to_ir().json())
+
+
+class TestSavedSampling(unittest.TestCase):
+    json_list: list[dict[str, Any]]
+    json_str: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        program_str = get_program_str()
+        cls.json_list = [
+            {
+                "circuit_program_str": program_str,
+                "n_shots": 100,
+                "saved_result": {
+                    "raw_data": {"0000": 50, "1000": 30, "0100": 15, "1100": 5}
+                },
+            },
+            {
+                "circuit_program_str": program_str,
+                "n_shots": 200,
+                "saved_result": {
+                    "raw_data": {"0000": 100, "1000": 60, "0100": 30, "1100": 10}
+                },
+            },
+            {
+                "circuit_program_str": program_str,
+                "n_shots": 200,
+                "saved_result": {
+                    "raw_data": {"0000": 100, "1000": 60, "0100": 30, "1100": 10}
+                },
+            },
+            {
+                "circuit_program_str": program_str,
+                "n_shots": 200,
+                "saved_result": {
+                    "raw_data": {"0000": 100, "1000": 60, "0100": 30, "1100": 10}
+                },
+            },
+            {
+                "circuit_program_str": program_str,
+                "n_shots": 200,
+                "saved_result": {
+                    "raw_data": {"0000": 100, "1000": 60, "0100": 30, "1100": 10}
+                },
+            },
+            {
+                "circuit_program_str": program_str,
+                "n_shots": 200,
+                "saved_result": {
+                    "raw_data": {"0000": 100, "1000": 60, "0100": 30, "1100": 10}
+                },
+            },
+        ]
+        cls.json_str = json.dumps(cls.json_list)
+
+    def test_saved_sampling(self) -> None:
+        circuit = QuantumCircuit(3)
+        circuit.add_X_gate(0)
+        circuit.add_H_gate(1)
+        circuit.add_Z_gate(2)
+
+        device = LocalSimulator()
+
+        backend = BraketSavedDataSamplingBackend(
+            device,
+            self.json_str,
+            circuit_converter=circuit_converter,
+        )
+        backend._max_shots = 200
+
+        saved_job_1 = backend.sample(circuit, 100)
+        assert isinstance(saved_job_1, BraketSavedDataSamplingJob)
+        assert isinstance(saved_job_1.result(), BraketSavedDataSamplingResult)
+        assert saved_job_1.result().counts == {0: 50, 1: 30, 2: 15, 3: 5}
+
+        with pytest.raises(KeyError, match="This experiment is not in the saved data."):
+            backend.sample(circuit, 30)
+
+        saved_job_2 = backend.sample(circuit, 1000)
+        assert isinstance(saved_job_2, CompositeSamplingJob)
+        for job in saved_job_2.jobs:
+            assert isinstance(job, BraketSavedDataSamplingJob)
+            assert isinstance(job.result(), BraketSavedDataSamplingResult)
+        assert saved_job_2.result().counts == {0: 500, 1: 300, 2: 150, 3: 50}
+
+        with pytest.raises(ValueError, match="Replay of this experiment is over"):
+            backend.sample(circuit, 300)


### PR DESCRIPTION
Data saving feature for `Braket` is supported by setting `save_data_while_sampling=True` in `BraketSamplingBackend`.

```python
from numpy import pi
from quri_parts.circuit import QuantumCircuit
from quri_parts.core.sampling import create_sampler_from_sampling_backend

circuit_1 = QuantumCircuit(4)
circuit_1.add_X_gate(0)
circuit_1.add_H_gate(1)
circuit_1.add_Y_gate(2)
circuit_1.add_CNOT_gate(1, 2)
circuit_1.add_RX_gate(3, pi/4)


circuit_2 = QuantumCircuit(4)
circuit_2.add_X_gate(0)
circuit_2.add_H_gate(1)
circuit_2.add_Y_gate(2)
circuit_2.add_CNOT_gate(1, 2)
circuit_2.add_RX_gate(3, pi/8)

qubit_mapping = {0: 3, 1: 2, 2: 0, 3: 1}

backend = BraketSamplingBackend(
    device, qubit_mapping=qubit_mapping, save_data_while_sampling=True
)
sampler = create_sampler_from_sampling_backend(backend)
sampling_result_1 = sampler(circuit_1, 1000)
print(sampling_result_1)
sampling_result_2 = sampler(circuit_2, 10000)
print(sampling_result_2)
```

Replaying experiment is also supported by:
```python
from quri_parts.braket.backend.saved_sampling import BraketSavedDataSamplingBackend

replay_backend = BraketSavedDataSamplingBackend(
    device, backend.jobs_json, qubit_mapping=qubit_mapping
)
replay_sampler = create_sampler_from_sampling_backend(replay_backend)
replay_sampling_result_1 = replay_sampler(circuit_1, 1000)
print(replay_sampling_result_1)
replay_sampling_result_2 = replay_sampler(circuit_2, 10000)
print(replay_sampling_result_2)
```