### PR TITLE
Fix inverse resolution and new Inverse Control resolver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,17 +2,17 @@ name: Test
 
 on:
   pull_request:
-    paths:
-      - packages/**/*.py
-      - packages/**/*.rs
-      - ./**/Cargo.toml
-      - ./**/Cargo.lock
-      - rust/**/*.rs
-      - poetry.lock
-      - .github/workflows/test.yml
-      - .github/actions/python-poetry-install/action.yml
-      - .github/actions/rust-install-cache/action.yml
-      - ./**/*.jl
+    # paths:
+    #   - packages/**/*.py
+    #   - packages/**/*.rs
+    #   - ./**/Cargo.toml
+    #   - ./**/Cargo.lock
+    #   - rust/**/*.rs
+    #   - poetry.lock
+    #   - .github/workflows/test.yml
+    #   - .github/actions/python-poetry-install/action.yml
+    #   - .github/actions/rust-install-cache/action.yml
+    #   - ./**/*.jl
   push:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,17 +2,17 @@ name: Test
 
 on:
   pull_request:
-    # paths:
-    #   - packages/**/*.py
-    #   - packages/**/*.rs
-    #   - ./**/Cargo.toml
-    #   - ./**/Cargo.lock
-    #   - rust/**/*.rs
-    #   - poetry.lock
-    #   - .github/workflows/test.yml
-    #   - .github/actions/python-poetry-install/action.yml
-    #   - .github/actions/rust-install-cache/action.yml
-    #   - ./**/*.jl
+    paths:
+      - packages/**/*.py
+      - packages/**/*.rs
+      - ./**/Cargo.toml
+      - ./**/Cargo.lock
+      - rust/**/*.rs
+      - poetry.lock
+      - .github/workflows/test.yml
+      - .github/actions/python-poetry-install/action.yml
+      - .github/actions/rust-install-cache/action.yml
+      - ./**/*.jl
   push:
     branches: [main]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,14 +155,14 @@ dependencies = [
 
 [[package]]
 name = "quri-parts"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,14 +155,14 @@ dependencies = [
 
 [[package]]
 name = "quri-parts"
-version = "0.22.1"
+version = "0.22.0"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.22.1"
+version = "0.22.0"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/packages/qsub/quri_parts/qsub/lib/std/control.py
+++ b/packages/qsub/quri_parts/qsub/lib/std/control.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from quri_parts.qsub.op import (
     AbstractOp,
-    BaseIdent,
     Ident,
     Op,
     OpFactory,
@@ -387,15 +386,16 @@ def _get_ctrl_inverse_resolver(
         assert isinstance(inner_op, Op)
         return inner_op
 
-    def ctrl_inv_resolver(ctrl_inv_op: Op, repository: SubRepository) -> Sub | None:
-        # ctrl_inv_op is supposed to be Controlled(Inverse(op))
-        inner_op = get_inner_op(ctrl_inv_op)
-        ctrl_sub = ctrl_resolver(Controlled(inner_op), repository)
-        assert ctrl_sub is not None
-        inv_ctrl_sub = get_inverted_sub(ctrl_sub)
-        return inv_ctrl_sub
+    class ControlInvSubResolver(SubResolver):
+        def __call__(self, ctrl_inv_op: Op, repository: SubRepository) -> Sub | None:
+            # ctrl_inv_op is supposed to be Controlled(Inverse(op))
+            inner_op = get_inner_op(ctrl_inv_op)
+            ctrl_sub = ctrl_resolver(Controlled(inner_op), repository)
+            assert ctrl_sub is not None
+            inv_ctrl_sub = get_inverted_sub(ctrl_sub)
+            return inv_ctrl_sub
 
-    return ctrl_inv_resolver
+    return ControlInvSubResolver()
 
 
 def _get_inv_target_condition(op: AbstractOp) -> SubResolverCondition:
@@ -430,7 +430,7 @@ def register_controlled_resolver(
     control_resolver: SubResolver,
     op: Op | OpFactory[Any],
 ) -> None:
-    """ """
+    """"""
     sub_repository.register_sub_resolver(
         Controlled, control_resolver, control_target_condition(op)
     )

--- a/packages/qsub/quri_parts/qsub/lib/std/inverse.py
+++ b/packages/qsub/quri_parts/qsub/lib/std/inverse.py
@@ -95,6 +95,8 @@ def inverse_sub_resolver(op: Op, repository: SubRepository) -> Sub | None:
             io = o
         builder.add_op(io, qubits, regs)
 
+    phase = target_sub.phase
+    builder.add_phase(-phase)
     return builder.build()
 
 
@@ -158,6 +160,17 @@ def inverse_multicontrolled_resolver(op: Op, repository: SubRepository) -> Sub:
     return builder.build()
 
 
+def inverse_inverse_resolver(op: Op, repository: SubRepository) -> Sub:
+    target = op.id.params[0]
+    assert isinstance(target, Op)
+    assert target.base_id == Inverse.base_id
+    inner_op = target.id.params[0]
+    assert isinstance(inner_op, Op)
+    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder.add_op(inner_op, builder.qubits)
+    return builder.build()
+
+
 _repo = default_repository()
 _repo.register_sub_resolver(Inverse, inverse_sub_resolver)
 
@@ -176,6 +189,7 @@ _resolvers: Collection[tuple[AbstractOp, SubResolver]] = [
     (Tdag, _inverse_op_resolver_gen(T)),
     (Controlled, inverse_controlled_resolver),
     (MultiControlled, inverse_multicontrolled_resolver),
+    (Inverse, inverse_inverse_resolver),
 ]
 
 for target, resolver in _resolvers:

--- a/packages/qsub/quri_parts/qsub/lib/std/inverse.py
+++ b/packages/qsub/quri_parts/qsub/lib/std/inverse.py
@@ -20,6 +20,8 @@ from quri_parts.qsub.op import (
     ParamUnitaryDef,
     param_op,
 )
+from quri_parts.qsub.qubit import Qubit
+from quri_parts.qsub.register import Register
 from quri_parts.qsub.resolve import (
     SubRepository,
     SubResolver,
@@ -58,6 +60,41 @@ def _single_op_sub(op: Op) -> Sub:
     return b.build()
 
 
+def _copy_sub_skeleton(
+    target_sub: Sub,
+) -> tuple[SubBuilder, dict[Qubit, Qubit], dict[Register, Register]]:
+    qubit_count = len(target_sub.qubits)
+    reg_count = len(target_sub.registers)
+    builder = SubBuilder(qubit_count, reg_count)
+    target_q = builder.qubits
+    target_aq = tuple(builder.add_aux_qubit() for _ in target_sub.aux_qubits)
+    qubit_map = dict(zip(target_sub.qubits, target_q)) | dict(
+        zip(target_sub.aux_qubits, target_aq)
+    )
+    target_ar = tuple(builder.add_aux_register() for _ in target_sub.aux_registers)
+    reg_map = dict(zip(target_sub.registers, builder.registers)) | dict(
+        zip(target_sub.aux_registers, target_ar)
+    )
+    return builder, qubit_map, reg_map
+
+
+def get_inverted_sub(target_sub: Sub) -> Sub:
+    builder, qubit_map, reg_map = _copy_sub_skeleton(target_sub)
+    for o, qs, rs in reversed(target_sub.operations):
+        qubits = tuple(qubit_map[q] for q in qs)
+        regs = tuple(reg_map[r] for r in rs)
+        if o.self_inverse:
+            io = o
+        elif o.unitary:
+            io = Inverse(o)
+        else:
+            io = o
+        builder.add_op(io, qubits, regs)
+    phase = target_sub.phase
+    builder.add_phase(-phase)
+    return builder.build()
+
+
 def inverse_sub_resolver(op: Op, repository: SubRepository) -> Sub | None:
     target_op = op.id.params[0]
     assert isinstance(target_op, Op)
@@ -71,33 +108,7 @@ def inverse_sub_resolver(op: Op, repository: SubRepository) -> Sub | None:
     if not target_sub:
         return None
 
-    builder = SubBuilder(op.qubit_count, op.reg_count)
-    target_q = builder.qubits
-
-    target_aq = tuple(builder.add_aux_qubit() for _ in target_sub.aux_qubits)
-    qubit_map = dict(zip(target_sub.qubits, target_q)) | dict(
-        zip(target_sub.aux_qubits, target_aq)
-    )
-
-    target_ar = tuple(builder.add_aux_register() for _ in target_sub.aux_registers)
-    reg_map = dict(zip(target_sub.registers, builder.registers)) | dict(
-        zip(target_sub.aux_registers, target_ar)
-    )
-
-    for o, qs, rs in reversed(target_sub.operations):
-        qubits = tuple(qubit_map[q] for q in qs)
-        regs = tuple(reg_map[r] for r in rs)
-        if o.self_inverse:
-            io = o
-        elif o.unitary:
-            io = Inverse(o)
-        else:
-            io = o
-        builder.add_op(io, qubits, regs)
-
-    phase = target_sub.phase
-    builder.add_phase(-phase)
-    return builder.build()
+    return get_inverted_sub(target_sub)
 
 
 def inverse_target_condition(op: AbstractOp) -> SubResolverCondition:

--- a/packages/qsub/tests/lib/std/test_control.py
+++ b/packages/qsub/tests/lib/std/test_control.py
@@ -678,15 +678,14 @@ def test_inverse_optimized_controlled() -> None:
         builder.add_op(Controlled(H), (qs[0], qs[1]))
         return builder.build()
 
-    register_controlled_resolver(default_repository(), controlled_h_cx_h_resolver, HCXH)
+    test_sub_repository = SubRepository()
+    register_controlled_resolver(test_sub_repository, controlled_h_cx_h_resolver, HCXH)
 
-    inv_op = Inverse(Controlled(HCXH))
-    ctrl_inv_sub = resolve_sub(inv_op)
+    inv_op = Controlled(Inverse(HCXH))
+    ctrl_inv_sub = resolve_sub(inv_op, test_sub_repository)
     assert ctrl_inv_sub is not None
-    inv_sub = resolve_sub(ctrl_inv_sub.operations[0][0])
-    assert inv_sub is not None
-    qs = inv_sub.qubits
-    aux_qs = inv_sub.aux_qubits
+    qs = ctrl_inv_sub.qubits
+    aux_qs = ctrl_inv_sub.aux_qubits
     expected_resolved_sub = (
         (Inverse(Controlled(H)), (qs[0], qs[1]), ()),
         (Inverse(Controlled(H)), (qs[0], qs[2]), ()),
@@ -696,4 +695,4 @@ def test_inverse_optimized_controlled() -> None:
         (Inverse(Controlled(H)), (qs[0], qs[2]), ()),
         (Inverse(Controlled(H)), (qs[0], qs[1]), ()),
     )
-    assert tuple(inv_sub.operations) == expected_resolved_sub
+    assert tuple(ctrl_inv_sub.operations) == expected_resolved_sub

--- a/packages/qsub/tests/lib/std/test_control.py
+++ b/packages/qsub/tests/lib/std/test_control.py
@@ -29,7 +29,6 @@ from quri_parts.qsub.lib.std import (
     Z,
 )
 from quri_parts.qsub.lib.std.control import (
-    control_target_condition,
     controlled_sub_resolver,
     register_controlled_resolver,
 )
@@ -648,7 +647,6 @@ def test_controlled_multicontrolled() -> None:
     assert sub.phase == 0
 
 
-
 def test_inverse_optimized_controlled() -> None:
     class _HCXH(OpSubDef):
         name = "HCXH"
@@ -680,9 +678,7 @@ def test_inverse_optimized_controlled() -> None:
         builder.add_op(Controlled(H), (qs[0], qs[1]))
         return builder.build()
 
-    register_controlled_resolver(
-        default_repository(), controlled_h_cx_h_resolver, HCXH
-    )
+    register_controlled_resolver(default_repository(), controlled_h_cx_h_resolver, HCXH)
 
     inv_op = Inverse(Controlled(HCXH))
     ctrl_inv_sub = resolve_sub(inv_op)

--- a/packages/qsub/tests/lib/std/test_control.py
+++ b/packages/qsub/tests/lib/std/test_control.py
@@ -11,6 +11,7 @@ from quri_parts.qsub.lib.std import (
     SWAP,
     Controlled,
     H,
+    Inverse,
     M,
     MultiControlled,
     Phase,
@@ -27,11 +28,16 @@ from quri_parts.qsub.lib.std import (
     Y,
     Z,
 )
-from quri_parts.qsub.lib.std.control import controlled_sub_resolver
+from quri_parts.qsub.lib.std.control import (
+    control_target_condition,
+    controlled_sub_resolver,
+    register_controlled_resolver,
+)
 from quri_parts.qsub.namespace import NameSpace
 from quri_parts.qsub.op import Ident, Op, ParameterValidationError
-from quri_parts.qsub.resolve import SubRepository, default_repository
-from quri_parts.qsub.sub import SubBuilder
+from quri_parts.qsub.opsub import OpSubDef, opsub
+from quri_parts.qsub.resolve import SubRepository, default_repository, resolve_sub
+from quri_parts.qsub.sub import Sub, SubBuilder
 
 
 class TestControlledOp:
@@ -640,3 +646,58 @@ def test_controlled_multicontrolled() -> None:
         (MultiControlled(Y, 4, 0b0101), (q0, q1, q2, q3, q4), ()),
     )
     assert sub.phase == 0
+
+
+
+def test_inverse_optimized_controlled() -> None:
+    class _HCXH(OpSubDef):
+        name = "HCXH"
+        qubit_count = 2
+
+        def sub(self, builder: SubBuilder) -> None:
+            aux_q = builder.add_aux_qubit()
+            qs = builder.qubits
+            builder.add_op(H, (qs[0],))
+            builder.add_op(H, (qs[1],))
+            builder.add_op(CNOT, (qs[1], aux_q))
+            builder.add_op(H, (qs[1],))
+            builder.add_op(H, (qs[0],))
+
+    HCXH, _ = opsub(_HCXH)
+
+    def controlled_h_cx_h_resolver(op: Op, repository: SubRepository) -> Sub:
+        target_op = op.id.params[0]
+        assert isinstance(target_op, Op)
+        builder = SubBuilder(op.qubit_count, op.reg_count)
+        a = builder.add_aux_qubit()
+        qs = builder.qubits
+        builder.add_op(Controlled(H), (qs[0], qs[1]))
+        builder.add_op(Controlled(H), (qs[0], qs[2]))
+        builder.add_op(Controlled(S), (qs[0], qs[1]))
+        builder.add_op(Controlled(S), (qs[0], qs[2]))
+        builder.add_op(CNOT, (qs[2], a))
+        builder.add_op(Controlled(H), (qs[0], qs[2]))
+        builder.add_op(Controlled(H), (qs[0], qs[1]))
+        return builder.build()
+
+    register_controlled_resolver(
+        default_repository(), controlled_h_cx_h_resolver, HCXH
+    )
+
+    inv_op = Inverse(Controlled(HCXH))
+    ctrl_inv_sub = resolve_sub(inv_op)
+    assert ctrl_inv_sub is not None
+    inv_sub = resolve_sub(ctrl_inv_sub.operations[0][0])
+    assert inv_sub is not None
+    qs = inv_sub.qubits
+    aux_qs = inv_sub.aux_qubits
+    expected_resolved_sub = (
+        (Inverse(Controlled(H)), (qs[0], qs[1]), ()),
+        (Inverse(Controlled(H)), (qs[0], qs[2]), ()),
+        (CNOT, (qs[2], aux_qs[0]), ()),
+        (Inverse(Controlled(S)), (qs[0], qs[2]), ()),
+        (Inverse(Controlled(S)), (qs[0], qs[1]), ()),
+        (Inverse(Controlled(H)), (qs[0], qs[2]), ()),
+        (Inverse(Controlled(H)), (qs[0], qs[1]), ()),
+    )
+    assert tuple(inv_sub.operations) == expected_resolved_sub

--- a/poetry.lock
+++ b/poetry.lock
@@ -1173,10 +1173,12 @@ googleapis-common-protos = ">=1.56.2,<2.0.dev0"
 grpcio = [
     {version = ">=1.33.2,<2.0dev", optional = true, markers = "extra == \"grpc\""},
     {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
     {version = ">=1.33.2,<2.0.dev0", optional = true, markers = "extra == \"grpc\""},
     {version = ">=1.49.1,<2.0.dev0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.dev0", optional = true, markers = "extra == \"grpc\""},
 ]
 proto-plus = ">=1.22.3,<2.0.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<6.0.0.dev0"
@@ -3027,9 +3029,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"


### PR DESCRIPTION
- Correct phase inversion
- Add inverse inverse resolver
- Correct resolution error of inverse controlled `Op`s by adding `register_controlled_resolver` function

Current issue: 
We can optimize controlled op if the op takes the form: $O = A^{\dagger} B A$. The optimization is that controlled-O can be implemented by $A^{\dagger} (c-B) A$ so that we don't need to control A. However, when an Op is subjected to this optimization, its inverse still controls the A, leading to inconsistent inverse control. The reason is that we only register how `c-O` is resolved, but whenever there is a `Inverse(Control(O))`, [this resolver](https://github.com/QunaSys/quri-parts/blob/main/packages/qsub/quri_parts/qsub/lib/std/inverse.py#L144) is applied first to change it into `Controlled(Inverse(O))`, then `Inverse(O)` is resolved into smaller ops and the `Controlled` is applied to them individually. The proper order is to apply the optimization resolver first and then invert all the ops.
