### PR TITLE
Better representation of state vectors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1002,6 +1002,27 @@ files = [
 markers = {main = "python_version >= \"3.10\" and sys_platform == \"win32\" or platform_system == \"Windows\" and (extra == \"cirq\" or extra == \"openfermion\")", dev = "platform_system == \"Windows\" or sys_platform == \"win32\"", lint = "platform_system == \"Windows\""}
 
 [[package]]
+name = "colorcet"
+version = "3.1.0"
+description = "Collection of perceptually uniform colormaps"
+optional = true
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "extra == \"colorcet\""
+files = [
+    {file = "colorcet-3.1.0-py3-none-any.whl", hash = "sha256:2a7d59cc8d0f7938eeedd08aad3152b5319b4ba3bcb7a612398cc17a384cb296"},
+    {file = "colorcet-3.1.0.tar.gz", hash = "sha256:2921b3cd81a2288aaf2d63dbc0ce3c26dcd882e8c389cc505d6886bf7aa9a4eb"},
+]
+
+[package.extras]
+all = ["colorcet[doc]", "colorcet[examples]", "colorcet[tests-extra]", "colorcet[tests]"]
+doc = ["colorcet[examples]", "nbsite (>=0.8.4)", "sphinx-copybutton"]
+examples = ["bokeh", "holoviews", "matplotlib", "numpy"]
+tests = ["packaging", "pre-commit", "pytest (>=2.8.5)", "pytest-cov"]
+tests-examples = ["colorcet[examples]", "nbval"]
+tests-extra = ["colorcet[tests]", "pytest-mpl"]
+
+[[package]]
 name = "comm"
 version = "0.2.3"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
@@ -3990,7 +4011,6 @@ files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
 ]
-markers = {main = "(python_version < \"3.14\" or extra == \"cirq\" or extra == \"openfermion\" or extra == \"tket\") and (extra == \"braket\" or extra == \"qiskit\" or extra == \"cirq\" or extra == \"openfermion\" or extra == \"tket\") and (python_version >= \"3.10\" or extra == \"braket\" or extra == \"qiskit\" or extra == \"cirq\" or extra == \"openfermion\")"}
 
 [package.extras]
 develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
@@ -8680,6 +8700,7 @@ type = ["pytest-mypy"]
 [extras]
 braket = ["quri-parts-braket"]
 cirq = ["quri-parts-cirq"]
+colorcet = ["colorcet"]
 ionq = ["quri-parts-ionq"]
 itensor = ["quri-parts-itensor"]
 openfermion = ["quri-parts-openfermion"]
