### PR TITLE
Remove dependency on quri-parts-qiskit from quri-parts-qulacs

### DIFF
--- a/quri-algo/quri_algo/circuit_lib/qpe.py
+++ b/quri-algo/quri_algo/circuit_lib/qpe.py
@@ -22,7 +22,16 @@ from quri_parts.qsub.op import Op
 from quri_parts.qsub.opsub import ParamUnitarySubDef, param_opsub
 from quri_parts.qsub.sub import SubBuilder
 
-__all__ = ["QFTdag", "QFTdagSub", "LineH", "LineHSub", "QPE", "QPESub", "QPEListUk", "QPEListUkSub"]
+__all__ = [
+    "QFTdag",
+    "QFTdagSub",
+    "LineH",
+    "LineHSub",
+    "QPE",
+    "QPESub",
+    "QPEListUk",
+    "QPEListUkSub",
+]
 
 
 class _QFTdag(ParamUnitarySubDef[int]):

--- a/quri-algo/quri_algo/circuit_lib/qpe.py
+++ b/quri-algo/quri_algo/circuit_lib/qpe.py
@@ -22,6 +22,8 @@ from quri_parts.qsub.op import Op
 from quri_parts.qsub.opsub import ParamUnitarySubDef, param_opsub
 from quri_parts.qsub.sub import SubBuilder
 
+__all__ = ["QFTdag", "QFTdagSub", "LineH", "LineHSub", "QPE", "QPESub", "QPEListUk", "QPEListUkSub"]
+
 
 class _QFTdag(ParamUnitarySubDef[int]):
     name = "QFTdag"
@@ -43,7 +45,10 @@ class _QFTdag(ParamUnitarySubDef[int]):
             builder.add_op(H, (qubits[k],))
 
 
-QFTdag, QFTdagSub = param_opsub(_QFTdag)
+__qftdag_result = param_opsub(_QFTdag)
+#: QFTdag subroutine factory.
+QFTdag = __qftdag_result[0]
+QFTdagSub = __qftdag_result[1]
 
 
 class _LineH(ParamUnitarySubDef[int]):
@@ -59,7 +64,10 @@ class _LineH(ParamUnitarySubDef[int]):
             builder.add_op(H, (qubits[k],))
 
 
-LineH, LineHSub = param_opsub(_LineH)
+__lineh_result = param_opsub(_LineH)
+#: LineH subroutine factory.
+LineH = __lineh_result[0]
+LineHSub = __lineh_result[1]
 
 
 class _QPE(ParamUnitarySubDef[int, Op]):
@@ -92,7 +100,10 @@ class _QPE(ParamUnitarySubDef[int, Op]):
 #: ancilla qubit in accordance with the standard formulation of QPE, where the
 #: op is applied a number of times corresponding to the binary power
 #: represented by its controlling ancilla bit.
-QPE, QPESub = param_opsub(_QPE)
+__qpe_result = param_opsub(_QPE)
+#: QPE subroutine factory.
+QPE = __qpe_result[0]
+QPESub = __qpe_result[1]
 
 
 class _QPEListUk(ParamUnitarySubDef[int, tuple[Op]]):
@@ -123,4 +134,17 @@ class _QPEListUk(ParamUnitarySubDef[int, tuple[Op]]):
 #:
 #: ops is a sequence of unitary operators that are applied, controlled by each
 #: ancilla bit in sequence. Each op in the sequence is applied only once.
-QPEListUk, QPEListUkSub = param_opsub(_QPEListUk)
+__qpelistuk_result = param_opsub(_QPEListUk)
+#: QPEListUk subroutine factory.
+QPEListUk = __qpelistuk_result[0]
+QPEListUkSub = __qpelistuk_result[1]
+
+# Fix __module__ so Sphinx autodoc picks up factory objects
+QFTdag.__module__ = __name__
+QFTdagSub.__module__ = __name__
+LineH.__module__ = __name__
+LineHSub.__module__ = __name__
+QPE.__module__ = __name__
+QPESub.__module__ = __name__
+QPEListUk.__module__ = __name__
+QPEListUkSub.__module__ = __name__

