### PR TITLE
fix sign mistake in controll h

### DIFF
--- a/packages/qsub/quri_parts/qsub/lib/std/control.py
+++ b/packages/qsub/quri_parts/qsub/lib/std/control.py
@@ -180,9 +180,9 @@ def controlled_z_resolver(op: Op, repository: SubRepository) -> Sub:
 def controlled_h_resolver(op: Op, repository: SubRepository) -> Sub:
     builder = SubBuilder(op.qubit_count, op.reg_count)
     q0, q1 = builder.qubits
-    builder.add_op(RY(math.pi / 4), (q1,))
-    builder.add_op(CZ, (q0, q1))
     builder.add_op(RY(-math.pi / 4), (q1,))
+    builder.add_op(CZ, (q0, q1))
+    builder.add_op(RY(math.pi / 4), (q1,))
     return builder.build()
 
 

--- a/packages/qsub/tests/lib/std/test_control.py
+++ b/packages/qsub/tests/lib/std/test_control.py
@@ -300,9 +300,9 @@ def test_controlled_h() -> None:
     assert len(sub.aux_registers) == 0
     q0, q1 = sub.qubits
     assert tuple(sub.operations) == (
-        (RY(math.pi / 4), (q1,), ()),
-        (CZ, (q0, q1), ()),
         (RY(-math.pi / 4), (q1,), ()),
+        (CZ, (q0, q1), ()),
+        (RY(math.pi / 4), (q1,), ()),
     )
     assert sub.phase == 0
 


### PR DESCRIPTION
Fix the bug of sign mistake when resolving controlled-h into basis `CZ` and `RY` gates