@@ -8697,4 +8718,4 @@ tket = ["quri-parts-tket"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.8"
-content-hash = "36c40739049945d8db2ee25f4a827018cd3d5dddc31e0429281044b3694688e9"
+content-hash = "093ef49f02d21ec230089745caf1bb2266c38d13bfd47f0a4b41a95f72c0f425"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ quri-parts-tensornetwork = { version = "*", optional = true }
 quri-parts-tket = { version = "*", optional = true, python = ">=3.10" }
 quri-parts-qsub = { version = "*", optional = true, python = ">=3.10" }
 quri-parts-qret = { version = "*", optional = true, python = ">=3.10" }
+colorcet = { version = "^3.1.0", optional = true }
+mpmath = "^1.3.0"
 
 [tool.poetry.extras]
 qulacs = ["quri-parts-qulacs"]
@@ -63,6 +65,7 @@ tket = ["quri-parts-tket"]
 tensornetwork = ["quri-parts-tensornetwork"]
 qsub = ["quri-parts-qsub"]
 qret = ["quri-parts-qret"]
+colorcet = ["colorcet"]
 
 [tool.poetry.group.dev.dependencies]
 quri-algo = { path = "quri-algo", develop = true, python = ">=3.10" }

--- a/quri-parts/packages/core/pyproject.toml
+++ b/quri-parts/packages/core/pyproject.toml
@@ -34,6 +34,7 @@ numpy = [
     { version = ">=2.1.0", markers = "python_version == '3.13'" },
     { version = ">=1.22.0,<2.0", markers = "python_version != '3.13'" },
 ]
+mpmath = "^1.3.0"
 quri-parts-circuit = "*"
 quri-parts-qulacs = "*"
 scipy = "^1.11.3"

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -209,6 +209,15 @@ def _format_component_latex(val: float, precision: int) -> str:
     return f"{val:.{precision}g}"
 
 
+def _count_additive_terms(node: ast.AST) -> int:
+    """Count the number of additive terms in an expression AST."""
+    if isinstance(node, ast.BinOp) and isinstance(node.op, (ast.Add, ast.Sub)):
+        return _count_additive_terms(node.left) + _count_additive_terms(node.right)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return _count_additive_terms(node.operand)
+    return 1
+
+
 def _identify_component_latex(val: float, precision: int) -> Optional[str]:
     """Try to express the value symbolically and convert to LaTeX."""
     try:
@@ -230,6 +239,9 @@ def _identify_component_latex(val: float, precision: int) -> Optional[str]:
     try:
         tree = ast.parse(expr, mode="eval")
     except Exception:
+        return None
+
+    if _count_additive_terms(tree.body) > 3:
         return None
 
     try:

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -505,8 +505,10 @@ def _draw_shaded_cylinder(
     radius: float,
     color: Any,
 ) -> None:
-    """Draw a shaded cylinder from the origin to *end* with the given RGBA
-    *color*."""
+    """Draw a shaded cylinder from the origin to *end* with the given RGBA.
+
+    *color*.
+    """
     sx, sy, sz = end
     length = float(np.sqrt(sx**2 + sy**2 + sz**2))
     if length < 1e-10:
@@ -538,8 +540,10 @@ def _draw_shaded_sphere(
     radius: float,
     color: Any,
 ) -> None:
-    """Draw a small shaded sphere surface at *center* with the given RGBA
-    *color*."""
+    """Draw a small shaded sphere surface at *center* with the given RGBA.
+
+    *color*.
+    """
     u = np.linspace(0, 2 * np.pi, 20)
     v = np.linspace(0, np.pi, 10)
     cx, cy, cz = center

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -8,10 +8,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from abc import ABC
-from typing import TYPE_CHECKING, Optional, Union, cast
+from math import comb
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import numpy as np
+from numpy.typing import NDArray
 from typing_extensions import TypeAlias
 
 from quri_parts.circuit.circuit import GateSequence, ImmutableQuantumCircuit
@@ -48,6 +51,60 @@ class QuantumStateVectorMixin(ABC):
     def vector(self) -> StateVectorType:
         return readonly_array(self._vector)
 
+    def draw(
+        self,
+        output: str = "text",
+        *,
+        max_terms: int = 16,
+        threshold: float = 1e-10,
+        precision: int = 6,
+    ) -> Any:
+        """Render the statevector.
+
+        Args:
+            output: One of ``"text"``, ``"latex_source"``, ``"latex"``,
+                ``"qsphere"``, ``"density_matrix"``, or ``"bloch_vector"``. The ``"latex"`` option
+                wraps the source in :class:`IPython.display.Latex` when IPython
+                is available; otherwise the raw string is returned. The
+                visualization options return a Matplotlib figure.
+            max_terms: Maximum number of non-negligible terms to include. The rest
+                are truncated.
+            threshold: Terms with magnitude below this value are treated as 0.
+            precision: Significant digits used for amplitudes/probabilities.
+        """
+        _warn_if_circuit_present(self)
+
+        fmt = output.lower()
+        if fmt not in {
+            "text",
+            "latex",
+            "latex_source",
+            "qsphere",
+            "density_matrix",
+            "bloch_vector",
+        }:
+            raise ValueError(f"Unsupported output format: {output}")
+
+        terms = _significant_terms(self._vector, threshold)
+        n_qubits = int(np.log2(self._dim))
+
+        if fmt == "text":
+            return _draw_text(terms, n_qubits, max_terms, precision)
+        if fmt == "qsphere":
+            return _draw_qsphere(self._vector, n_qubits, precision)
+        if fmt == "density_matrix":
+            return _draw_density_matrix(self._vector, n_qubits, precision)
+        if fmt == "bloch_vector":
+            return _draw_bloch_vector(self._vector, n_qubits)
+        latex_src = _draw_latex(terms, n_qubits, max_terms, precision)
+        if fmt == "latex_source":
+            return latex_src
+        return _to_ipython_latex(latex_src)
+
+    def _repr_latex_(self) -> str:
+        # Wrap in $$ so Jupyter renders math; keep it short with truncation defaults
+        return f"$$ {self.draw(output='latex_source')} $$"
+
 
 class QuantumStateVector(
     QuantumStateVectorMixin, CircuitQuantumStateMixin, QuantumState
@@ -82,3 +139,484 @@ class QuantumStateVector(
         """
         circuit = self._circuit + gates
         return QuantumStateVector(self._n_qubits, self.vector, circuit)
+
+
+def _warn_if_circuit_present(state: object) -> None:
+    """Warn if draw() is called while a circuit with gates is attached.
+
+    QuantumStateVector stores amplitudes directly; attached circuits are
+    ignored during rendering to avoid accidentally suggesting that gates
+    are applied.
+    """
+    circuit = getattr(state, "_circuit", None)
+    gates = getattr(circuit, "gates", None)
+    if gates and len(gates) > 0:
+        warnings.warn(
+            "draw() renders the stored state vector and ignores any attached circuit.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def _format_complex_text(val: complex, precision: int) -> str:
+    real = val.real
+    imag = val.imag
+    real_zero = np.isclose(real, 0.0, atol=10 ** (-(precision + 2)))
+    imag_zero = np.isclose(imag, 0.0, atol=10 ** (-(precision + 2)))
+
+    parts: list[str] = []
+    if not real_zero:
+        parts.append(f"{real:.{precision}g}")
+    if not imag_zero:
+        sign = "+" if imag >= 0 and parts else ""
+        parts.append(f"{sign}{imag:.{precision}g}j")
+    if not parts:
+        return "0"
+    return "".join(parts)
+
+
+def _format_complex_latex(val: complex, precision: int) -> str:
+    real = val.real
+    imag = val.imag
+    real_zero = np.isclose(real, 0.0, atol=10 ** (-(precision + 2)))
+    imag_zero = np.isclose(imag, 0.0, atol=10 ** (-(precision + 2)))
+
+    parts: list[str] = []
+    if not real_zero:
+        parts.append(_format_component_latex(real, precision))
+    if not imag_zero:
+        sign = "+" if imag >= 0 and parts else ""
+        imag_str = _format_component_latex(imag, precision)
+        parts.append(f"{sign}{imag_str}i")
+    if not parts:
+        return "0"
+    if len(parts) > 1:
+        return f"({''.join(parts)})"
+    return "".join(parts)
+
+
+def _format_component_latex(val: float, precision: int) -> str:
+    """Render a real component with a few common symbolic forms."""
+    common = {
+        (1 / np.sqrt(2)): r"\frac{1}{\sqrt{2}}",
+        -(1 / np.sqrt(2)): r"-\frac{1}{\sqrt{2}}",
+        np.pi / 2: r"\frac{\pi}{2}",
+        -np.pi / 2: r"-\frac{\pi}{2}",
+        np.pi / 4: r"\frac{\pi}{4}",
+        -np.pi / 4: r"-\frac{\pi}{4}",
+        np.pi / 6: r"\frac{\pi}{6}",
+        -np.pi / 6: r"-\frac{\pi}{6}",
+        np.pi / 8: r"\frac{\pi}{8}",
+        -np.pi / 8: r"-\frac{\pi}{8}",
+    }
+    for k, v in common.items():
+        if np.isclose(val, k, atol=10 ** (-(precision + 2))):
+            return v
+    return f"{val:.{precision}g}"
+
+
+def _significant_terms(
+    vector: StateVectorType, threshold: float
+) -> list[tuple[int, complex]]:
+    idxs = np.where(np.abs(vector) > threshold)[0]
+    terms = [(int(idx), complex(vector[idx])) for idx in idxs]
+    # Sort by magnitude descending, then by index for determinism
+    terms.sort(key=lambda t: (-abs(t[1]), t[0]))
+    return terms
+
+
+def _draw_text(
+    terms: list[tuple[int, complex]],
+    n_qubits: int,
+    max_terms: int,
+    precision: int,
+) -> str:
+    if not terms:
+        return "0"
+
+    rendered = []
+    for idx, amp in terms[:max_terms]:
+        bitstr = format(idx, f"0{n_qubits}b")
+        prob = abs(amp) ** 2
+        rendered.append(
+            f"|{bitstr}> amp={_format_complex_text(amp, precision)} "
+            f"prob={prob:.{precision}g}"
+        )
+    if len(terms) > max_terms:
+        truncated = len(terms) - max_terms
+        rendered.append(f"... ({truncated} terms truncated)")
+    return "\n".join(rendered)
+
+
+def _draw_latex(
+    terms: list[tuple[int, complex]],
+    n_qubits: int,
+    max_terms: int,
+    precision: int,
+) -> str:
+    if not terms:
+        return "0"
+
+    rendered = []
+    for idx, amp in terms[:max_terms]:
+        bitstr = format(idx, f"0{n_qubits}b")
+        rendered.append(f"{_format_complex_latex(amp, precision)}" f"|{bitstr}\\rangle")
+    if len(terms) > max_terms:
+        rendered.append(r"\cdots")
+    return " + ".join(rendered)
+
+
+def _to_ipython_latex(latex_str: str) -> Any:
+    """Wrap LaTeX source for IPython display if available."""
+    try:
+        from IPython.display import Latex
+
+        return Latex(f"$${latex_str}$$")
+    except Exception:
+        return latex_str
+
+
+def _is_mpl_in_inline_mode() -> bool:
+    from matplotlib import get_backend
+
+    return get_backend() in ["nbAgg", "module://matplotlib_inline.backend_inline"]
+
+
+def _draw_qsphere(
+    vector: StateVectorType, n_qubits: int, precision: int
+) -> Any:  # pragma: no cover - visual
+    try:
+        import matplotlib.pyplot as plt
+    except Exception as e:  # pragma: no cover - import guard
+        raise ImportError(
+            "Matplotlib is required for 'qsphere' output. Install matplotlib to enable."
+        ) from e
+    try:
+        import colorcet as cc  # type: ignore[import-untyped]
+
+        cmap = cc.m_cyclic_mybm_20_100_c48
+        # cmap = plt.get_cmap("hsv")
+    except Exception:  # pragma: no cover - import guard
+        cmap = plt.get_cmap("hsv")
+
+    from matplotlib.colors import Normalize
+
+    fig = plt.figure(figsize=(5, 4))
+    ax = cast(Any, fig.add_subplot(111, projection="3d"))
+
+    probs = np.abs(vector) ** 2
+    phases = np.angle(vector)
+    phase_norm = Normalize(vmin=-np.pi, vmax=np.pi)
+
+    # sphere grid
+    u = np.linspace(0, 2 * np.pi, 25)
+    v = np.linspace(0, np.pi, 25)
+    xs = np.outer(np.cos(u), np.sin(v))
+    ys = np.outer(np.sin(u), np.sin(v))
+    zs = np.outer(np.ones_like(u), np.cos(v))
+    ax.plot_surface(xs, ys, zs, color="lightgray", alpha=0.2, linewidth=0)
+
+    top_indices = np.argsort(probs)[::-1]
+    for i in top_indices:
+        if probs[i] < 1e-12:
+            continue
+        bitstr = format(i, f"0{n_qubits}b")
+        x, y, z = _qsphere_coordinates(bitstr, n_qubits)
+        color = (phases[i] + 11 / 8 * np.pi) % (2 * np.pi) - np.pi
+        size = max(20, 800 * probs[i])
+
+        ax.scatter(
+            [x],
+            [y],
+            [z],
+            s=size,
+            c=[color],
+            linewidth=0.0,
+            cmap=cmap,
+            norm=phase_norm,
+        )
+        ax.scatter(
+            [x],
+            [y],
+            [z],
+            s=1.0,
+            c="black",
+        )
+
+        ax.text(
+            1.3 * x,
+            1.3 * y,
+            1.3 * z,
+            f"$|{bitstr}\\rangle$",
+            ha="center",
+            va="center",
+            fontsize=8,
+            color="black",
+        )
+
+    # Add dashed latitude circles at Hamming-weight bands
+    for weight in range(n_qubits + 1):
+        z = -2 * weight / n_qubits + 1
+        r = np.sqrt(max(0.0, 1 - z**2))
+        theta = np.linspace(-2 * np.pi, 2 * np.pi, 200)
+        lat_x = r * np.cos(theta)
+        lat_y = r * np.sin(theta)
+        lat_z = np.full_like(theta, z)
+        ax.plot(lat_x, lat_y, lat_z, color="gray", lw=0.8, ls=":", alpha=0.5)
+
+    # Phase color bar with pi/4 ticks
+    mappable = plt.cm.ScalarMappable(cmap=cmap, norm=phase_norm)
+    mappable.set_array([])
+    cbar = fig.colorbar(mappable, ax=ax, shrink=0.6, pad=0.05)
+    ticks = [
+        -np.pi,
+        -3 * np.pi / 4,
+        -np.pi / 2,
+        -np.pi / 4,
+        0,
+        np.pi / 4,
+        np.pi / 2,
+        3 * np.pi / 4,
+        np.pi,
+    ]
+    cbar.set_ticks(ticks)
+    cbar.set_ticklabels(
+        [
+            r"$-\pi$",
+            r"$-3\pi/4$",
+            r"$-\pi/2$",
+            r"$-\pi/4$",
+            r"$0$",
+            r"$\pi/4$",
+            r"$\pi/2$",
+            r"$3\pi/4$",
+            r"$\pi$",
+        ]
+    )
+    cbar.set_label("Phase", rotation=270, labelpad=15)
+
+    # Keep perspective level with the equator and aspect spherical
+    ax.view_init(elev=5, azim=90)
+    ax.set_box_aspect((1, 1, 1))
+    ax.set_xlim([-1, 1])
+    ax.set_ylim([-1, 1])
+    ax.set_zlim([-1, 1])
+
+    ax.set_axis_off()
+    fig.tight_layout()
+
+    if _is_mpl_in_inline_mode():
+        plt.close(fig)
+    return fig
+
+
+def _draw_density_matrix(
+    vector: StateVectorType, n_qubits: int, precision: int
+) -> Any:  # pragma: no cover - visual
+    try:
+        import matplotlib.pyplot as plt
+        from matplotlib.patches import Rectangle
+    except Exception as e:  # pragma: no cover - import guard
+        raise ImportError(
+            "Matplotlib is required for 'density_matrix' output. Install matplotlib to enable."
+        ) from e
+
+    rho = np.outer(vector, np.conjugate(vector))
+    dim = rho.shape[0]
+    max_abs = np.max(np.abs(rho)) or 1.0
+
+    fig, axes = plt.subplots(1, 2, figsize=(9, 4))
+    labels = [format(i, f"0{n_qubits}b") for i in range(dim)]
+
+    def _hinton(ax: Any, data: NDArray[Any], title: str) -> None:
+        ax.patch.set_facecolor("gray")
+        ax.set_aspect("equal", "box")
+        ax.set_xticks(np.arange(dim) + 0.5)
+        ax.set_yticks(np.arange(dim) + 0.5)
+        ax.set_xticklabels([f"$|{label}\\rangle$" for label in labels])
+        ax.set_yticklabels([f"$|{label}\\rangle$" for label in labels])
+        ax.set_xlim(0, dim)
+        ax.set_ylim(0, dim)
+        ax.set_title(title)
+        for (r, c), val in np.ndenumerate(data[::-1, :]):
+            magnitude = np.sqrt(abs(val) / max_abs)
+            if magnitude == 0:
+                continue
+            plot_x, plot_y = c + 0.5, r + 0.5
+            color = "white" if val.real >= 0 else "black"
+            rect = Rectangle(
+                (plot_x - magnitude / 2, plot_y - magnitude / 2),
+                magnitude,
+                magnitude,
+                facecolor=color,
+                edgecolor=color,
+            )
+            ax.add_patch(rect)
+
+    _hinton(axes[0], rho.real, "Re[ρ]")
+    _hinton(axes[1], rho.imag, "Im[ρ]")
+
+    fig.tight_layout()
+    if _is_mpl_in_inline_mode():
+        plt.close(fig)
+    return fig
+
+
+def _draw_bloch_vector(
+    vector: StateVectorType, n_qubits: int
+) -> Any:  # pragma: no cover - visual
+    try:
+        import matplotlib.pyplot as plt
+    except Exception as e:  # pragma: no cover - import guard
+        raise ImportError("Matplotlib is required for 'bloch_vector' output.") from e
+
+    bloch_vecs = _bloch_vectors_from_state(vector, n_qubits)
+    cols = min(4, n_qubits)
+    rows = int(np.ceil(n_qubits / cols))
+    fig, axes = plt.subplots(
+        rows, cols, subplot_kw={"projection": "3d"}, figsize=(cols * 4, rows * 4)
+    )
+    axes_list = cast(Any, np.atleast_1d(axes).flatten())
+
+    for idx, bloch_vec in enumerate(bloch_vecs):
+        ax = cast(Any, axes_list[idx])
+        ax.view_init(elev=25, azim=30)
+        _render_bloch_vector(ax, bloch_vec)
+        ax.set_title(f"Qubit {idx}", fontsize=10)
+
+        # Equator and longitude markers
+        theta = np.linspace(0, 2 * np.pi, 400)
+        for phi in [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4]:
+            eq_x = np.cos(theta) * np.sin(phi)
+            eq_y = np.sin(theta) * np.sin(phi)
+            eq_z = np.ones_like(theta) * np.cos(phi)
+            ax.plot(eq_x, eq_y, eq_z, color="gray", lw=0.8, ls=":", alpha=0.7)
+
+        for phi in [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4]:
+            lon_x = np.cos(phi) * np.sin(theta)
+            lon_y = np.sin(phi) * np.sin(theta)
+            lon_z = np.cos(theta)
+            ax.plot(lon_x, lon_y, lon_z, color="gray", lw=0.8, ls=":", alpha=0.7)
+
+    # Hide unused subplots
+    for ax in axes_list[len(bloch_vecs) :]:
+        ax.set_visible(False)
+
+    fig.tight_layout()
+    if _is_mpl_in_inline_mode():
+        plt.close(fig)
+    return fig
+
+
+def _qsphere_coordinates(bitstr: str, n_qubits: int) -> tuple[float, float, float]:
+    """Position basis states on a sphere."""
+    weight = bitstr.count("1")
+    z = -2 * weight / n_qubits + 1
+    num_divisions = comb(n_qubits, weight) if weight else 1
+    order = _bit_string_index(bitstr)
+    angle = (weight / n_qubits) * (2 * np.pi) + (order * 2 * (np.pi / num_divisions))
+    if (weight > n_qubits / 2) or (
+        weight == n_qubits / 2 and order >= num_divisions / 2
+    ):
+        angle = np.pi - angle - (2 * np.pi / num_divisions)
+
+    r = np.sqrt(max(0.0, 1 - z**2))
+    x = r * np.cos(angle)
+    y = r * np.sin(angle)
+    return x, y, z
+
+
+def _bit_string_index(bitstr: str) -> int:
+    """Lexicographic index among strings with the same Hamming weight."""
+    n = len(bitstr)
+    ones = [pos for pos, char in enumerate(bitstr) if char == "1"]
+    k = len(ones)
+    dualm = sum(comb(n - 1 - ones[k - 1 - i], i + 1) for i in range(k))
+    return int(dualm)
+
+
+def _bloch_vectors_from_state(
+    vector: StateVectorType, n_qubits: int
+) -> list[tuple[float, float, float]]:
+    """Compute single-qubit Bloch vectors for each qubit of a pure
+    statevector."""
+    vec = np.asarray(vector, dtype=np.complex128)
+    dim = len(vec)
+    if dim != 2**n_qubits:
+        raise ValueError("Statevector dimension does not match qubit count.")
+
+    bloch_vecs: list[tuple[float, float, float]] = []
+    for q in range(n_qubits):
+        sx = 0.0
+        sy = 0.0
+        sz = 0.0
+        mask = 1 << q
+        for idx in range(dim):
+            amp = vec[idx]
+            if idx & mask:
+                sz -= abs(amp) ** 2
+            else:
+                sz += abs(amp) ** 2
+                partner = idx | mask
+                partner_amp = vec[partner]
+                prod = np.conjugate(amp) * partner_amp
+                sx += 2 * np.real(prod)
+                sy += 2 * np.imag(prod)
+        bloch_vecs.append((sx, sy, sz))
+    return bloch_vecs
+
+
+def _render_bloch_vector(ax: Any, bloch_vec: tuple[float, float, float]) -> None:
+    """Render a single Bloch vector on a unit sphere."""
+    from matplotlib.patches import FancyArrowPatch
+    from mpl_toolkits.mplot3d import proj3d  # type: ignore[import-untyped]
+
+    # Draw sphere surface
+    u = np.linspace(0, 2 * np.pi, 30)
+    v = np.linspace(0, np.pi, 15)
+    x = np.outer(np.cos(u), np.sin(v))
+    y = np.outer(np.sin(u), np.sin(v))
+    z = np.outer(np.ones_like(u), np.cos(v))
+    ax.plot_surface(
+        x, y, z, rstride=1, cstride=1, color="lightgray", alpha=0.2, linewidth=0
+    )
+
+    # Axes lines
+    ax.plot([-1, 1], [0, 0], [0, 0], color="grey", linewidth=1)
+    ax.plot([0, 0], [-1, 1], [0, 0], color="grey", linewidth=1)
+    ax.plot([0, 0], [0, 0], [-1, 1], color="grey", linewidth=1)
+    ax.text(1.3, 0, 0, "X", color="grey")
+    ax.text(0, 1.1, 0, "Y", color="grey")
+    ax.text(0, 0, 1.1, "Z", color="grey")
+
+    class Arrow3D(FancyArrowPatch):
+        def __init__(
+            self, xs: Any, ys: Any, zs: Any, *args: Any, **kwargs: Any
+        ) -> None:
+            super().__init__((0, 0), (0, 0), *args, **kwargs)
+            self._verts3d = xs, ys, zs
+
+        def do_3d_projection(self, renderer: Any = None) -> float:
+            xs3d, ys3d, zs3d = self._verts3d
+            axes = cast(Any, self.axes)
+            xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, axes.M)
+            self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
+            return float(np.min(zs))
+
+    sx, sy, sz = bloch_vec
+    arrow = Arrow3D(
+        [0, sx],
+        [0, sy],
+        [0, sz],
+        mutation_scale=20,
+        lw=5,
+        arrowstyle="-|>",
+        color="darkblue",
+    )
+    ax.add_artist(arrow)
+
+    ax.set_xlim([-0.8, 0.8])
+    ax.set_ylim([-0.8, 0.8])
+    ax.set_zlim([-0.8, 0.8])
+    ax.set_box_aspect((1, 1, 1))
+    ax.set_axis_off()

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -455,6 +455,79 @@ def _to_ipython_latex(latex_str: str) -> Any:
         return latex_str
 
 
+def _light_source() -> Any:
+    from matplotlib.colors import LightSource
+
+    return LightSource(azdeg=45, altdeg=45)
+
+
+def _draw_shaded_cylinder(
+    ax: Any,
+    end: tuple[float, float, float],
+    radius: float,
+    color: Any,
+) -> None:
+    """Draw a shaded cylinder from the origin to *end* with the given RGBA *color*."""
+    sx, sy, sz = end
+    length = float(np.sqrt(sx**2 + sy**2 + sz**2))
+    if length < 1e-10:
+        return
+
+    theta = np.linspace(0, 2 * np.pi, 20)
+    r_grid, theta_grid = np.meshgrid([radius, radius], theta)
+    z_grid = np.tile([0.0, length], (len(theta), 1))
+    x_grid = radius * np.cos(theta_grid)
+    y_grid = radius * np.sin(theta_grid)
+
+    polar = float(np.arccos(np.clip(sz / length, -1.0, 1.0)))
+    azimuth = float(np.arctan2(sx, -sy))
+    rot_x = np.array([
+        [1, 0, 0],
+        [0, np.cos(polar), -np.sin(polar)],
+        [0, np.sin(polar), np.cos(polar)],
+    ])
+    rot_z = np.array([
+        [np.cos(azimuth), -np.sin(azimuth), 0],
+        [np.sin(azimuth), np.cos(azimuth), 0],
+        [0, 0, 1],
+    ])
+    pts = np.c_[x_grid.flatten(), y_grid.flatten(), z_grid.flatten()].T
+    rotated = (rot_z @ rot_x @ pts).T
+    ax.plot_surface(
+        rotated[:, 0].reshape(z_grid.shape),
+        rotated[:, 1].reshape(z_grid.shape),
+        rotated[:, 2].reshape(z_grid.shape),
+        color=color,
+        alpha=0.7,
+        linewidth=0,
+        shade=True,
+        lightsource=_light_source(),
+    )
+
+
+def _draw_shaded_sphere(
+    ax: Any,
+    center: tuple[float, float, float],
+    radius: float,
+    color: Any,
+) -> None:
+    """Draw a small shaded sphere surface at *center* with the given RGBA *color*."""
+    u = np.linspace(0, 2 * np.pi, 20)
+    v = np.linspace(0, np.pi, 10)
+    cx, cy, cz = center
+    x = cx + radius * np.outer(np.cos(u), np.sin(v))
+    y = cy + radius * np.outer(np.sin(u), np.sin(v))
+    z = cz + radius * np.outer(np.ones_like(u), np.cos(v))
+    ax.plot_surface(
+        x, y, z,
+        color=color,
+        alpha=0.95,
+        linewidth=0,
+        shade=True,
+        lightsource=_light_source(),
+    )
+
+
 def _is_mpl_in_inline_mode() -> bool:
     from matplotlib import get_backend
 
@@ -502,18 +575,11 @@ def _draw_qsphere(
         bitstr = format(i, f"0{n_qubits}b")
         x, y, z = _qsphere_coordinates(bitstr, n_qubits)
         color = (phases[i] + 2 * np.pi) % (2 * np.pi)
-        size = max(20, 800 * probs[i])
+        rgba = cmap(phase_norm(color))
+        radius = 0.1 * np.sqrt(probs[i])
+        _draw_shaded_cylinder(ax, (x, y, z), radius * 0.3, rgba)
+        _draw_shaded_sphere(ax, (x, y, z), radius, rgba)
 
-        ax.scatter(
-            [x],
-            [y],
-            [z],
-            s=size,
-            c=[color],
-            linewidth=0.0,
-            cmap=cmap,
-            norm=phase_norm,
-        )
 
         ax.text(
             1.3 * x,
@@ -852,8 +918,6 @@ def _bloch_arrow_surface(
     )
     pts = np.c_[x_grid.flatten(), y_grid.flatten(), z_grid.flatten()].T
     rotated = (rot_z @ rot_x @ pts).T
-    from matplotlib.colors import LightSource
-
     ax.plot_surface(
         rotated[:, 0].reshape(r_grid.shape),
         rotated[:, 1].reshape(r_grid.shape),
@@ -862,7 +926,7 @@ def _bloch_arrow_surface(
         alpha=0.9,
         linewidth=0,
         shade=True,
-        lightsource=LightSource(azdeg=45, altdeg=-45),
+        lightsource=_light_source(),
     )
 
 
@@ -875,7 +939,7 @@ def _render_bloch_vector(ax: Any, bloch_vec: tuple[float, float, float]) -> None
     y = np.outer(np.sin(u), np.sin(v))
     z = np.outer(np.ones_like(u), np.cos(v))
     ax.plot_surface(
-        x, y, z, rstride=1, cstride=1, color="lightgray", alpha=0.2, linewidth=0
+        x, y, z, rstride=1, cstride=1, color="lightgray", alpha=0.2, linewidth=0, 
     )
 
     _bloch_arrow_surface(ax, bloch_vec)

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -637,23 +637,81 @@ def _draw_bloch_vector(
         ax.plot([-1, 1], [0, 0], [0, 0], color="grey", linewidth=1)
         ax.plot([0, 0], [-1, 1], [0, 0], color="grey", linewidth=1)
         ax.plot([0, 0], [0, 0], [-1, 1], color="grey", linewidth=1)
-        ax.text(1.3, 0, 0, "X", color="grey")
-        ax.text(0, 1.1, 0, "Y", color="grey")
-        ax.text(0, 0, 1.1, "Z", color="grey")
+        ax.text(1.1, 0.0, 0.1, "X", color="grey")
+        ax.text(0.0, 1.0, 0.1, "Y", color="grey")
+        ax.text(0.0, -0.05, 1.05, "Z", color="grey")
 
-        # Equator and longitude markers
+        # Equator and 90-degree meridians as reference
         theta = np.linspace(0, 2 * np.pi, 400)
-        for phi in [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4]:
-            eq_x = np.cos(theta) * np.sin(phi)
-            eq_y = np.sin(theta) * np.sin(phi)
-            eq_z = np.ones_like(theta) * np.cos(phi)
-            ax.plot(eq_x, eq_y, eq_z, color="gray", lw=0.8, ls=":", alpha=0.7)
+        ax.plot(
+            np.cos(theta),
+            np.sin(theta),
+            np.zeros_like(theta),
+            color="gray",
+            lw=0.8,
+            ls=":",
+            alpha=0.5,
+        )
+        t = np.linspace(0, np.pi, 400)
+        for phi in [0, np.pi / 2, np.pi, 3 * np.pi / 2]:
+            ax.plot(
+                np.cos(phi) * np.sin(t),
+                np.sin(phi) * np.sin(t),
+                np.cos(t),
+                color="gray",
+                lw=0.8,
+                ls=":",
+                alpha=0.7,
+            )
 
-        for phi in [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4]:
-            lon_x = np.cos(phi) * np.sin(theta)
-            lon_y = np.sin(phi) * np.sin(theta)
-            lon_z = np.cos(theta)
-            ax.plot(lon_x, lon_y, lon_z, color="gray", lw=0.8, ls=":", alpha=0.7)
+        # Latitude circle and meridian at the Bloch vector position
+        sx, sy, sz = bloch_vec
+        magnitude = np.sqrt(sx**2 + sy**2 + sz**2)
+        if magnitude > 1e-6:
+            phi = np.arctan2(sy, sx)
+            polar_angle = np.arccos(np.clip(sz / magnitude, -1.0, 1.0))
+            theta = np.linspace(0, 2 * np.pi, 400)
+            ax.plot(
+                np.cos(theta) * np.sin(polar_angle),
+                np.sin(theta) * np.sin(polar_angle),
+                np.full_like(theta, np.cos(polar_angle)),
+                color="orange",
+                lw=0.8,
+                ls="-",
+                alpha=0.6,
+            )
+            
+            t = np.linspace(0., np.pi, 200)
+            ax.plot(
+                np.cos(phi) * np.sin(t),
+                np.sin(phi) * np.sin(t),
+                np.cos(t),
+                color="orange",
+                lw=0.8,
+                ls="-",
+                alpha=0.6,
+            )
+
+            t = np.linspace(0., 1., 200)
+            ax.plot(
+                t * sx / magnitude,
+                t * sy / magnitude,
+                t * sz / magnitude,
+                color="orange",
+                lw=0.8,
+                ls="--",
+                alpha=0.6,
+            )
+
+            ax.scatter(
+                np.cos(phi) * np.sin(polar_angle),
+                np.sin(phi) * np.sin(polar_angle),
+                np.cos(polar_angle),
+                color="orange",
+                lw=0.8,
+                ls="-",
+                alpha=0.6,
+            )
 
     # Hide unused subplots
     for ax in axes_list[len(bloch_vecs) :]:
@@ -723,11 +781,81 @@ def _bloch_vectors_from_state(
     return bloch_vecs
 
 
+def _bloch_arrow_surface(
+    ax: Any,
+    direction: tuple[float, float, float],
+    width: float = 0.03,
+    head_fraction: float = 0.2,
+    head_width: float = 2.5,
+    color: str = "orange",
+) -> None:
+    """Draw a 3D arrow as a surface of revolution pointing in *direction*.
+
+    The arrow tip lands exactly at *direction* (which doubles as the endpoint),
+    and the surface participates in matplotlib's z-ordering so it is correctly
+    occluded by the sphere when pointing away from the viewer.
+    """
+    sx, sy, sz = direction
+    length = float(np.sqrt(sx**2 + sy**2 + sz**2))
+    if length < 1e-10:
+        return
+
+    # Head scales sublinearly with arrow length (exponent < 1) so it stays
+    # relatively larger for short arrows.  Capped so it never exceeds the
+    # total arrow length.
+    nominal_head_length = head_fraction  # absolute size at length == 1
+    nominal_head_radius = head_width * width
+    scale = (length+2.) / 3.  # sublinear: shrinks slower than the arrow
+    actual_head_length = min(length, nominal_head_length * scale)
+    actual_head_radius = nominal_head_radius * scale
+    shaft_length = length - actual_head_length
+    shaft_width = scale * width
+
+    # 2-D profile (radius, height) defining shaft + cone head
+    profile_r = np.array([0, shaft_width, shaft_width, actual_head_radius, 0])
+    profile_z = np.array([0, 0, shaft_length, shaft_length, length])
+
+    theta = np.linspace(0, 2 * np.pi, 30)
+    r_grid, theta_grid = np.meshgrid(profile_r, theta)
+    z_grid = np.tile(profile_z, (len(theta), 1))
+    x_grid = r_grid * np.sin(theta_grid)
+    y_grid = r_grid * np.cos(theta_grid)
+
+    # Rotate the z-aligned arrow to point along (sx, sy, sz)
+    polar = float(np.arccos(np.clip(sz / length, -1.0, 1.0)))
+    azimuth = float(np.arctan2(sx, -sy))
+    rot_x = np.array(
+        [
+            [1, 0, 0],
+            [0, np.cos(polar), -np.sin(polar)],
+            [0, np.sin(polar), np.cos(polar)],
+        ]
+    )
+    rot_z = np.array(
+        [
+            [np.cos(azimuth), -np.sin(azimuth), 0],
+            [np.sin(azimuth), np.cos(azimuth), 0],
+            [0, 0, 1],
+        ]
+    )
+    pts = np.c_[x_grid.flatten(), y_grid.flatten(), z_grid.flatten()].T
+    rotated = (rot_z @ rot_x @ pts).T
+    from matplotlib.colors import LightSource
+
+    ax.plot_surface(
+        rotated[:, 0].reshape(r_grid.shape),
+        rotated[:, 1].reshape(r_grid.shape),
+        rotated[:, 2].reshape(r_grid.shape),
+        color=color,
+        alpha=0.9,
+        linewidth=0,
+        shade=True,
+        lightsource=LightSource(azdeg=45, altdeg=-45),
+    )
+
+
 def _render_bloch_vector(ax: Any, bloch_vec: tuple[float, float, float]) -> None:
     """Render a single Bloch vector on a unit sphere."""
-    from matplotlib.patches import FancyArrowPatch
-    from mpl_toolkits.mplot3d import proj3d  # type: ignore[import-untyped]
-
     # Draw sphere surface
     u = np.linspace(0, 2 * np.pi, 30)
     v = np.linspace(0, np.pi, 15)
@@ -738,31 +866,7 @@ def _render_bloch_vector(ax: Any, bloch_vec: tuple[float, float, float]) -> None
         x, y, z, rstride=1, cstride=1, color="lightgray", alpha=0.2, linewidth=0
     )
 
-    class Arrow3D(FancyArrowPatch):
-        def __init__(
-            self, xs: Any, ys: Any, zs: Any, *args: Any, **kwargs: Any
-        ) -> None:
-            super().__init__((0, 0), (0, 0), *args, **kwargs)
-            self._verts3d = xs, ys, zs
-
-        def do_3d_projection(self, renderer: Any = None) -> float:
-            xs3d, ys3d, zs3d = self._verts3d
-            axes = cast(Any, self.axes)
-            xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, axes.M)
-            self.set_positions((xs[0], ys[0]), (xs[1], ys[1]))
-            return float(np.min(zs))
-
-    sx, sy, sz = bloch_vec
-    arrow = Arrow3D(
-        [0, sx],
-        [0, sy],
-        [0, sz],
-        mutation_scale=20,
-        lw=5,
-        arrowstyle="-|>",
-        color="darkblue",
-    )
-    ax.add_artist(arrow)
+    _bloch_arrow_surface(ax, bloch_vec)
 
     ax.set_xlim([-0.8, 0.8])
     ax.set_ylim([-0.8, 0.8])

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -64,7 +64,7 @@ class QuantumStateVectorMixin(ABC):
 
         Args:
             output: One of ``"text"``, ``"latex_source"``, ``"latex"``,
-                ``"qsphere"``, ``"density_matrix"``, or ``"bloch_vector"``. The ``"latex"`` option
+                ``"qsphere"``, ``"hinton"``, or ``"bloch_vector"``. The ``"latex"`` option
                 wraps the source in :class:`IPython.display.Latex` when IPython
                 is available; otherwise the raw string is returned. The
                 visualization options return a Matplotlib figure.
@@ -81,7 +81,7 @@ class QuantumStateVectorMixin(ABC):
             "latex",
             "latex_source",
             "qsphere",
-            "density_matrix",
+            "hinton",
             "bloch_vector",
         }:
             raise ValueError(f"Unsupported output format: {output}")
@@ -93,8 +93,8 @@ class QuantumStateVectorMixin(ABC):
             return _draw_text(terms, n_qubits, max_terms, precision)
         if fmt == "qsphere":
             return _draw_qsphere(self._vector, n_qubits, precision)
-        if fmt == "density_matrix":
-            return _draw_density_matrix(self._vector, n_qubits, precision)
+        if fmt == "hinton":
+            return _draw_hinton(self._vector, n_qubits, precision)
         if fmt == "bloch_vector":
             return _draw_bloch_vector(self._vector, n_qubits)
         latex_src = _draw_latex(terms, n_qubits, max_terms, precision)
@@ -671,7 +671,7 @@ def _draw_qsphere(
     return fig
 
 
-def _draw_density_matrix(
+def _draw_hinton(
     vector: StateVectorType, n_qubits: int, precision: int
 ) -> Any:  # pragma: no cover - visual
     try:
@@ -679,7 +679,7 @@ def _draw_density_matrix(
         from matplotlib.patches import Rectangle
     except Exception as e:  # pragma: no cover - import guard
         raise ImportError(
-            "Matplotlib is required for 'density_matrix' output. Install matplotlib to enable."
+            "Matplotlib is required for 'hinton' output. Install matplotlib to enable."
         ) from e
 
     rho = np.outer(vector, np.conjugate(vector))

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -461,13 +461,52 @@ def _light_source() -> Any:
     return LightSource(azdeg=45, altdeg=45)
 
 
+def _rotate_z_to_direction(
+    pts: Any, direction: tuple[float, float, float], length: float
+) -> Any:
+    """Rotate z-aligned points so the +z axis aligns with *direction*.
+
+    Parameters
+    ----------
+    pts:
+        (3, N) array of points expressed in the local z-aligned frame.
+    direction:
+        Target direction vector (sx, sy, sz).
+    length:
+        Pre-computed ``||direction||``; must be > 0.
+
+    Returns
+    -------
+    (N, 3) array of rotated points.
+    """
+    sx, sy, sz = direction
+    polar = float(np.arccos(np.clip(sz / length, -1.0, 1.0)))
+    azimuth = float(np.arctan2(sx, -sy))
+    rot_x = np.array(
+        [
+            [1, 0, 0],
+            [0, np.cos(polar), -np.sin(polar)],
+            [0, np.sin(polar), np.cos(polar)],
+        ]
+    )
+    rot_z = np.array(
+        [
+            [np.cos(azimuth), -np.sin(azimuth), 0],
+            [np.sin(azimuth), np.cos(azimuth), 0],
+            [0, 0, 1],
+        ]
+    )
+    return (rot_z @ rot_x @ pts).T
+
+
 def _draw_shaded_cylinder(
     ax: Any,
     end: tuple[float, float, float],
     radius: float,
     color: Any,
 ) -> None:
-    """Draw a shaded cylinder from the origin to *end* with the given RGBA *color*."""
+    """Draw a shaded cylinder from the origin to *end* with the given RGBA
+    *color*."""
     sx, sy, sz = end
     length = float(np.sqrt(sx**2 + sy**2 + sz**2))
     if length < 1e-10:
@@ -479,20 +518,8 @@ def _draw_shaded_cylinder(
     x_grid = radius * np.cos(theta_grid)
     y_grid = radius * np.sin(theta_grid)
 
-    polar = float(np.arccos(np.clip(sz / length, -1.0, 1.0)))
-    azimuth = float(np.arctan2(sx, -sy))
-    rot_x = np.array([
-        [1, 0, 0],
-        [0, np.cos(polar), -np.sin(polar)],
-        [0, np.sin(polar), np.cos(polar)],
-    ])
-    rot_z = np.array([
-        [np.cos(azimuth), -np.sin(azimuth), 0],
-        [np.sin(azimuth), np.cos(azimuth), 0],
-        [0, 0, 1],
-    ])
     pts = np.c_[x_grid.flatten(), y_grid.flatten(), z_grid.flatten()].T
-    rotated = (rot_z @ rot_x @ pts).T
+    rotated = _rotate_z_to_direction(pts, (sx, sy, sz), length)
     ax.plot_surface(
         rotated[:, 0].reshape(z_grid.shape),
         rotated[:, 1].reshape(z_grid.shape),
@@ -511,7 +538,8 @@ def _draw_shaded_sphere(
     radius: float,
     color: Any,
 ) -> None:
-    """Draw a small shaded sphere surface at *center* with the given RGBA *color*."""
+    """Draw a small shaded sphere surface at *center* with the given RGBA
+    *color*."""
     u = np.linspace(0, 2 * np.pi, 20)
     v = np.linspace(0, np.pi, 10)
     cx, cy, cz = center
@@ -519,7 +547,9 @@ def _draw_shaded_sphere(
     y = cy + radius * np.outer(np.sin(u), np.sin(v))
     z = cz + radius * np.outer(np.ones_like(u), np.cos(v))
     ax.plot_surface(
-        x, y, z,
+        x,
+        y,
+        z,
         color=color,
         alpha=0.95,
         linewidth=0,
@@ -579,7 +609,6 @@ def _draw_qsphere(
         radius = 0.1 * np.sqrt(probs[i])
         _draw_shaded_cylinder(ax, (x, y, z), radius * 0.3, rgba)
         _draw_shaded_sphere(ax, (x, y, z), radius, rgba)
-
 
         ax.text(
             1.3 * x,
@@ -758,8 +787,8 @@ def _draw_bloch_vector(
                 ls="-",
                 alpha=0.6,
             )
-            
-            t = np.linspace(0., np.pi, 200)
+
+            t = np.linspace(0.0, np.pi, 200)
             ax.plot(
                 np.cos(phi) * np.sin(t),
                 np.sin(phi) * np.sin(t),
@@ -770,7 +799,7 @@ def _draw_bloch_vector(
                 alpha=0.6,
             )
 
-            t = np.linspace(0., 1., 200)
+            t = np.linspace(0.0, 1.0, 200)
             ax.plot(
                 t * sx / magnitude,
                 t * sy / magnitude,
@@ -869,9 +898,10 @@ def _bloch_arrow_surface(
 ) -> None:
     """Draw a 3D arrow as a surface of revolution pointing in *direction*.
 
-    The arrow tip lands exactly at *direction* (which doubles as the endpoint),
-    and the surface participates in matplotlib's z-ordering so it is correctly
-    occluded by the sphere when pointing away from the viewer.
+    The arrow tip lands exactly at *direction* (which doubles as the
+    endpoint), and the surface participates in matplotlib's z-ordering
+    so it is correctly occluded by the sphere when pointing away from
+    the viewer.
     """
     sx, sy, sz = direction
     length = float(np.sqrt(sx**2 + sy**2 + sz**2))
@@ -883,7 +913,7 @@ def _bloch_arrow_surface(
     # total arrow length.
     nominal_head_length = head_fraction  # absolute size at length == 1
     nominal_head_radius = head_width * width
-    scale = (length+2.) / 3.  # sublinear: shrinks slower than the arrow
+    scale = (length + 2.0) / 3.0  # sublinear: shrinks slower than the arrow
     actual_head_length = min(length, nominal_head_length * scale)
     actual_head_radius = nominal_head_radius * scale
     shaft_length = length - actual_head_length
@@ -900,24 +930,8 @@ def _bloch_arrow_surface(
     y_grid = r_grid * np.cos(theta_grid)
 
     # Rotate the z-aligned arrow to point along (sx, sy, sz)
-    polar = float(np.arccos(np.clip(sz / length, -1.0, 1.0)))
-    azimuth = float(np.arctan2(sx, -sy))
-    rot_x = np.array(
-        [
-            [1, 0, 0],
-            [0, np.cos(polar), -np.sin(polar)],
-            [0, np.sin(polar), np.cos(polar)],
-        ]
-    )
-    rot_z = np.array(
-        [
-            [np.cos(azimuth), -np.sin(azimuth), 0],
-            [np.sin(azimuth), np.cos(azimuth), 0],
-            [0, 0, 1],
-        ]
-    )
     pts = np.c_[x_grid.flatten(), y_grid.flatten(), z_grid.flatten()].T
-    rotated = (rot_z @ rot_x @ pts).T
+    rotated = _rotate_z_to_direction(pts, (sx, sy, sz), length)
     ax.plot_surface(
         rotated[:, 0].reshape(r_grid.shape),
         rotated[:, 1].reshape(r_grid.shape),
@@ -939,7 +953,14 @@ def _render_bloch_vector(ax: Any, bloch_vec: tuple[float, float, float]) -> None
     y = np.outer(np.sin(u), np.sin(v))
     z = np.outer(np.ones_like(u), np.cos(v))
     ax.plot_surface(
-        x, y, z, rstride=1, cstride=1, color="lightgray", alpha=0.2, linewidth=0, 
+        x,
+        y,
+        z,
+        rstride=1,
+        cstride=1,
+        color="lightgray",
+        alpha=0.2,
+        linewidth=0,
     )
 
     _bloch_arrow_surface(ax, bloch_vec)

--- a/quri-parts/packages/core/quri_parts/core/state/state_vector.py
+++ b/quri-parts/packages/core/quri_parts/core/state/state_vector.py
@@ -8,6 +8,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import warnings
 from abc import ABC
 from math import comb
@@ -195,24 +196,190 @@ def _format_complex_latex(val: complex, precision: int) -> str:
     return "".join(parts)
 
 
+_IDENTIFICATION_BASE_CONSTANTS = ["pi", "sqrt(2)", "sqrt(3)", "sqrt(5)"]
+_LATEX_NAME_MAP = {"pi": r"\pi", "e": "e"}
+
+
 def _format_component_latex(val: float, precision: int) -> str:
-    """Render a real component with a few common symbolic forms."""
-    common = {
-        (1 / np.sqrt(2)): r"\frac{1}{\sqrt{2}}",
-        -(1 / np.sqrt(2)): r"-\frac{1}{\sqrt{2}}",
-        np.pi / 2: r"\frac{\pi}{2}",
-        -np.pi / 2: r"-\frac{\pi}{2}",
-        np.pi / 4: r"\frac{\pi}{4}",
-        -np.pi / 4: r"-\frac{\pi}{4}",
-        np.pi / 6: r"\frac{\pi}{6}",
-        -np.pi / 6: r"-\frac{\pi}{6}",
-        np.pi / 8: r"\frac{\pi}{8}",
-        -np.pi / 8: r"-\frac{\pi}{8}",
-    }
-    for k, v in common.items():
-        if np.isclose(val, k, atol=10 ** (-(precision + 2))):
-            return v
+    """Render a real component using mpmath-based identifications when
+    possible."""
+    identified = _identify_component_latex(val, precision)
+    if identified is not None:
+        return identified
     return f"{val:.{precision}g}"
+
+
+def _identify_component_latex(val: float, precision: int) -> Optional[str]:
+    """Try to express the value symbolically and convert to LaTeX."""
+    try:
+        from mpmath import mp  # type: ignore[import-untyped]
+    except Exception:
+        return None
+
+    tol = 10 ** (-(precision + 2))
+    prev_dps = mp.dps
+    try:
+        mp.dps = max(prev_dps, precision + 5, 30)
+        expr = mp.identify(mp.mpf(val), _IDENTIFICATION_BASE_CONSTANTS, tol=tol)
+    except Exception:
+        return None
+    finally:
+        mp.dps = prev_dps
+    if not expr:
+        return None
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except Exception:
+        return None
+
+    try:
+        evaluated = _evaluate_identification_ast(tree.body, mp)
+        target = mp.mpf(val)
+        tol_val = mp.mpf(tol)
+        if not mp.almosteq(evaluated, target, rel_eps=tol_val, abs_eps=tol_val):
+            return None
+    except Exception:
+        return None
+
+    return _identification_expr_to_latex(tree.body, precision)
+
+
+def _identification_expr_to_latex(expr: ast.AST, precision: int) -> Optional[str]:
+    """Convert the expression returned by mpmath.identify into LaTeX."""
+    try:
+        latex, _ = _ast_to_latex(expr, precision)
+    except Exception:
+        return None
+    return latex
+
+
+def _evaluate_identification_ast(node: ast.AST, mp: Any) -> Any:
+    """Evaluate the identification AST using the given mpmath context."""
+    if isinstance(node, ast.Constant):
+        return mp.mpf(node.value)
+    if isinstance(node, ast.Name):
+        if node.id == "pi":
+            return mp.pi
+        if node.id == "e":
+            return mp.e
+        raise ValueError(f"Unsupported constant name: {node.id}")
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -_evaluate_identification_ast(node.operand, mp)
+    if isinstance(node, ast.BinOp):
+        if isinstance(node.op, ast.Add):
+            return _evaluate_identification_ast(
+                node.left, mp
+            ) + _evaluate_identification_ast(node.right, mp)
+        if isinstance(node.op, ast.Sub):
+            return _evaluate_identification_ast(
+                node.left, mp
+            ) - _evaluate_identification_ast(node.right, mp)
+        if isinstance(node.op, ast.Mult):
+            return _evaluate_identification_ast(
+                node.left, mp
+            ) * _evaluate_identification_ast(node.right, mp)
+        if isinstance(node.op, ast.Div):
+            return _evaluate_identification_ast(
+                node.left, mp
+            ) / _evaluate_identification_ast(node.right, mp)
+        if isinstance(node.op, ast.Pow):
+            return _evaluate_identification_ast(
+                node.left, mp
+            ) ** _evaluate_identification_ast(node.right, mp)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        args = [_evaluate_identification_ast(arg, mp) for arg in node.args]
+        func = node.func.id
+        if func == "sqrt" and args:
+            return mp.sqrt(args[0])
+        if func == "log" and args:
+            return mp.log(args[0])
+        if func == "exp" and args:
+            return mp.e ** args[0]
+    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+
+def _ast_to_latex(node: ast.AST, precision: int) -> tuple[str, int]:
+    """Recursively convert a restricted AST to a LaTeX string."""
+    if isinstance(node, ast.Constant):
+        val = node.value
+        if isinstance(val, float):
+            return f"{val:.{precision}g}", 5
+        return str(val), 5
+    if isinstance(node, ast.Name):
+        return _LATEX_NAME_MAP.get(node.id, node.id), 5
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        inner, inner_prec = _ast_to_latex(node.operand, precision)
+        return f"-{_parenthesize(inner, inner_prec, 2)}", 4
+    if isinstance(node, ast.BinOp):
+        if isinstance(node.op, ast.Add):
+            left, left_prec = _ast_to_latex(node.left, precision)
+            right, right_prec = _ast_to_latex(node.right, precision)
+            return (
+                f"{_parenthesize(left, left_prec, 1)} + {_parenthesize(right, right_prec, 1)}",
+                1,
+            )
+        if isinstance(node.op, ast.Sub):
+            left, left_prec = _ast_to_latex(node.left, precision)
+            right, right_prec = _ast_to_latex(node.right, precision)
+            return (
+                f"{_parenthesize(left, left_prec, 1)} - {_parenthesize(right, right_prec, 1)}",
+                1,
+            )
+        if isinstance(node.op, ast.Mult):
+            left, left_prec = _ast_to_latex(node.left, precision)
+            right, right_prec = _ast_to_latex(node.right, precision)
+            left = _parenthesize(left, left_prec, 2)
+            right = _parenthesize(right, right_prec, 2)
+            return _combine_multiplication_terms(left, right), 2
+        if isinstance(node.op, ast.Div):
+            numerator, _ = _ast_to_latex(node.left, precision)
+            denominator, _ = _ast_to_latex(node.right, precision)
+            return f"\\frac{{{numerator}}}{{{denominator}}}", 3
+        if isinstance(node.op, ast.Pow):
+            base, base_prec = _ast_to_latex(node.left, precision)
+            exp, exp_prec = _ast_to_latex(node.right, precision)
+            base = _parenthesize(base, base_prec, 3)
+            exp = _parenthesize(exp, exp_prec, 3)
+            return f"{base}^{{{exp}}}", 3
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        args = [_ast_to_latex(arg, precision) for arg in node.args]
+        func = node.func.id
+        if func == "sqrt" and args:
+            arg, _ = args[0]
+            return f"\\sqrt{{{arg}}}", 4
+        if func == "log" and args:
+            arg, _ = args[0]
+            return f"\\log\\left({arg}\\right)", 4
+        if func == "exp" and args:
+            arg, _ = args[0]
+            return f"e^{{{arg}}}", 4
+    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+
+def _parenthesize(expr: str, child_prec: int, parent_prec: int) -> str:
+    if child_prec < parent_prec:
+        return f"({expr})"
+    return expr
+
+
+def _combine_multiplication_terms(left: str, right: str) -> str:
+    denom = _unit_fraction_denominator(left)
+    if denom is not None:
+        return f"\\frac{{{right}}}{{{denom}}}"
+    denom = _unit_fraction_denominator(right)
+    if denom is not None:
+        return f"\\frac{{{left}}}{{{denom}}}"
+    if left == "1":
+        return right
+    if left == "-1":
+        return f"-{right}"
+    return f"{left}\\,{right}"
+
+
+def _unit_fraction_denominator(expr: str) -> Optional[str]:
+    if expr.startswith("\\frac{1}{") and expr.endswith("}"):
+        return expr[len("\\frac{1}{") : -1]
+    return None
 
 
 def _significant_terms(
@@ -220,8 +387,8 @@ def _significant_terms(
 ) -> list[tuple[int, complex]]:
     idxs = np.where(np.abs(vector) > threshold)[0]
     terms = [(int(idx), complex(vector[idx])) for idx in idxs]
-    # Sort by magnitude descending, then by index for determinism
-    terms.sort(key=lambda t: (-abs(t[1]), t[0]))
+    # # Sort by magnitude descending, then by index for determinism
+    # terms.sort(key=lambda t: (-abs(t[1]), t[0]))
     return terms
 
 
@@ -292,21 +459,21 @@ def _draw_qsphere(
             "Matplotlib is required for 'qsphere' output. Install matplotlib to enable."
         ) from e
     try:
-        import colorcet as cc  # type: ignore[import-untyped]
+        import importlib
 
+        cc = importlib.import_module("colorcet")
         cmap = cc.m_cyclic_mybm_20_100_c48
-        # cmap = plt.get_cmap("hsv")
     except Exception:  # pragma: no cover - import guard
         cmap = plt.get_cmap("hsv")
 
     from matplotlib.colors import Normalize
 
-    fig = plt.figure(figsize=(5, 4))
-    ax = cast(Any, fig.add_subplot(111, projection="3d"))
+    fig = plt.figure(figsize=(6, 4))
+    ax = cast(Any, fig.add_subplot(111, projection="3d", computed_zorder=True))
 
     probs = np.abs(vector) ** 2
     phases = np.angle(vector)
-    phase_norm = Normalize(vmin=-np.pi, vmax=np.pi)
+    phase_norm = Normalize(vmin=0, vmax=2 * np.pi)
 
     # sphere grid
     u = np.linspace(0, 2 * np.pi, 25)
@@ -314,7 +481,7 @@ def _draw_qsphere(
     xs = np.outer(np.cos(u), np.sin(v))
     ys = np.outer(np.sin(u), np.sin(v))
     zs = np.outer(np.ones_like(u), np.cos(v))
-    ax.plot_surface(xs, ys, zs, color="lightgray", alpha=0.2, linewidth=0)
+    ax.plot_surface(xs, ys, zs, color="lightgray", alpha=0.2, linewidth=0, zorder=0)
 
     top_indices = np.argsort(probs)[::-1]
     for i in top_indices:
@@ -322,7 +489,7 @@ def _draw_qsphere(
             continue
         bitstr = format(i, f"0{n_qubits}b")
         x, y, z = _qsphere_coordinates(bitstr, n_qubits)
-        color = (phases[i] + 11 / 8 * np.pi) % (2 * np.pi) - np.pi
+        color = (phases[i] + 2 * np.pi) % (2 * np.pi)
         size = max(20, 800 * probs[i])
 
         ax.scatter(
@@ -335,13 +502,6 @@ def _draw_qsphere(
             cmap=cmap,
             norm=phase_norm,
         )
-        ax.scatter(
-            [x],
-            [y],
-            [z],
-            s=1.0,
-            c="black",
-        )
 
         ax.text(
             1.3 * x,
@@ -350,7 +510,6 @@ def _draw_qsphere(
             f"$|{bitstr}\\rangle$",
             ha="center",
             va="center",
-            fontsize=8,
             color="black",
         )
 
@@ -369,38 +528,29 @@ def _draw_qsphere(
     mappable.set_array([])
     cbar = fig.colorbar(mappable, ax=ax, shrink=0.6, pad=0.05)
     ticks = [
-        -np.pi,
-        -3 * np.pi / 4,
-        -np.pi / 2,
-        -np.pi / 4,
         0,
-        np.pi / 4,
         np.pi / 2,
-        3 * np.pi / 4,
         np.pi,
+        3 * np.pi / 2,
+        2 * np.pi,
     ]
     cbar.set_ticks(ticks)
     cbar.set_ticklabels(
         [
-            r"$-\pi$",
-            r"$-3\pi/4$",
-            r"$-\pi/2$",
-            r"$-\pi/4$",
             r"$0$",
-            r"$\pi/4$",
             r"$\pi/2$",
-            r"$3\pi/4$",
             r"$\pi$",
+            r"$3\pi/2$",
+            r"$2\pi$",
         ]
     )
     cbar.set_label("Phase", rotation=270, labelpad=15)
 
-    # Keep perspective level with the equator and aspect spherical
-    ax.view_init(elev=5, azim=90)
+    ax.view_init(elev=7, azim=80)
     ax.set_box_aspect((1, 1, 1))
-    ax.set_xlim([-1, 1])
-    ax.set_ylim([-1, 1])
-    ax.set_zlim([-1, 1])
+    ax.set_xlim([-0.8, 0.8])
+    ax.set_ylim([-0.8, 0.8])
+    ax.set_zlim([-0.8, 0.8])
 
     ax.set_axis_off()
     fig.tight_layout()
@@ -423,7 +573,6 @@ def _draw_density_matrix(
 
     rho = np.outer(vector, np.conjugate(vector))
     dim = rho.shape[0]
-    max_abs = np.max(np.abs(rho)) or 1.0
 
     fig, axes = plt.subplots(1, 2, figsize=(9, 4))
     labels = [format(i, f"0{n_qubits}b") for i in range(dim)]
@@ -438,8 +587,8 @@ def _draw_density_matrix(
         ax.set_xlim(0, dim)
         ax.set_ylim(0, dim)
         ax.set_title(title)
-        for (r, c), val in np.ndenumerate(data[::-1, :]):
-            magnitude = np.sqrt(abs(val) / max_abs)
+        for (r, c), val in np.ndenumerate(data[:, :]):
+            magnitude = np.sqrt(abs(val))
             if magnitude == 0:
                 continue
             plot_x, plot_y = c + 0.5, r + 0.5
@@ -483,6 +632,14 @@ def _draw_bloch_vector(
         ax.view_init(elev=25, azim=30)
         _render_bloch_vector(ax, bloch_vec)
         ax.set_title(f"Qubit {idx}", fontsize=10)
+
+        # Axes lines
+        ax.plot([-1, 1], [0, 0], [0, 0], color="grey", linewidth=1)
+        ax.plot([0, 0], [-1, 1], [0, 0], color="grey", linewidth=1)
+        ax.plot([0, 0], [0, 0], [-1, 1], color="grey", linewidth=1)
+        ax.text(1.3, 0, 0, "X", color="grey")
+        ax.text(0, 1.1, 0, "Y", color="grey")
+        ax.text(0, 0, 1.1, "Z", color="grey")
 
         # Equator and longitude markers
         theta = np.linspace(0, 2 * np.pi, 400)
@@ -580,14 +737,6 @@ def _render_bloch_vector(ax: Any, bloch_vec: tuple[float, float, float]) -> None
     ax.plot_surface(
         x, y, z, rstride=1, cstride=1, color="lightgray", alpha=0.2, linewidth=0
     )
-
-    # Axes lines
-    ax.plot([-1, 1], [0, 0], [0, 0], color="grey", linewidth=1)
-    ax.plot([0, 0], [-1, 1], [0, 0], color="grey", linewidth=1)
-    ax.plot([0, 0], [0, 0], [-1, 1], color="grey", linewidth=1)
-    ax.text(1.3, 0, 0, "X", color="grey")
-    ax.text(0, 1.1, 0, "Y", color="grey")
-    ax.text(0, 0, 1.1, "Z", color="grey")
 
     class Arrow3D(FancyArrowPatch):
         def __init__(

--- a/quri-parts/packages/core/tests/core/state/test_state_vector_draw.py
+++ b/quri-parts/packages/core/tests/core/state/test_state_vector_draw.py
@@ -1,0 +1,63 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from quri_parts.circuit import ParametricQuantumCircuit, QuantumCircuit
+from quri_parts.core.state import ParametricQuantumStateVector, QuantumStateVector
+
+
+def test_draw_latex_superposition() -> None:
+    amp = 1 / np.sqrt(2)
+    state = QuantumStateVector(2, vector=[amp, 0, 0, amp])
+
+    rendered = state.draw(output="latex_source", precision=6)
+
+    assert (
+        rendered == "\\frac{1}{\\sqrt{2}}|00\\rangle + \\frac{1}{\\sqrt{2}}|11\\rangle"
+    )
+
+
+def test_draw_text_truncation() -> None:
+    state = QuantumStateVector(2, vector=[0.5, 0.5, 0.5, 0.5])
+
+    rendered = state.draw(output="text", max_terms=2, precision=3)
+
+    assert "|00>" in rendered
+    assert "|01>" in rendered or "|10>" in rendered or "|11>" in rendered
+    assert "terms truncated" in rendered
+
+
+def test_parametric_state_draw() -> None:
+    circuit = ParametricQuantumCircuit(1)
+    state = ParametricQuantumStateVector(1, circuit, [0, 1])
+
+    rendered = state.draw(output="latex_source", precision=3)
+
+    assert rendered == "1|1\\rangle"
+
+
+def test_draw_latex_common_pi_fraction() -> None:
+    state = QuantumStateVector(1, vector=[0, 1j * np.pi / 4])
+
+    rendered = state.draw(output="latex_source", precision=6)
+
+    assert rendered == "\\frac{\\pi}{4}i|1\\rangle"
+
+
+def test_draw_warns_when_circuit_attached() -> None:
+    circuit = QuantumCircuit(1)
+    circuit.add_X_gate(0)  # ensure a gate exists
+    state = QuantumStateVector(1, circuit=circuit.freeze())
+
+    with pytest.warns(UserWarning, match="ignores any attached circuit"):
+        rendered = state.draw(output="text")
+    assert "|0" in rendered or "|1" in rendered

--- a/quri-parts/packages/core/tests/core/state/test_state_vector_draw.py
+++ b/quri-parts/packages/core/tests/core/state/test_state_vector_draw.py
@@ -22,7 +22,7 @@ def test_draw_latex_superposition() -> None:
     rendered = state.draw(output="latex_source", precision=6)
 
     assert (
-        rendered == "\\frac{1}{\\sqrt{2}}|00\\rangle + \\frac{1}{\\sqrt{2}}|11\\rangle"
+        rendered == "\\frac{\\sqrt{2}}{2}|00\\rangle + \\frac{\\sqrt{2}}{2}|11\\rangle"
     )
 
 

--- a/quri-parts/packages/core/tests/core/state/test_state_vector_visualizations.py
+++ b/quri-parts/packages/core/tests/core/state/test_state_vector_visualizations.py
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+try:
+    import matplotlib  # noqa: F401
+    from matplotlib.figure import Figure
+except ImportError:  # pragma: no cover - import guard
+    pytest.skip("matplotlib not available", allow_module_level=True)
+
+from quri_parts.core.state import QuantumStateVector
+
+
+def test_qsphere_returns_figure() -> None:
+    amp = 1 / np.sqrt(2)
+    state = QuantumStateVector(2, vector=[amp, 0, 0, amp])
+
+    fig = state.draw(output="qsphere")
+
+    assert isinstance(fig, Figure)
+
+
+def test_density_matrix_returns_figure() -> None:
+    amp = 1 / np.sqrt(2)
+    state = QuantumStateVector(1, vector=[amp, amp])
+
+    fig = state.draw(output="density_matrix")
+
+    assert isinstance(fig, Figure)

--- a/quri-parts/packages/core/tests/core/state/test_state_vector_visualizations.py
+++ b/quri-parts/packages/core/tests/core/state/test_state_vector_visualizations.py
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover - import guard
     pytest.skip("matplotlib not available", allow_module_level=True)
 
 from quri_parts.core.state import QuantumStateVector
+from quri_parts.core.state.state_vector import _format_component_latex
 
 
 def test_qsphere_returns_figure() -> None:
@@ -36,3 +37,14 @@ def test_density_matrix_returns_figure() -> None:
     fig = state.draw(output="density_matrix")
 
     assert isinstance(fig, Figure)
+
+
+def test_format_component_latex_identifies_common_terms() -> None:
+    assert _format_component_latex(np.pi / 4, 6) == r"\frac{\pi}{4}"
+    assert _format_component_latex(-np.pi / 6, 6) == r"-\frac{\pi}{6}"
+    assert _format_component_latex(1 / np.sqrt(3), 6) == r"\frac{\sqrt{3}}{3}"
+
+
+def test_format_component_latex_numeric_fallback() -> None:
+    val = 0.123456
+    assert _format_component_latex(val, 3) == f"{val:.3g}"

--- a/quri-parts/packages/core/tests/core/state/test_state_vector_visualizations.py
+++ b/quri-parts/packages/core/tests/core/state/test_state_vector_visualizations.py
@@ -30,11 +30,11 @@ def test_qsphere_returns_figure() -> None:
     assert isinstance(fig, Figure)
 
 
-def test_density_matrix_returns_figure() -> None:
+def test_hinton_returns_figure() -> None:
     amp = 1 / np.sqrt(2)
     state = QuantumStateVector(1, vector=[amp, amp])
 
-    fig = state.draw(output="density_matrix")
+    fig = state.draw(output="hinton")
 
     assert isinstance(fig, Figure)
 


### PR DESCRIPTION
## Visualization

Adds a `draw()` method with three visualization modes to `QuantumStateVector`

```python
from quri_parts.core.state import QuantumStateVector
import numpy as np

amp = np.sqrt(1/2)
state = QuantumStateVector(1, [amp, -amp])

state.draw(output="bloch")       # Bloch sphere
state.draw(output="qsphere")     # Q-sphere (multi-qubit phase/probability view)
state.draw(output="hinton")      # Hinton diagram of the density matrix
```

- `bloch`: Visualizes the state as a point on the Bloch sphere. For multi-qubit states, reduced single-qubit states are shown via partial trace.
   <img width="370" height="390" alt="image" src="https://github.com/user-attachments/assets/87292a2e-14e9-4cf0-bfe0-218bf4f75e9b" />

- `qsphere`: Global view of a multi-qubit state in the computational basis. Dot size = probability, color = phase of each basis state.
   <img width="490" height="390" alt="image" src="https://github.com/user-attachments/assets/77e7f3fc-f015-4487-9d1e-b5f17fa6e485" />

- `hinton`: Hinton diagram of the density matrix. Square size encodes magnitude, color (white/black) encodes the sign of real/imaginary parts.
   <img width="809" height="390" alt="image" src="https://github.com/user-attachments/assets/0e73b56e-4c95-4738-b7eb-cfe1bea9e7d9" />


## Text/Latex Representation

Adds text/latex representation of `QuantumState`, which uses [mpmath](https://mpmath.org/) to find expressions for floating point coefficients.

```python
from quri_parts.core.state import QuantumStateVector
import numpy as np

amp = np.sqrt(1/2)
state = QuantumStateVector(1, [amp, -amp])

state.draw()
state.draw(output="latex_source")
state.draw(output="latex") 
```

```
|0> amp=0.707107 prob=0.5
|1> amp=-0.707107 prob=0.5
\frac{\sqrt{2}}{2}|0\rangle + -\frac{\sqrt{2}}{2}|1\rangle
<IPython.core.display.Latex object>
```

Jupyter notebooks will automatically render the LaTeX object as formatted math when evaluating a cell.
<img width="395" height="147" alt="image" src="https://github.com/user-attachments/assets/f15b3a92-e9cc-4a81-91b8-5e2a05729d77" />
