### PR TITLE
Fix error of tensornetwork

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Run test
         shell: bash
         run: |
-          poetry env use '${{ steps.setup-python.outputs.python-path }}'
+          poetry env use 3.${{ matrix.python-version }}
           poetry run pip install pytest
           if [[ "${{ runner.os }}" = "Linux" ]]; then
               sudo apt install -y libjpeg-dev
@@ -193,7 +193,7 @@ jobs:
           fi
           if [[ "${{ matrix.system.os }}" == "windows-latest" ]]; then
             # We cannot run tests on native Windows, since pyscf does not support it.
-            poetry install -vv --only main --extras qulacs --extras braket --extras qiskit --extras cirq --extras openfermion --extras stim --extras openqasm --extras quantinuum --extras ionq --extras tket --extras qsub
+            poetry install -vv --only main --extras qulacs --extras braket --extras qiskit --extras cirq --extras openfermion --extras stim --extras openqasm --extras quantinuum --extras ionq --extras tket --extras qsub --extras tensornetwork
             poetry run pytest packages --ignore=packages/pyscf --ignore=packages/itensor
           else
             poetry run pytest packages

--- a/packages/circuit/tests/circuit/test_inverse.py
+++ b/packages/circuit/tests/circuit/test_inverse.py
@@ -105,8 +105,14 @@ def _assert_inverse_gates(a: QuantumGate, b: QuantumGate) -> None:
 
 
 def _assert_inverse_circuits(a: QuantumCircuit, b: QuantumCircuit) -> None:
-    assert a == inverse_circuit(b)
-    assert inverse_circuit(a) == b
+    if a != inverse_circuit(b):
+        raise AssertionError(
+            f"a != inverse_circuit(b). {a=}, {b=}, {inverse_circuit(b)=}"
+        )
+    if inverse_circuit(a) != b:
+        raise AssertionError(
+            f"inverse_circuit(a) != b. {a=}, {b=}, {inverse_circuit(a)=}"
+        )
 
 
 def test_inverse_gate() -> None:


### PR DESCRIPTION
In Windows, `tensornetwork-ng` installation fails. (I don't know why it is not occured in main branch)

```
E   ModuleNotFoundError: No module named 'quri_parts.tensornetwork'
E   ModuleNotFoundError: No module named 'tensornetwork'
```