--- a/quri-algo/quri_algo/circuit_lib/time_evolution/trotter_time_evo.py
+++ b/quri-algo/quri_algo/circuit_lib/time_evolution/trotter_time_evo.py
@@ -11,6 +11,8 @@ from quri_parts.qsub.sub import SubBuilder
 
 from quri_algo.problem import QubitHamiltonian
 
+__all__ = ["TrotterTimeEvo", "TrotterTimeEvoSub"]
+
 
 class _TrotterTimeEvo(ParamUnitarySubDef[QubitHamiltonian, float, int, int]):
     name = "TrotterTimeEvolution"
@@ -54,4 +56,11 @@ class _TrotterTimeEvo(ParamUnitarySubDef[QubitHamiltonian, float, int, int]):
                 builder.add_op(op, q)
 
 
-TrotterTimeEvo, TrotterTimeEvoSub = param_opsub(_TrotterTimeEvo)
+__trottertimeevo_result = param_opsub(_TrotterTimeEvo)
+#: TrotterTimeEvo subroutine factory.
+TrotterTimeEvo = __trottertimeevo_result[0]
+TrotterTimeEvoSub = __trottertimeevo_result[1]
+
+# Fix __module__ so Sphinx autodoc picks up factory objects
+TrotterTimeEvo.__module__ = __name__
+TrotterTimeEvoSub.__module__ = __name__

--- a/quri-algo/quri_algo/qsub/time_evolution/trotter_time_evo.py
+++ b/quri-algo/quri_algo/qsub/time_evolution/trotter_time_evo.py
@@ -1,3 +1,5 @@
+"""Deprecated. Use :mod:`quri_algo.circuit_lib.time_evolution.trotter_time_evo`."""
+
 import warnings
 
 warnings.warn(
@@ -10,3 +12,5 @@ from quri_algo.circuit_lib.time_evolution.trotter_time_evo import (  # noqa: F40
     TrotterTimeEvo,
     TrotterTimeEvoSub,
 )
+
+__all__ = ["TrotterTimeEvo", "TrotterTimeEvoSub"]

--- a/quri-algo/quri_algo/qsub/time_evolution/trotter_time_evo.py
+++ b/quri-algo/quri_algo/qsub/time_evolution/trotter_time_evo.py
@@ -1,4 +1,7 @@
-"""Deprecated. Use :mod:`quri_algo.circuit_lib.time_evolution.trotter_time_evo`."""
+"""Deprecated.
+
+Use :mod:`quri_algo.circuit_lib.time_evolution.trotter_time_evo`.
+"""
 
 import warnings
 

--- a/quri-parts/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/quri-parts/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -14,10 +14,7 @@ from typing import Optional, Union
 from qiskit import transpile
 from qiskit.providers import Backend
 
-from quri_parts.circuit import (
-    ImmutableQuantumCircuit,
-    gate_names,
-)
+from quri_parts.circuit import ImmutableQuantumCircuit, gate_names
 from quri_parts.circuit.gate_names import GateNameType
 from quri_parts.circuit.transpile import CircuitTranspilerProtocol
 from quri_parts.qiskit.circuit import circuit_from_qiskit, convert_circuit

--- a/quri-parts/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
+++ b/quri-parts/packages/qiskit/quri_parts/qiskit/circuit/transpile/__init__.py
@@ -9,16 +9,14 @@
 # limitations under the License.
 
 from collections.abc import Mapping, Sequence
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 from qiskit import transpile
 from qiskit.providers import Backend
 
 from quri_parts.circuit import (
     ImmutableQuantumCircuit,
-    QuantumCircuit,
     gate_names,
-    gates,
 )
 from quri_parts.circuit.gate_names import GateNameType
 from quri_parts.circuit.transpile import CircuitTranspilerProtocol
@@ -93,37 +91,6 @@ class QiskitTranspiler(CircuitTranspilerProtocol):
         return circuit_from_qiskit(optimized_qiskit_circ)
 
 
-def transpile_ecr_gates(circuit: ImmutableQuantumCircuit) -> ImmutableQuantumCircuit:
-    """Replace ECR gates with native gates understood by Qulacs."""
-    converted = QuantumCircuit(circuit.qubit_count)
-    for gate in circuit.gates:
-        ecr_targets = _get_ecr_targets(gate)
-        if ecr_targets is not None:
-            control, target = ecr_targets
-            converted.add_gate(gates.S(control))
-            converted.add_gate(gates.SqrtX(target))
-            converted.add_gate(gates.CNOT(control, target))
-            converted.add_gate(gates.X(control))
-        else:
-            converted.add_gate(gate)
-    return converted
-
-
-def _get_ecr_targets(gate: object) -> Optional[tuple[int, int]]:
-    if not hasattr(gate, "target_indices"):
-        return None
-
-    target_indices = getattr(gate, "target_indices")
-    if len(target_indices) != 2:
-        return None
-
-    if hasattr(gate, "name") and gate.name == ECR:
-        return cast(tuple[int, int], tuple(target_indices))
-
-    return None
-
-
 __all__ = [
     "QiskitTranspiler",
-    "transpile_ecr_gates",
 ]

--- a/quri-parts/packages/qulacs/quri_parts/qulacs/circuit/__init__.py
+++ b/quri-parts/packages/qulacs/quri_parts/qulacs/circuit/__init__.py
@@ -41,11 +41,11 @@ from quri_parts.circuit.gate_names import (
     is_two_qubit_gate_name,
     is_unitary_matrix_gate_name,
 )
-from quri_parts.qiskit.circuit.transpile import transpile_ecr_gates
 
 from ..utils import cast_to_list
 from .compiled_circuit import compile_circuit, compile_parametric_circuit
 from .qulacs_circuit_converter import circuit_from_qulacs
+from .transpile import transpile_ecr_gates
 
 _single_qubit_gate_qulacs: Mapping[
     SingleQubitGateNameType, Callable[[int], qulacs.QuantumGateBase]

--- a/quri-parts/packages/qulacs/quri_parts/qulacs/circuit/transpile/__init__.py
+++ b/quri-parts/packages/qulacs/quri_parts/qulacs/circuit/transpile/__init__.py
@@ -1,0 +1,50 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, cast
+
+from quri_parts.circuit import ImmutableQuantumCircuit, QuantumCircuit, gates
+
+_ECR_GATE_NAME = "ECR"
+
+
+def transpile_ecr_gates(circuit: ImmutableQuantumCircuit) -> ImmutableQuantumCircuit:
+    """Replace ECR gates with native gates understood by Qulacs."""
+    converted = QuantumCircuit(circuit.qubit_count)
+    for gate in circuit.gates:
+        ecr_targets = _get_ecr_targets(gate)
+        if ecr_targets is not None:
+            control, target = ecr_targets
+            converted.add_gate(gates.S(control))
+            converted.add_gate(gates.SqrtX(target))
+            converted.add_gate(gates.CNOT(control, target))
+            converted.add_gate(gates.X(control))
+        else:
+            converted.add_gate(gate)
+    return converted
+
+
+def _get_ecr_targets(gate: object) -> Optional[tuple[int, int]]:
+    if not hasattr(gate, "target_indices"):
+        return None
+
+    target_indices = getattr(gate, "target_indices")
+    if len(target_indices) != 2:
+        return None
+
+    if hasattr(gate, "name") and gate.name == _ECR_GATE_NAME:
+        return cast(tuple[int, int], tuple(target_indices))
+
+    return None
+
+
+__all__ = [
+    "transpile_ecr_gates",
+]


### PR DESCRIPTION
Remove dependency on `quri-parts-qiskit` from `quri-parts-qulacs`.

I created a transpile module `quri-parts.qulacs.circuit.transpile` and moved the transpile function there.

Closes https://github.com/QunaSys/quri-sdk/issues/513