### PR TITLE
Qsub Quantum Register feature

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/qpe.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/qpe.py
@@ -17,11 +17,16 @@
 
 import warnings
 from cmath import pi
+from typing import Sequence
 
 from quri_parts.qsub.lib.std import SWAP, Controlled, H, Phase
+from quri_parts.qsub.namespace import NameSpace
 from quri_parts.qsub.op import Op
 from quri_parts.qsub.opsub import ParamUnitarySubDef, param_opsub
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 from quri_parts.qsub.sub import SubBuilder
+
+from . import NS as parent_ns
 
 warnings.warn(
     "quri_parts.qsub.lib.qpe is deprecated and no longer maintained. Please import with quri_algo.qsub.qpe instead.",
@@ -29,12 +34,18 @@ warnings.warn(
     stacklevel=2,
 )
 
+NS = NameSpace("qpe", parent_ns)
+
 
 class _QFTdag(ParamUnitarySubDef[int]):
     name = "QFTdag"
+    ns = NS
 
     def qubit_count_fn(self, bits: int) -> int:
         return bits
+
+    def qregs_fn(self, bits: int) -> Sequence[QRegSpec]:
+        return (QRegSpec(DEFAULT_QNAME, bits),)
 
     def sub(self, builder: SubBuilder, bits: int) -> None:
         qubits = builder.qubits
@@ -55,9 +66,13 @@ QFTdag, QFTdagSub = param_opsub(_QFTdag)
 
 class _LineH(ParamUnitarySubDef[int]):
     name = "LineH"
+    ns = NS
 
     def qubit_count_fn(self, bits: int) -> int:
         return bits
+
+    def qregs_fn(self, bits: int) -> Sequence[QRegSpec]:
+        return (QRegSpec("qs", bits),)
 
     def sub(self, builder: SubBuilder, bits: int) -> None:
         qubits = builder.qubits
@@ -71,13 +86,17 @@ LineH, LineHSub = param_opsub(_LineH)
 
 class _QPE(ParamUnitarySubDef[int, Op]):
     name = "QPE"
+    ns = NS
 
     def qubit_count_fn(self, bits: int, op: Op) -> int:
         return bits + op.qubit_count
 
+    def qregs_fn(self, bits: int, op: Op) -> Sequence[QRegSpec]:
+        return (QRegSpec("read_out", bits), QRegSpec("system", op.qubit_count))
+
     def sub(self, builder: SubBuilder, bits: int, op: Op) -> None:
-        qubits = builder.qubits
-        pqs, sqs = qubits[:bits], qubits[bits:]
+        pqs = builder.qregs["read_out"].qubits
+        sqs = builder.qregs["system"].qubits
 
         builder.add_op(LineH(bits), pqs)
         for k in range(bits):
@@ -104,13 +123,17 @@ QPE, QPESub = param_opsub(_QPE)
 
 class _QPEListUk(ParamUnitarySubDef[int, tuple[Op]]):
     name = "QPEListUk"
+    ns = NS
 
     def qubit_count_fn(self, bits: int, ops: tuple[Op]) -> int:
         return bits + ops[0].qubit_count
 
+    def qregs_fn(self, bits: int, ops: tuple[Op]) -> Sequence[QRegSpec]:
+        return (QRegSpec("read_out", bits), QRegSpec("system", ops[0].qubit_count))
+
     def sub(self, builder: SubBuilder, bits: int, ops: tuple[Op]) -> None:
-        qubits = builder.qubits
-        pqs, sqs = qubits[:bits], qubits[bits:]
+        pqs = builder.qregs["read_out"].qubits
+        sqs = builder.qregs["system"].qubits
 
         builder.add_op(LineH(bits), pqs)
         for k in range(bits):

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/cnot.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/cnot.py
@@ -9,7 +9,9 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.register import CTRL_QNAME, TARGET_QNAME, QRegSpec
 
 from . import NS
 
-CNOT: Op = Op(Ident(NS, "CNOT"), 2, self_inverse=True)
+cnot_qreg_specs = (QRegSpec(CTRL_QNAME, 1), QRegSpec(TARGET_QNAME, 1))
+CNOT: Op = Op(Ident(NS, "CNOT"), 2, self_inverse=True, qregs=cnot_qreg_specs)

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/conditional.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/conditional.py
@@ -18,8 +18,8 @@ from quri_parts.qsub.sub import SubBuilder
 from . import NS
 
 # Compare and branch on zero.
-Cbz = Op(Ident(NS, "Cbz"), 0, 2, unitary=False)
-Label = Op(Ident(NS, "Label"), 0, 1, unitary=False)
+Cbz = Op(Ident(NS, "Cbz"), 0, (), 2, unitary=False)
+Label = Op(Ident(NS, "Label"), 0, (), 1, unitary=False)
 
 
 @contextmanager

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/control.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/control.py
@@ -9,7 +9,7 @@
 # limitations under the License.
 
 import math
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 from typing import Any
 
 from quri_parts.qsub.lib import std
@@ -23,6 +23,7 @@ from quri_parts.qsub.op import (
     param_op,
 )
 from quri_parts.qsub.qubit import Qubit
+from quri_parts.qsub.register import CTRL_QNAME, QRegSpec
 from quri_parts.qsub.resolve import (
     SimpleSubRepository,
     SubRepository,
@@ -41,7 +42,11 @@ from .swap import SWAP
 from .t import T, Tdag
 from .toffoli import Toffoli
 
+
 # Parametric Op definitions
+def get_new_ctrl_label(inner_reg_specs: Sequence[QRegSpec]) -> int:
+    n_sub_ctrls = sum([int(CTRL_QNAME in rs.name) for rs in inner_reg_specs])
+    return n_sub_ctrls
 
 
 class _Controlled(ParamUnitaryDef[Op]):
@@ -53,6 +58,11 @@ class _Controlled(ParamUnitaryDef[Op]):
 
     def reg_count_fn(self, target_op: Op) -> int:
         return target_op.reg_count
+
+    def qregs_fn(self, target_op: Op) -> Sequence[QRegSpec]:
+        ctrl_label = get_new_ctrl_label(target_op.qregs)
+        ctrl_name = CTRL_QNAME if ctrl_label == 0 else f"{CTRL_QNAME}_{ctrl_label}"
+        return (QRegSpec(ctrl_name, 1), *target_op.qregs)
 
     def validate_params(self, target_op: Op) -> None:
         if not target_op.unitary:
@@ -76,10 +86,13 @@ def controlled_sub_resolver(op: Op, repository: SubRepository) -> Sub | None:
     if not target_sub:
         return None
 
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     c, *target_q = builder.qubits
 
-    target_aq = tuple(builder.add_aux_qubit() for _ in target_sub.aux_qubits)
+    if target_sub.aux_qregs is not None:
+        for qr in target_sub.aux_qregs.values():
+            builder.add_aux_qreg(qr.name, qr.size)
+    target_aq = builder.aux_qubits
     qubit_map = dict(zip(target_sub.qubits, target_q)) | dict(
         zip(target_sub.aux_qubits, target_aq)
     )
@@ -129,13 +142,13 @@ def control_target_condition(op: AbstractOp) -> SubResolverCondition:
 
 
 def controlled_x_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(CNOT, builder.qubits)
     return builder.build()
 
 
 def controlled_y_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     c, t = builder.qubits
     builder.add_op(Sdag, (t,))
     builder.add_op(CNOT, (c, t))
@@ -144,13 +157,13 @@ def controlled_y_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_z_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(CZ, builder.qubits)
     return builder.build()
 
 
 def controlled_h_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     builder.add_op(RY(-math.pi / 4), (q1,))
     builder.add_op(CZ, (q0, q1))
@@ -172,7 +185,7 @@ def controlled_rx_resolver(op: Op, repository: SubRepository) -> Sub:
     assert isinstance(target, Op)
     angle = target.id.params[0]
     assert isinstance(angle, float)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _crx(builder, q0, q1, angle)
     return builder.build()
@@ -190,7 +203,7 @@ def controlled_ry_resolver(op: Op, repository: SubRepository) -> Sub:
     assert isinstance(target, Op)
     angle = target.id.params[0]
     assert isinstance(angle, float)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _cry(builder, q0, q1, angle)
     return builder.build()
@@ -208,7 +221,7 @@ def controlled_rz_resolver(op: Op, repository: SubRepository) -> Sub:
     assert isinstance(target, Op)
     angle = target.id.params[0]
     assert isinstance(angle, float)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _crz(builder, q0, q1, angle)
     return builder.build()
@@ -219,7 +232,7 @@ def controlled_phase_resolver(op: Op, repository: SubRepository) -> Sub:
     assert isinstance(target, Op)
     angle = target.id.params[0]
     assert isinstance(angle, float)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _crz(builder, q0, q1, angle)
     builder.add_op(Phase(angle / 2), (q0,))
@@ -227,7 +240,7 @@ def controlled_phase_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_sqrtx_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _crx(builder, q0, q1, math.pi / 2)
     builder.add_op(Phase(math.pi / 4), (q0,))
@@ -235,7 +248,7 @@ def controlled_sqrtx_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_sqrtxdag_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _crx(builder, q0, q1, -math.pi / 2)
     builder.add_op(Phase(-math.pi / 4), (q0,))
@@ -243,7 +256,7 @@ def controlled_sqrtxdag_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_sqrty_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _cry(builder, q0, q1, math.pi / 2)
     builder.add_op(Phase(math.pi / 4), (q0,))
@@ -251,7 +264,7 @@ def controlled_sqrty_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_sqrtydag_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     _cry(builder, q0, q1, -math.pi / 2)
     builder.add_op(Phase(-math.pi / 4), (q0,))
@@ -259,7 +272,7 @@ def controlled_sqrtydag_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_s_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     builder.add_op(CNOT, (q0, q1))
     builder.add_op(Tdag, (q1,))
@@ -270,7 +283,7 @@ def controlled_s_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_sdag_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     builder.add_op(CNOT, (q0, q1))
     builder.add_op(T, (q1,))
@@ -281,7 +294,7 @@ def controlled_sdag_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_t_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     builder.add_op(CNOT, (q0, q1))
     builder.add_op(Phase(-math.pi / 8), (q1,))
@@ -292,7 +305,7 @@ def controlled_t_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_tdag_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1 = builder.qubits
     builder.add_op(CNOT, (q0, q1))
     builder.add_op(Phase(math.pi / 8), (q1,))
@@ -303,7 +316,7 @@ def controlled_tdag_resolver(op: Op, repository: SubRepository) -> Sub:
 
 
 def controlled_cnot_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(Toffoli, builder.qubits)
     return builder.build()
 
@@ -311,13 +324,13 @@ def controlled_cnot_resolver(op: Op, repository: SubRepository) -> Sub:
 def controlled_cz_resolver(op: Op, repository: SubRepository) -> Sub:
     from .multi_control import MultiControlled
 
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(MultiControlled(Z, 2, 0b11), builder.qubits)
     return builder.build()
 
 
 def controlled_swap_resolver(op: Op, repository: SubRepository) -> Sub:
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     q0, q1, q2 = builder.qubits
     builder.add_op(CNOT, (q2, q1))
     builder.add_op(Toffoli, (q0, q1, q2))
@@ -328,7 +341,7 @@ def controlled_swap_resolver(op: Op, repository: SubRepository) -> Sub:
 def controlled_toffoli_resolver(op: Op, repository: SubRepository) -> Sub:
     from .multi_control import MultiControlled
 
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(MultiControlled(X, 3, 0b111), builder.qubits)
     return builder.build()
 

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/cz.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/cz.py
@@ -9,7 +9,9 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.register import CTRL_QNAME, TARGET_QNAME, QRegSpec
 
 from . import NS
 
-CZ: Op = Op(Ident(NS, "CZ"), 2, self_inverse=True)
+cz_qreg_specs = (QRegSpec(CTRL_QNAME, 1), QRegSpec(TARGET_QNAME, 1))
+CZ: Op = Op(Ident(NS, "CZ"), 2, self_inverse=True, qregs=cz_qreg_specs)

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/inverse.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/inverse.py
@@ -8,7 +8,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 
 from quri_parts.qsub.lib.std import Controlled, MultiControlled
 from quri_parts.qsub.op import (
@@ -21,7 +21,11 @@ from quri_parts.qsub.op import (
     param_op,
 )
 from quri_parts.qsub.qubit import Qubit
-from quri_parts.qsub.register import Register
+from quri_parts.qsub.register import (
+    QRegSpec,
+    Register,
+    get_qregs_from_quantum_register_map,
+)
 from quri_parts.qsub.resolve import (
     SubRepository,
     SubResolver,
@@ -46,6 +50,9 @@ class _Inverse(ParamUnitaryDef[Op]):
     def reg_count_fn(self, target_op: Op) -> int:
         return target_op.reg_count
 
+    def qregs_fn(self, target_op: Op) -> Sequence[QRegSpec]:
+        return target_op.qregs
+
     def validate_params(self, target_op: Op) -> None:
         if not target_op.unitary:
             raise ParameterValidationError(f"target_op {target_op} is not unitary")
@@ -55,7 +62,7 @@ Inverse = param_op(_Inverse)
 
 
 def _single_op_sub(op: Op) -> Sub:
-    b = SubBuilder(op.qubit_count, op.reg_count)
+    b = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     b.add_op(op, b.qubits, b.registers)
     return b.build()
 
@@ -65,9 +72,17 @@ def _copy_sub_skeleton(
 ) -> tuple[SubBuilder, dict[Qubit, Qubit], dict[Register, Register]]:
     qubit_count = len(target_sub.qubits)
     reg_count = len(target_sub.registers)
-    builder = SubBuilder(qubit_count, reg_count)
+
+    qregs = None
+    if target_sub.qregs is not None:
+        qregs = get_qregs_from_quantum_register_map(target_sub.qregs)
+
+    builder = SubBuilder(qubit_count, reg_count, qregs)
     target_q = builder.qubits
-    target_aq = tuple(builder.add_aux_qubit() for _ in target_sub.aux_qubits)
+    if target_sub.aux_qregs is not None:
+        for qr in target_sub.aux_qregs.values():
+            builder.add_aux_qreg(qr.name, qr.size)
+    target_aq = builder.aux_qubits
     qubit_map = dict(zip(target_sub.qubits, target_q)) | dict(
         zip(target_sub.aux_qubits, target_aq)
     )
@@ -129,7 +144,7 @@ def _inverse_rotation_resolver_gen(op_factory: OpFactory[float]) -> SubResolver:
         assert isinstance(target, Op)
         angle = target.id.params[0]
         assert isinstance(angle, float)
-        builder = SubBuilder(op.qubit_count, op.reg_count)
+        builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
         builder.add_op(op_factory(-angle), builder.qubits)
         return builder.build()
 
@@ -140,7 +155,7 @@ def _inverse_op_resolver_gen(inverse_op: Op) -> SubResolver:
     def resolver(op: Op, repository: SubRepository) -> Sub:
         target = op.id.params[0]
         assert isinstance(target, Op)
-        builder = SubBuilder(op.qubit_count, op.reg_count)
+        builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
         builder.add_op(inverse_op, builder.qubits)
         return builder.build()
 
@@ -153,7 +168,7 @@ def inverse_controlled_resolver(op: Op, repository: SubRepository) -> Sub:
     assert target.base_id == Controlled.base_id
     inner_op = target.id.params[0]
     assert isinstance(inner_op, Op)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(Controlled(Inverse(inner_op)), builder.qubits)
     return builder.build()
 
@@ -164,7 +179,7 @@ def inverse_multicontrolled_resolver(op: Op, repository: SubRepository) -> Sub:
     assert target.base_id == MultiControlled.base_id
     inner_op, control_bits, control_value = target.id.params
     assert isinstance(inner_op, Op)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(
         MultiControlled(Inverse(inner_op), control_bits, control_value), builder.qubits
     )
@@ -177,7 +192,7 @@ def inverse_inverse_resolver(op: Op, repository: SubRepository) -> Sub:
     assert target.base_id == Inverse.base_id
     inner_op = target.id.params[0]
     assert isinstance(inner_op, Op)
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
     builder.add_op(inner_op, builder.qubits)
     return builder.build()
 

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/measure.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/measure.py
@@ -12,4 +12,4 @@ from quri_parts.qsub.op import Ident, Op
 
 from . import NS
 
-M = Op(Ident(NS, "M"), 1, 1, unitary=False)
+M = Op.from_qubit_count(Ident(NS, "M"), 1, 1, unitary=False)

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control.py
@@ -10,7 +10,7 @@
 
 from collections.abc import Callable
 from contextlib import AbstractContextManager
-from typing import Optional
+from typing import Optional, Sequence
 
 from quri_parts.qsub.op import (
     Op,
@@ -20,11 +20,12 @@ from quri_parts.qsub.op import (
     param_op,
 )
 from quri_parts.qsub.qubit import Qubit
+from quri_parts.qsub.register import CTRL_QNAME, QRegSpec
 from quri_parts.qsub.resolve import SubRepository, default_repository
 from quri_parts.qsub.sub import Sub, SubBuilder
 
 from . import NS
-from .control import Controlled, control_target_condition
+from .control import Controlled, control_target_condition, get_new_ctrl_label
 from .logic import scoped_and, scoped_and_clifford_t, scoped_and_single_toffoli
 from .single_clifford import X
 
@@ -42,6 +43,13 @@ class _MultiControlled(ParamUnitaryDef[Op, int, int]):
 
     def reg_count_fn(self, target_op: Op, control_bits: int, control_value: int) -> int:
         return target_op.reg_count
+
+    def qregs_fn(
+        self, target_op: Op, control_bits: int, control_value: int
+    ) -> Sequence[QRegSpec]:
+        ctrl_label = get_new_ctrl_label(target_op.qregs)
+        ctrl_name = f"{CTRL_QNAME}_{ctrl_label}" if ctrl_label > 0 else CTRL_QNAME
+        return (QRegSpec(ctrl_name, control_bits), *target_op.qregs)
 
     def validate_params(
         self, target_op: Op, control_bits: int, control_value: int
@@ -68,7 +76,9 @@ def _multi_controlled_sub(
     control_value: Optional[int],
     s_and: Callable[[SubBuilder, Qubit, Qubit], AbstractContextManager[Qubit]],
 ) -> Sub:
-    builder = SubBuilder(op.qubit_count + control_bits)
+    builder = SubBuilder.from_qregs(
+        MultiControlled(op, control_bits, control_value).qregs, op.reg_count
+    )
     qubits = builder.qubits
 
     if control_value is None:
@@ -140,7 +150,7 @@ def controlled_multicontrolled_resolver(op: Op, repository: SubRepository) -> Su
     assert isinstance(control_value, int)
     control_bits += 1
     control_value = (control_value << 1) + 1
-    builder = SubBuilder(op.qubit_count, op.reg_count)
+    builder = SubBuilder.from_qregs(op.qregs, op.reg_count)
     builder.add_op(
         MultiControlled(inner_op, control_bits, control_value), builder.qubits
     )

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multi_control_gates.py
@@ -10,7 +10,7 @@
 
 import math
 from contextlib import AbstractContextManager
-from typing import Callable
+from typing import Callable, Sequence
 
 import numpy as np
 
@@ -23,12 +23,13 @@ from quri_parts.qsub.op import (
     param_op,
 )
 from quri_parts.qsub.qubit import Qubit
+from quri_parts.qsub.register import CTRL_QNAME, TARGET_QNAME, QRegSpec
 from quri_parts.qsub.resolve import SubRepository, SubResolver, default_repository
 from quri_parts.qsub.sub import Sub, SubBuilder
 
 from . import NS
 from .cnot import CNOT
-from .control import Controlled
+from .control import Controlled, get_new_ctrl_label
 from .cz import CZ
 from .logic import scoped_and
 from .multi_control import MultiControlled, _multi_controlled_sub
@@ -60,6 +61,9 @@ class _MCBase(ParamUnitaryDef[int]):
     def reg_count_fn(self, _control_bits: int) -> int:
         return 0
 
+    def qregs_fn(self, control_bits: int) -> Sequence[QRegSpec]:
+        return (QRegSpec(CTRL_QNAME, control_bits), QRegSpec(TARGET_QNAME, 1))
+
     def validate_params(self, control_bits: int) -> None:
         if not control_bits >= 1:
             raise ParameterValidationError(
@@ -75,6 +79,9 @@ class _MCRotationBase(ParamUnitaryDef[int, float]):
 
     def reg_count_fn(self, _control_bits: int, _angle: float) -> int:
         return 0
+
+    def qregs_fn(self, control_bits: int, angle: float) -> Sequence[QRegSpec]:
+        return (QRegSpec(CTRL_QNAME, control_bits), QRegSpec(TARGET_QNAME, 1))
 
     def validate_params(self, control_bits: int, _: float) -> None:
         if not control_bits >= 1:
@@ -235,7 +242,12 @@ def MultiControlledNamedMCGatesSub(
     also resolves MultiControlled gates, generating known MC? gates and fallback
     with unknown ops.
     """
-    builder = SubBuilder(target_op.qubit_count + control_bits, target_op.reg_count)
+    ctrl_label = get_new_ctrl_label(target_op.qregs)
+    ctrl_name = CTRL_QNAME if ctrl_label == 0 else f"{CTRL_QNAME}_{ctrl_label}"
+    qregs = (QRegSpec(ctrl_name, control_bits), *target_op.qregs)
+    builder = SubBuilder(
+        target_op.qubit_count + control_bits, target_op.reg_count, qregs
+    )
     qubits = builder.qubits
 
     # Handle negation using add_neg pattern
@@ -396,11 +408,14 @@ def generate_multicontrolled_to_mc_sub_resolver(
             # ex) MultiControlled[U] -> Toffoli + Controlled[U] + Toffoli
             return _multi_controlled_sub(target_op, control_bits, control_value, s_and)
 
-        builder = SubBuilder(op.qubit_count, op.reg_count)
+        builder = SubBuilder(op.qubit_count, op.reg_count, op.qregs)
         control_q = builder.qubits[:control_bits]
         target_q = builder.qubits[control_bits:]
 
-        target_aq = tuple(builder.add_aux_qubit() for _ in target_sub.aux_qubits)
+        if target_sub.aux_qregs is not None:
+            for qr in target_sub.aux_qregs.values():
+                builder.add_aux_qreg(qr.name, qr.size)
+        target_aq = builder.aux_qubits
         qubit_map = dict(zip(target_sub.qubits, target_q)) | dict(
             zip(target_sub.aux_qubits, target_aq)
         )

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multipauli.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/multipauli.py
@@ -8,8 +8,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Sequence
+
 from quri_parts.qsub.lib import std
 from quri_parts.qsub.opsub import ParamUnitarySubDef, param_opsub
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 from quri_parts.qsub.sub import SubBuilder
 
 from . import NS
@@ -21,6 +24,9 @@ class _Pauli(ParamUnitarySubDef[tuple[int, ...]]):
 
     def qubit_count_fn(self, pauli_ids: tuple[int, ...]) -> int:
         return len(pauli_ids)
+
+    def qregs_fn(self, pauli_ids: tuple[int, ...]) -> Sequence[QRegSpec]:
+        return (QRegSpec(DEFAULT_QNAME, len(pauli_ids)),)
 
     def sub(self, builder: SubBuilder, pauli_ids: tuple[int, ...]) -> None:
         for qubit, pauli in zip(builder.qubits, pauli_ids):
@@ -44,6 +50,9 @@ class _PauliRotation(ParamUnitarySubDef[tuple[int, ...], float]):
 
     def qubit_count_fn(self, pauli_ids: tuple[int, ...], angle: float) -> int:
         return len(pauli_ids)
+
+    def qregs_fn(self, pauli_ids: tuple[int, ...], angle: float) -> Sequence[QRegSpec]:
+        return (QRegSpec("qs", len(pauli_ids)),)
 
     def sub(
         self, builder: SubBuilder, pauli_ids: tuple[int, ...], angle: float

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/rotation.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/rotation.py
@@ -9,6 +9,7 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import ParamUnitaryDef, param_op
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 
 from . import NS
 
@@ -17,6 +18,7 @@ class _RX(ParamUnitaryDef[float]):
     ns = NS
     name = "RX"
     qubit_count = 1
+    qregs = (QRegSpec(DEFAULT_QNAME, 1),)
 
 
 RX = param_op(_RX)
@@ -26,6 +28,7 @@ class _RY(ParamUnitaryDef[float]):
     ns = NS
     name = "RY"
     qubit_count = 1
+    qregs = (QRegSpec(DEFAULT_QNAME, 1),)
 
 
 RY = param_op(_RY)
@@ -35,6 +38,7 @@ class _RZ(ParamUnitaryDef[float]):
     ns = NS
     name = "RZ"
     qubit_count = 1
+    qregs = (QRegSpec(DEFAULT_QNAME, 1),)
 
 
 RZ = param_op(_RZ)
@@ -44,6 +48,7 @@ class _Phase(ParamUnitaryDef[float]):
     ns = NS
     name = "Phase"
     qubit_count = 1
+    qregs = (QRegSpec(DEFAULT_QNAME, 1),)
 
 
 Phase = param_op(_Phase)

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/single_clifford.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/single_clifford.py
@@ -9,17 +9,20 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 
 from . import NS
 
-Identity = Op(Ident(NS, "Identity"), 1, self_inverse=True)
-H = Op(Ident(NS, "H"), 1, self_inverse=True)
-X = Op(Ident(NS, "X"), 1, self_inverse=True)
-Y = Op(Ident(NS, "Y"), 1, self_inverse=True)
-Z = Op(Ident(NS, "Z"), 1, self_inverse=True)
-S = Op(Ident(NS, "S"), 1)
-Sdag = Op(Ident(NS, "Sdag"), 1)
-SqrtX = Op(Ident(NS, "SqrtX"), 1)
-SqrtXdag = Op(Ident(NS, "SqrtXdag"), 1)
-SqrtY = Op(Ident(NS, "SqrtY"), 1)
-SqrtYdag = Op(Ident(NS, "SqrtYdag"), 1)
+Identity = Op(
+    Ident(NS, "Identity"), 1, self_inverse=True, qregs=(QRegSpec(DEFAULT_QNAME, 1),)
+)
+H = Op(Ident(NS, "H"), 1, self_inverse=True, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+X = Op(Ident(NS, "X"), 1, self_inverse=True, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+Y = Op(Ident(NS, "Y"), 1, self_inverse=True, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+Z = Op(Ident(NS, "Z"), 1, self_inverse=True, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+S = Op(Ident(NS, "S"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+Sdag = Op(Ident(NS, "Sdag"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+SqrtX = Op(Ident(NS, "SqrtX"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+SqrtXdag = Op(Ident(NS, "SqrtXdag"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+SqrtY = Op(Ident(NS, "SqrtY"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+SqrtYdag = Op(Ident(NS, "SqrtYdag"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
@@ -9,7 +9,8 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 
 from . import NS
 
-SWAP = Op(Ident(NS, "SWAP"), 2, self_inverse=True)
+SWAP = Op(Ident(NS, "SWAP"), 2, self_inverse=True, qregs=(QRegSpec(DEFAULT_QNAME, 2),))

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/t.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/t.py
@@ -9,8 +9,9 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 
 from . import NS
 
-T = Op(Ident(NS, "T"), 1)
-Tdag = Op(Ident(NS, "Tdag"), 1)
+T = Op(Ident(NS, "T"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))
+Tdag = Op(Ident(NS, "Tdag"), 1, qregs=(QRegSpec(DEFAULT_QNAME, 1),))

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/toffoli.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/toffoli.py
@@ -9,7 +9,9 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.register import CTRL_QNAME, TARGET_QNAME, QRegSpec
 
 from . import NS
 
-Toffoli = Op(Ident(NS, "Toffoli"), 3, self_inverse=True)
+toff_qregs = (QRegSpec(CTRL_QNAME, 2), QRegSpec(TARGET_QNAME, 1))
+Toffoli = Op(Ident(NS, "Toffoli"), 3, self_inverse=True, qregs=toff_qregs)

--- a/quri-parts/packages/qsub/quri_parts/qsub/op.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/op.py
@@ -9,10 +9,20 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Generic, NamedTuple, Optional, ParamSpec, Protocol, TypeAlias
+from typing import (
+    Any,
+    Generic,
+    NamedTuple,
+    Optional,
+    ParamSpec,
+    Protocol,
+    Sequence,
+    TypeAlias,
+)
 
 from .namespace import DEFAULT, NameSpace
 from .param import ArrayRef
+from .register import QRegSpec, check_register_appear_once, get_default_qreg_sequence
 
 BaseIdent: TypeAlias = tuple[NameSpace, str]
 # Param should contain str but adding it makes mypy fail with segmentation fault
@@ -65,16 +75,59 @@ class AbstractOp(Protocol):
 class Op:
     id: Ident
     qubit_count: int
+    qregs: Sequence[QRegSpec]
     reg_count: int = 0
     unitary: bool = True
     self_inverse: bool = False
+
+    def __post_init__(self) -> None:
+        self._check_qubit_count()
+        check_register_appear_once(self.qregs)
+
+    @staticmethod
+    def from_qregs(
+        id: Ident,
+        qregs: Sequence[QRegSpec],
+        reg_count: int = 0,
+        unitary: bool = True,
+        self_inverse: bool = False,
+    ) -> "Op":
+        qubit_count = sum([qr.qubit_count for qr in qregs])
+        return Op(id, qubit_count, qregs, reg_count, unitary, self_inverse)
+
+    @staticmethod
+    def from_qubit_count(
+        id: Ident,
+        qubit_count: int,
+        reg_count: int = 0,
+        unitary: bool = True,
+        self_inverse: bool = False,
+    ) -> "Op":
+        qregs = get_default_qreg_sequence(qubit_count)
+        return Op(id, qubit_count, qregs, reg_count, unitary, self_inverse)
 
     @property
     def base_id(self) -> BaseIdent:
         return self.id.base
 
     def __str__(self) -> str:
-        return f"{str(self.id)}(qubits={self.qubit_count}, registers={self.reg_count})"
+        qreg_str = ", ".join(f"{qr.name}: {qr.qubit_count}" for qr in self.qregs)
+        arg_str = ", ".join(
+            [
+                f"qubits={self.qubit_count}",
+                f"qregs=<{qreg_str}>",
+                f"registers={self.reg_count}",
+                f"unitary={self.unitary}",
+                f"self_inv={self.self_inverse}",
+            ]
+        )
+        return f"{str(self.id)}({arg_str})"
+
+    def _check_qubit_count(self) -> None:
+        actual_qubit_cnts = sum([r.qubit_count for r in self.qregs])
+        assert (
+            actual_qubit_cnts == self.qubit_count
+        ), f"Expecting {self.qubit_count} qubits, but got {actual_qubit_cnts} qubits."
 
 
 class OpFactory(Protocol[Params]):
@@ -94,6 +147,13 @@ class OpDef:
     reg_count: int = 0
     unitary: bool = True
     self_inverse: bool = False
+    qregs: Sequence[QRegSpec] | None = None
+
+    @classmethod
+    def get_qregs(cls) -> Sequence[QRegSpec]:
+        if cls.qregs is not None:
+            return cls.qregs
+        return get_default_qreg_sequence(cls.qubit_count)
 
 
 def op(op_def: type[OpDef]) -> Op:
@@ -108,6 +168,7 @@ def op(op_def: type[OpDef]) -> Op:
         reg_count=reg_count,
         unitary=unitary,
         self_inverse=self_inverse,
+        qregs=op_def.get_qregs(),
     )
 
 
@@ -123,6 +184,7 @@ class ParametricMixin(Generic[Params]):
     qubit_count: Optional[int]
     reg_count: Optional[int] = 0
     self_inverse: bool = False
+    qregs: Sequence[QRegSpec] | None = None
 
     def qubit_count_fn(self, *params: Params.args, **_: Params.kwargs) -> int:
         if self.qubit_count is not None:
@@ -135,6 +197,12 @@ class ParametricMixin(Generic[Params]):
             return self.reg_count
         else:
             raise ValueError("reg_count attribute is not set")
+
+    def qregs_fn(self, *params: Params.args, **_: Params.kwargs) -> Sequence[QRegSpec]:
+        if self.qregs is not None:
+            return self.qregs
+        else:
+            return get_default_qreg_sequence(self.qubit_count_fn(*params))
 
     def self_inverse_fn(self, *params: Params.args, **_: Params.kwargs) -> bool:
         return self.self_inverse
@@ -176,12 +244,14 @@ class _ParamOpFactory(OpFactory[Params]):
         reg_count = self.op_def.reg_count_fn(*params)
         unitary = self.op_def.unitary
         self_inverse = self.op_def.self_inverse_fn(*params)
+        qregs = self.op_def.qregs_fn(*params)
         return Op(
             id=ident,
             qubit_count=qubit_count,
             reg_count=reg_count,
             unitary=unitary,
             self_inverse=self_inverse,
+            qregs=qregs,
         )
 
 
@@ -199,6 +269,7 @@ class SimpleParamOp(ParametricMixin[Params]):
     reg_count: Optional[int] = 0
     unitary: bool = True
     self_inverse: bool = False
+    qregs: Sequence[QRegSpec] | None = None
 
     def __call__(self, *params: Params.args) -> Op:
         ident = Ident(*self.base_id, params=params)
@@ -206,10 +277,12 @@ class SimpleParamOp(ParametricMixin[Params]):
         reg_count = self.reg_count_fn(*params)
         unitary = self.unitary
         self_inverse = self.self_inverse_fn(*params)
+        qregs = self.qregs_fn(*params)
         return Op(
             id=ident,
             qubit_count=qubit_count,
             reg_count=reg_count,
             unitary=unitary,
             self_inverse=self_inverse,
+            qregs=qregs,
         )

--- a/quri-parts/packages/qsub/quri_parts/qsub/register.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/register.py
@@ -8,7 +8,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import NamedTuple
+from dataclasses import dataclass
+from typing import NamedTuple, Sequence, overload
+
+from .qubit import Qubit
+
+CTRL_QNAME = "ctrl"
+DEFAULT_QNAME = "qs"
+TARGET_QNAME = "target"
 
 
 class Register(NamedTuple):
@@ -16,3 +23,54 @@ class Register(NamedTuple):
 
     def __str__(self) -> str:
         return f"r{self.uid}"
+
+
+class QRegSpec(NamedTuple):
+    name: str
+    qubit_count: int
+
+
+@dataclass(frozen=True)
+class QuantumRegister:
+    name: str
+    qubits: Sequence[Qubit]
+
+    @property
+    def size(self) -> int:
+        return len(self.qubits)
+
+    @overload
+    def __getitem__(self, idx: int) -> Qubit:
+        ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> Sequence[Qubit]:
+        ...
+
+    def __getitem__(self, idx: int | slice) -> Qubit | Sequence[Qubit]:
+        return self.qubits[idx]
+
+    def get_qubit_idx(self, qubit: Qubit) -> int:
+        return self.qubits.index(qubit)
+
+    def __str__(self) -> str:
+        qstr = ", ".join([str(q) for q in self.qubits])
+        return f"{self.name}<{qstr}>"
+
+
+def check_register_appear_once(qregs: Sequence[QRegSpec]) -> None:
+    name_set: set[str] = set()
+    for qr in qregs:
+        if qr.name in name_set:
+            raise ValueError(f"Duplicated register of name {qr.name}")
+        name_set.add(qr.name)
+
+
+def get_default_qreg_sequence(qubit_count: int) -> Sequence[QRegSpec]:
+    return tuple(QRegSpec(f"{DEFAULT_QNAME}_{i}", 1) for i in range(qubit_count))
+
+
+def get_qregs_from_quantum_register_map(
+    qr_map: dict[str, QuantumRegister]
+) -> Sequence[QRegSpec]:
+    return tuple(QRegSpec(name, len(qr.qubits)) for name, qr in qr_map.items())

--- a/quri-parts/packages/qsub/quri_parts/qsub/sub.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/sub.py
@@ -8,6 +8,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+import itertools
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from math import pi
@@ -15,12 +17,13 @@ from typing import TypeAlias
 
 from .op import Op, ParametricMixin, Params
 from .qubit import Qubit
-from .register import Register
-
-
-def _op_app_str(op: Op, qubits: Sequence[Qubit], regs: Sequence[Register]) -> str:
-    args = [str(x) for x in (*qubits, *regs)]
-    return f"{op.id}({', '.join(args)})"
+from .register import (
+    QRegSpec,
+    QuantumRegister,
+    Register,
+    check_register_appear_once,
+    get_default_qreg_sequence,
+)
 
 
 @dataclass
@@ -31,24 +34,92 @@ class Sub:
     aux_registers: Sequence[Register]
     operations: Sequence[tuple[Op, Sequence[Qubit], Sequence[Register]]]
     phase: float = 0
+    qregs: dict[str, QuantumRegister] | None = None
+    aux_qregs: dict[str, QuantumRegister] | None = None
+
+    @functools.cached_property
+    def qreg_specs(self) -> Sequence[QRegSpec]:
+        assert self.qregs is not None and self.aux_qregs is not None
+        return tuple(
+            QRegSpec(reg_name, qr.size)
+            for reg_name, qr in (self.qregs | self.aux_qregs).items()
+        )
+
+    @functools.cached_property
+    def _sub_qubit_to_local_qubit_str_mapping(self) -> dict[Qubit, str]:
+        qubit_iter = iter((*self.qubits, *self.aux_qubits))
+        qubit_to_local_qubit_map: dict[Qubit, str] = {}
+        for qreg in self.qreg_specs:
+            for local_idx in range(qreg.qubit_count):
+                qubit_to_local_qubit_map[next(qubit_iter)] = f"{qreg.name}.q{local_idx}"
+        return qubit_to_local_qubit_map
+
+    def _get_op_qubit_str(self, op: Op, qubits: Sequence[Qubit]) -> str:
+        local_qubit_strs = (
+            self._sub_qubit_to_local_qubit_str_mapping[q] for q in qubits
+        )
+        text_comp = []
+        for qreg_spec in op.qregs:
+            qbit_str = ", ".join(
+                [next(local_qubit_strs) for _ in range(qreg_spec.qubit_count)]
+            )
+            if qreg_spec.qubit_count > 1:
+                qbit_str = f"({qbit_str})"
+            text_comp.append(f"{qreg_spec.name}: {qbit_str}")
+        return ", ".join(text_comp)
+
+    def _get_cl_reg_str(self, registers: Sequence[Register]) -> str:
+        if len(registers) == 0:
+            return ""
+        elif len(registers) == 1:
+            return f"cl: {str(registers[0])}"
+        else:
+            return f"cl: ({', '.join(map(str, registers))})"
+
+    def _get_operation_str(
+        self, op: Op, qubits: Sequence[Qubit], registers: Sequence[Register]
+    ) -> str:
+        qubit_str = self._get_op_qubit_str(op, qubits)
+        cl_str = self._get_cl_reg_str(registers)
+        texts = ", ".join([text for text in (qubit_str, cl_str) if len(text) > 0])
+        return f"{op.id}({texts})"
 
     def __str__(self) -> str:
         op_str_list = [
-            _op_app_str(op, qubits, regs) for op, qubits, regs in self.operations
+            self._get_operation_str(o, qs, rs) for o, qs, rs in self.operations
         ]
         if len(op_str_list) > 1:
             op_str = "\n " + ",\n ".join(op_str_list) + "\n"
         else:
             op_str = ", ".join(op_str_list)
-        return f"Sub[{op_str}]"
+
+        reg_strs = []
+        if self.qregs is not None:
+            reg_strs.extend([f"{v.name}: {v.size}" for v in self.qregs.values()])
+        if self.aux_qregs is not None:
+            reg_strs.extend([f"{v.name}: {v.size}" for v in self.aux_qregs.values()])
+        if len(self.registers) > 0:
+            reg_strs.extend([str(r) for r in self.registers])
+        if len(self.aux_registers) > 0:
+            reg_strs.extend([str(r) for r in self.aux_registers])
+        reg_str = ", ".join(reg_strs)
+        return f"Sub({reg_str})[{op_str}]"
 
 
 class SubBuilder:
-    def __init__(self, arg_qubits_count: int, arg_reg_count: int = 0) -> None:
+    def __init__(
+        self,
+        arg_qubits_count: int,
+        arg_reg_count: int = 0,
+        arg_qregs: Sequence[QRegSpec] | None = None,
+    ) -> None:
         if arg_qubits_count < 0:
             raise ValueError("arg_qubits_count must be greater than or equal to 0.")
         if arg_reg_count < 0:
             raise ValueError("arg_reg_count must be greater than or equal to 0.")
+        if arg_qregs is None:
+            arg_qregs = get_default_qreg_sequence(arg_qubits_count)
+        check_register_appear_once(arg_qregs)
         self._operations: list[tuple[Op, Sequence[Qubit], Sequence[Register]]] = []
         self._qubits = tuple(Qubit(i) for i in range(arg_qubits_count))
         self._aux_id = arg_qubits_count
@@ -57,6 +128,42 @@ class SubBuilder:
         self._aux_reg_id = arg_reg_count
         self._aux_regs: list[Register] = []
         self._phase: float = 0
+
+        self._arg_qregs = arg_qregs
+        self._qregs = self._get_qregs()
+        self._aux_qregs: dict[str, QuantumRegister] = {}
+
+    @staticmethod
+    def from_qregs(
+        arg_qregs: Sequence[QRegSpec], arg_reg_count: int = 0
+    ) -> "SubBuilder":
+        qubit_count = (
+            sum([qr.qubit_count for qr in arg_qregs]) if len(arg_qregs) != 0 else 0
+        )
+        return SubBuilder(qubit_count, arg_reg_count, arg_qregs)
+
+    def _get_qregs(self) -> dict[str, QuantumRegister]:
+        if self._arg_qregs is None:
+            return None
+        idx = 0
+        regs: dict[str, QuantumRegister] = {}
+        for q_reg_arg in self._arg_qregs:
+            qubits = self._qubits[idx : idx + q_reg_arg.qubit_count]  # noqa: E203
+            regs[q_reg_arg.name] = QuantumRegister(q_reg_arg.name, qubits)
+            idx += q_reg_arg.qubit_count
+        if len(self.qubits) != idx:
+            raise ValueError(
+                f"Qubit count mismatch. Builder request {self.qubits}, "
+                f"but got {idx} qubits from arg_qreg."
+            )
+        return regs
+
+    def _validate_qreg_name(self, new_qreg_name: str) -> None:
+        for name in itertools.chain(self._qregs, self._aux_qregs):
+            assert name != new_qreg_name, (
+                f"New QReg name {new_qreg_name} conflicting with"
+                f" existing QReg name {name}."
+            )
 
     def add_op(
         self, op: Op, qubits: Sequence[Qubit], regs: Sequence[Register] = ()
@@ -88,14 +195,40 @@ class SubBuilder:
     def aux_registers(self) -> Sequence[Register]:
         return tuple(self._aux_regs)
 
-    def add_aux_qubit(self) -> Qubit:
+    @property
+    def qregs(self) -> dict[str, QuantumRegister]:
+        return self._qregs.copy()
+
+    @property
+    def aux_qregs(self) -> dict[str, QuantumRegister]:
+        return self._aux_qregs.copy()
+
+    def get_qregs(self, names: Sequence[str]) -> Sequence[QuantumRegister]:
+        all_regs = self.qregs | self.aux_qregs
+        return tuple(all_regs[name] for name in names)
+
+    def _add_aux_qubit_internal(self) -> Qubit:
         qubit = Qubit(self._aux_id)
         self._aux_id += 1
         self._aux_qubits.append(qubit)
         return qubit
 
+    def add_aux_qubit(self) -> Qubit:
+        qubit = self._add_aux_qubit_internal()
+        name = f"aux_{qubit.uid}"
+        qreg = QuantumRegister(name, (qubit,))
+        self._aux_qregs[name] = qreg
+        return qubit
+
     def add_aux_qubits(self, count: int) -> Sequence[Qubit]:
         return tuple(self.add_aux_qubit() for _ in range(count))
+
+    def add_aux_qreg(self, name: str, qubit_count: int) -> QuantumRegister:
+        self._validate_qreg_name(name)
+        ancs = tuple(self._add_aux_qubit_internal() for _ in range(qubit_count))
+        qreg = QuantumRegister(name, ancs)
+        self._aux_qregs[name] = qreg
+        return qreg
 
     def add_aux_register(self) -> Register:
         reg = Register(self._aux_reg_id)
@@ -110,6 +243,20 @@ class SubBuilder:
         self._phase += phase
         return self._phase
 
+    def connect(self, op: Op, **reg_map: Sequence[Qubit] | QuantumRegister) -> None:
+        qubits: list[Qubit] = []
+        for reg_spec in op.qregs:
+            qs = reg_map[reg_spec.name]
+            if isinstance(qs, QuantumRegister):
+                qs = qs.qubits
+            assert len(qs) == reg_spec.qubit_count, (
+                "Qubit count mismatch. "
+                f"Expected {reg_spec.qubit_count} for register {reg_spec.name}, "
+                f"but got {len(qs)}."
+            )
+            qubits.extend(qs)
+        self.add_op(op, tuple(qubits))
+
     def build(self) -> Sub:
         return Sub(
             tuple(self._qubits),
@@ -118,6 +265,8 @@ class SubBuilder:
             tuple(self._aux_regs),
             tuple(self._operations),
             self._phase % (2 * pi),
+            qregs=self._qregs,
+            aux_qregs=self.aux_qregs,
         )
 
 
@@ -127,13 +276,14 @@ SubFactory: TypeAlias = Callable[Params, Sub]
 class SubDef:
     qubit_count: int
     reg_count: int = 0
+    qregs: Sequence[QRegSpec] | None = None
 
     def sub(self, builder: SubBuilder) -> None:
         raise NotImplementedError
 
 
 def sub(sub_def: type[SubDef]) -> Sub:
-    builder = SubBuilder(sub_def.qubit_count, sub_def.reg_count)
+    builder = SubBuilder(sub_def.qubit_count, sub_def.reg_count, sub_def.qregs)
     sub_def().sub(builder)
     return builder.build()
 
@@ -150,8 +300,7 @@ def param_sub(sub_def: type[ParamSubDef[Params]]) -> SubFactory[Params]:
 
     def s(*params: Params.args, **_: Params.kwargs) -> Sub:
         builder = SubBuilder(
-            d.qubit_count_fn(*params),
-            d.reg_count_fn(*params),
+            d.qubit_count_fn(*params), d.reg_count_fn(*params), d.qregs_fn(*params)
         )
         d.sub(builder, *params)
         return builder.build()

--- a/quri-parts/packages/qsub/tests/eval/test_count.py
+++ b/quri-parts/packages/qsub/tests/eval/test_count.py
@@ -53,10 +53,10 @@ def test_t_count() -> None:
 
 def test_aux_qubits() -> None:
     NS = NameSpace("test")
-    F = Op(Ident(NS, "F"), 1, 0)
-    G = Op(Ident(NS, "G"), 3, 0)
-    H = Op(Ident(NS, "H"), 2, 0)
-    K = Op(Ident(NS, "K"), 2, 0)
+    F = Op.from_qubit_count(Ident(NS, "F"), 1, 0)
+    G = Op.from_qubit_count(Ident(NS, "G"), 3, 0)
+    H = Op.from_qubit_count(Ident(NS, "H"), 2, 0)
+    K = Op.from_qubit_count(Ident(NS, "K"), 2, 0)
 
     fb = SubBuilder(1)
     (fq0,) = fb.qubits
@@ -111,7 +111,7 @@ def test_total_qubits_simple_local_aux() -> None:
 
 def test_total_qubits_simple_nested_aux() -> None:
     NS = NameSpace("test_simple_nested")
-    F = Op(Ident(NS, "F"), 1, 0)
+    F = Op.from_qubit_count(Ident(NS, "F"), 1, 0)
 
     fb = SubBuilder(1)
     (fq0,) = fb.qubits
@@ -139,10 +139,10 @@ def test_total_qubits_simple_nested_aux() -> None:
 
 def test_total_qubits() -> None:
     NS = NameSpace("test")
-    F = Op(Ident(NS, "F"), 1, 0)
-    G = Op(Ident(NS, "G"), 3, 0)
-    H = Op(Ident(NS, "H"), 2, 0)
-    K = Op(Ident(NS, "K"), 2, 0)
+    F = Op.from_qubit_count(Ident(NS, "F"), 1, 0)
+    G = Op.from_qubit_count(Ident(NS, "G"), 3, 0)
+    H = Op.from_qubit_count(Ident(NS, "H"), 2, 0)
+    K = Op.from_qubit_count(Ident(NS, "K"), 2, 0)
 
     fb = SubBuilder(1)
     (fq0,) = fb.qubits

--- a/quri-parts/packages/qsub/tests/lib/std/test_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_control.py
@@ -35,6 +35,7 @@ from quri_parts.qsub.lib.std.control import (
 from quri_parts.qsub.namespace import NameSpace
 from quri_parts.qsub.op import Ident, Op, ParameterValidationError
 from quri_parts.qsub.opsub import OpSubDef, opsub
+from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 from quri_parts.qsub.resolve import (
     SimpleSubRepository,
     SubRepository,
@@ -57,6 +58,92 @@ class TestControlledOp:
             Controlled(M)
 
 
+class TestControlledQRegs:
+    def test_controlled_single_level_qregs(self) -> None:
+        """Controlled(X) should have qregs: (ctrl, qs)"""
+        cx = Controlled(X)
+        assert len(cx.qregs) == 2
+        assert cx.qregs[0] == QRegSpec("ctrl", 1)
+        assert cx.qregs[1] == QRegSpec("qs", 1)
+
+    def test_controlled_nested_two_level_qregs(self) -> None:
+        """Controlled(Controlled(X)) should have qregs: (ctrl_1, ctrl, qs)"""
+        ccx = Controlled(Controlled(X))
+        assert len(ccx.qregs) == 3
+        assert ccx.qregs[0] == QRegSpec("ctrl_1", 1)
+        assert ccx.qregs[1] == QRegSpec("ctrl", 1)
+        assert ccx.qregs[2] == QRegSpec("qs", 1)
+
+    def test_controlled_nested_three_level_qregs(self) -> None:
+        """Controlled(Controlled(Controlled(X))) should have qregs: (ctrl_2,
+        ctrl_1, ctrl, qs)"""
+        cccx = Controlled(Controlled(Controlled(X)))
+        assert len(cccx.qregs) == 4
+        assert cccx.qregs[0] == QRegSpec("ctrl_2", 1)
+        assert cccx.qregs[1] == QRegSpec("ctrl_1", 1)
+        assert cccx.qregs[2] == QRegSpec("ctrl", 1)
+        assert cccx.qregs[3] == QRegSpec("qs", 1)
+
+    def test_controlled_single_qubit_gate_qregs(self) -> None:
+        """All single-qubit Cliffords should have controlled qregs: (ctrl,
+        qs)"""
+        for op in [
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sdag,
+            SqrtX,
+            SqrtXdag,
+            SqrtY,
+            SqrtYdag,
+            RX(0.5),
+            RY(0.5),
+            RZ(0.5),
+            Phase(0.5),
+            T,
+            Tdag,
+        ]:
+            c_op = Controlled(op)
+            assert c_op.qregs == (QRegSpec("ctrl", 1), QRegSpec(DEFAULT_QNAME, 1))
+
+    def test_controlled_cnot_qregs(self) -> None:
+        """Controlled(CNOT) should have qregs: (ctrl_1, ctrl, target)"""
+        c_cnot = Controlled(CNOT)
+        assert c_cnot.qregs == (
+            QRegSpec("ctrl_1", 1),
+            QRegSpec("ctrl", 1),
+            QRegSpec("target", 1),
+        )
+
+    def test_controlled_cz_qregs(self) -> None:
+        """Controlled(CZ) should have qregs: (ctrl_1, ctrl, target)"""
+        c_cz = Controlled(CZ)
+        assert c_cz.qregs == (
+            QRegSpec("ctrl_1", 1),
+            QRegSpec("ctrl", 1),
+            QRegSpec("target", 1),
+        )
+
+    def test_controlled_swap_qregs(self) -> None:
+        """Controlled(SWAP) should have qregs: (ctrl, qs)"""
+        c_swap = Controlled(SWAP)
+        assert c_swap.qregs == (
+            QRegSpec("ctrl", 1),
+            QRegSpec("qs", 2),
+        )
+
+    def test_controlled_toffoli_qregs(self) -> None:
+        """Controlled(Toffoli) should have qregs: (ctrl_1, ctrl, target)"""
+        c_toff = Controlled(Toffoli)
+        assert c_toff.qregs == (
+            QRegSpec("ctrl_1", 1),
+            QRegSpec("ctrl", 2),
+            QRegSpec("target", 1),
+        )
+
+
 _repo = default_repository()
 
 
@@ -67,7 +154,7 @@ class TestControlledSub:
         assert sub is None
 
     def test_expand_sub(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 2, 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 2, 1)
         builder = SubBuilder(2, 1)
         q0, q1 = builder.qubits
         (r,) = builder.registers
@@ -97,7 +184,7 @@ class TestControlledSub:
         assert sub.phase == 0
 
     def test_expand_sub_with_aux_qubits(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         (q,) = builder.qubits
         a = builder.add_aux_qubit()
@@ -122,8 +209,37 @@ class TestControlledSub:
         )
         assert sub.phase == 0
 
+    def test_expand_sub_with_aux_register(self) -> None:
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
+        builder = SubBuilder(1)
+        (q,) = builder.qubits
+        builder.add_aux_qreg("aaa", 1)
+        builder.add_op(H, (q,))
+        builder.add_op(Y, builder.aux_qregs["aaa"][:])
+        f_sub = builder.build()
+        repository = SimpleSubRepository()
+        repository.register_sub(F, f_sub)
+
+        cf = Controlled(F)
+        sub = controlled_sub_resolver(cf, repository)
+        assert sub
+        assert sub.aux_qregs is not None
+        assert len(sub.qubits) == 2
+        assert len(sub.aux_qubits) == 1
+        assert len(sub.registers) == 0
+        assert len(sub.aux_registers) == 0
+        assert len(sub.aux_qregs) == 1
+        assert next(iter(sub.aux_qregs)) == "aaa"
+        q0, q1 = sub.qubits
+        (a,) = sub.aux_qregs["aaa"][:]
+        assert tuple(sub.operations) == (
+            (Controlled(H), (q0, q1), ()),
+            (Controlled(Y), (q0, a), ()),
+        )
+        assert sub.phase == 0
+
     def test_expand_sub_with_aux_registers(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         (q,) = builder.qubits
         r = builder.add_aux_register()
@@ -149,7 +265,7 @@ class TestControlledSub:
         assert sub.phase == 0
 
     def test_expand_sub_with_phase(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         (q,) = builder.qubits
         builder.add_op(H, (q,))
@@ -173,7 +289,7 @@ class TestControlledSub:
         assert sub.phase == 0
 
     def test_expand_sub_with_pi_phase(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         builder.add_op(H, builder.qubits)
         builder.add_phase(math.pi)
@@ -196,7 +312,7 @@ class TestControlledSub:
         assert sub.phase == 0
 
     def test_expand_sub_with_half_pi_phase(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         builder.add_op(H, builder.qubits)
         builder.add_phase(math.pi / 2)
@@ -219,7 +335,7 @@ class TestControlledSub:
         assert sub.phase == 0
 
     def test_expand_sub_with_minus_half_pi_phase(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         builder.add_op(H, builder.qubits)
         builder.add_phase(-math.pi / 2)
@@ -653,6 +769,7 @@ def test_inverse_optimized_controlled() -> None:
     class _HCXH(OpSubDef):
         name = "HCXH"
         qubit_count = 2
+        qregs = (QRegSpec("qs", 2),)
 
         def sub(self, builder: SubBuilder) -> None:
             aux_q = builder.add_aux_qubit()
@@ -698,3 +815,42 @@ def test_inverse_optimized_controlled() -> None:
         (Inverse(Controlled(H)), (qs[0], qs[1]), ()),
     )
     assert tuple(ctrl_inv_sub.operations) == expected_resolved_sub
+
+
+def test_inverse_optimized_controlled_qregs() -> None:
+    class _HCXH(OpSubDef):
+        name = "HCXH"
+        qubit_count = 2
+        qregs = (QRegSpec("my_reg", 2),)
+
+        def sub(self, builder: SubBuilder) -> None:
+            builder.add_op(H, (builder.qubits[0],))
+            builder.add_op(H, (builder.qubits[1],))
+            builder.add_op(CNOT, (builder.qubits[0], builder.qubits[1]))
+            builder.add_op(H, (builder.qubits[0],))
+            builder.add_op(H, (builder.qubits[1],))
+
+    HCXH, _ = opsub(_HCXH)
+
+    def controlled_h_h_resolver(op: Op, repository: SubRepository) -> Sub:
+        builder = SubBuilder.from_qregs(op.qregs, op.reg_count)
+        qs = builder.qubits
+        builder.add_op(H, (qs[1],))
+        builder.add_op(H, (qs[2],))
+        builder.add_op(Controlled(CNOT), (qs[0], qs[1], qs[2]))
+        builder.add_op(H, (qs[2],))
+        builder.add_op(H, (qs[1],))
+        return builder.build()
+
+    test_sub_repository = SimpleSubRepository()
+    register_controlled_resolver(test_sub_repository, controlled_h_h_resolver, HCXH)
+
+    inv_op = Controlled(Inverse(HCXH))
+    assert inv_op.qregs == (QRegSpec("ctrl", 1), QRegSpec("my_reg", 2))
+
+    ctrl_inv_sub = resolve_sub(inv_op, test_sub_repository)
+    assert ctrl_inv_sub is not None
+    assert ctrl_inv_sub.qregs is not None
+    assert "ctrl" in ctrl_inv_sub.qregs
+    assert "my_reg" in ctrl_inv_sub.qregs
+    assert ctrl_inv_sub.qregs["my_reg"].name == "my_reg"

--- a/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_multi_control.py
@@ -51,7 +51,13 @@ from quri_parts.qsub.lib.std.multi_control_gates import (
 from quri_parts.qsub.op import Op
 from quri_parts.qsub.opsub import OpSubDef, opsub
 from quri_parts.qsub.qubit import Qubit
-from quri_parts.qsub.register import Register
+from quri_parts.qsub.register import (
+    CTRL_QNAME,
+    DEFAULT_QNAME,
+    QRegSpec,
+    QuantumRegister,
+    Register,
+)
 from quri_parts.qsub.resolve import default_repository, resolve_sub
 from quri_parts.qsub.sub import SubBuilder
 
@@ -329,6 +335,7 @@ def test_multi_control_with_resolver_complex() -> None:
     class ComplexOpSubDef(OpSubDef):
         name = "ComplexOp"
         qubit_count = 3
+        qregs = (QRegSpec("qs", 3),)
 
         def sub(self, builder: SubBuilder) -> None:
             q0, q1, q2 = builder.qubits
@@ -367,7 +374,10 @@ def test_multi_control_with_resolver_complex() -> None:
     assert resolved_sub is not None
     assert len(resolved_sub.qubits) == 6
     assert len(resolved_sub.aux_qubits) == 0
-
+    assert resolved_sub.qregs == {
+        CTRL_QNAME: QuantumRegister(CTRL_QNAME, resolved_sub.qubits[:3]),
+        DEFAULT_QNAME: QuantumRegister(DEFAULT_QNAME, resolved_sub.qubits[3:]),
+    }
     # Check that it has the expected MultiControlled operations
     q0, q1, q2, q3, q4, q5 = resolved_sub.qubits
     assert resolved_sub.operations == (
@@ -397,6 +407,10 @@ def test_resolve_multicontrolled_various_control_values() -> None:
         mc_toffoli = MultiControlled(Toffoli, control_bits, control_value)
         sub = resolve_sub(mc_toffoli)
         assert sub is not None
+        assert sub.qregs is not None
+        assert sub.qregs["ctrl_1"].size == control_bits  # added ctrl register
+        assert sub.qregs["ctrl"].size == 2  # ctrl register of Toffoli
+        assert sub.qregs["target"].size == 1  # target register of Toffoli
 
         # Assert that the resolved control value matches expected
         assert control_value == expected_resolved_control_value
@@ -445,6 +459,11 @@ def test_resolve_multicontrolled_toffoli_control_values() -> None:
         mc_toffoli = MultiControlled(Toffoli, control_bits, control_value)
         sub = resolve_sub(mc_toffoli, repo)
         assert sub is not None
+        assert sub.qregs is not None
+
+        assert sub.qregs["ctrl_1"].size == control_bits  # added ctrl register
+        assert sub.qregs["ctrl"].size == 2  # ctrl register of Toffoli
+        assert sub.qregs["target"].size == 1  # target register of Toffoli
 
         # Assert that sub.operations consists of exactly one MultiControlled operation
         assert len(sub.operations) == 1
@@ -974,6 +993,52 @@ class TestMultiControlledNamedMCGatesSub:
         assert sub.operations[1][0].id.local_name.startswith("MC")  # MCTdag
         assert sub.operations[2][0].id.local_name == "X"  # Negation
 
+    def test_mc_op_with_aux_qreg(self) -> None:
+        """Test phase π handling when MSB is set in control_value."""
+
+        class TestOpSubDef(OpSubDef):
+            name = "TestOp"
+            qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
+
+            def sub(self, builder: SubBuilder) -> None:
+                q0 = builder.qubits[0]
+                builder.add_op(X, (q0,))
+                aux_qreg = builder.add_aux_qreg("aaa", 2)
+                builder.add_op(Z, (aux_qreg[0],))
+                builder.add_op(Z, (aux_qreg[1],))
+
+        repo = default_repository().copy()
+        test_op, _ = opsub(TestOpSubDef, repo)
+        repo.register_sub_resolver(
+            MultiControlled, generate_multicontrolled_to_mc_sub_resolver()
+        )
+
+        # Test with MSB set (control_value = 0b11, MSB is bit 1)
+        mc_phase_op = MultiControlled(test_op, 2, 0b11)
+        resolved_sub = resolve_sub(mc_phase_op, repo)
+        assert resolved_sub is not None
+        assert resolved_sub.aux_qregs is not None
+
+        assert len(resolved_sub.aux_qregs) == 1
+        assert next(iter(resolved_sub.aux_qregs)) == "aaa"
+        assert len(resolved_sub.aux_qregs["aaa"].qubits) == 2
+
+        qubits = resolved_sub.qubits
+        a_reg = resolved_sub.aux_qregs["aaa"]
+
+        assert resolved_sub.operations[0] == (MultiControlled(X, 2, 0b11), qubits, ())
+        assert resolved_sub.operations[1] == (
+            MultiControlled(Z, 2, 0b11),
+            (*qubits[:2], a_reg[0]),
+            (),
+        )
+        assert resolved_sub.operations[2] == (
+            MultiControlled(Z, 2, 0b11),
+            (*qubits[:2], a_reg[1]),
+            (),
+        )
+
 
 class TestPhaseHandlingInResolver:
     """Test phase handling in generate_multicontrolled_to_mc_sub_resolver."""
@@ -985,6 +1050,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1017,6 +1083,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1054,6 +1121,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1086,6 +1154,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1119,6 +1188,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1152,6 +1222,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1183,6 +1254,7 @@ class TestPhaseHandlingInResolver:
         class PhaseOpSubDef(OpSubDef):
             name = "PhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1215,6 +1287,7 @@ class TestPhaseHandlingInResolver:
         class ZeroPhaseOpSubDef(OpSubDef):
             name = "ZeroPhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1247,6 +1320,7 @@ class TestPhaseHandlingInResolver:
         class LargePhaseOpSubDef(OpSubDef):
             name = "LargePhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]
@@ -1280,6 +1354,7 @@ class TestPhaseHandlingInResolver:
         class NegativePhaseOpSubDef(OpSubDef):
             name = "NegativePhaseOp"
             qubit_count = 1
+            qregs = (QRegSpec("q", 1),)
 
             def sub(self, builder: SubBuilder) -> None:
                 q0 = builder.qubits[0]

--- a/quri-parts/packages/qsub/tests/lib/std/test_qsub_inverse.py
+++ b/quri-parts/packages/qsub/tests/lib/std/test_qsub_inverse.py
@@ -30,7 +30,8 @@ from quri_parts.qsub.lib.std import (
 from quri_parts.qsub.lib.std.inverse import inverse_sub_resolver
 from quri_parts.qsub.namespace import NameSpace
 from quri_parts.qsub.op import Ident, Op, ParameterValidationError
-from quri_parts.qsub.resolve import SimpleSubRepository, default_repository
+from quri_parts.qsub.register import QRegSpec
+from quri_parts.qsub.resolve import SimpleSubRepository, default_repository, resolve_sub
 from quri_parts.qsub.sub import SubBuilder
 
 
@@ -52,7 +53,7 @@ _repo = default_repository()
 
 class TestInverseSub:
     def test_inverse_sub(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 2, 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 2, 1)
         builder = SubBuilder(2, 1)
         q0, q1 = builder.qubits
         (r,) = builder.registers
@@ -82,7 +83,7 @@ class TestInverseSub:
         assert sub.phase == 0
 
     def test_inverse_sub_with_aux_qubits(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         (q,) = builder.qubits
         a = builder.add_aux_qubit()
@@ -107,8 +108,37 @@ class TestInverseSub:
         )
         assert sub.phase == 0
 
+    def test_inverse_sub_with_aux_qreg(self) -> None:
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
+        builder = SubBuilder(1)
+        (q,) = builder.qubits
+        builder.add_aux_qreg("aaa", 1)
+        builder.add_op(H, (q,))
+        builder.add_op(S, builder.aux_qregs["aaa"][:])
+        f_sub = builder.build()
+        repository = SimpleSubRepository()
+        repository.register_sub(F, f_sub)
+
+        fdag = Inverse(F)
+        sub = inverse_sub_resolver(fdag, repository)
+        assert sub
+        assert sub.aux_qregs is not None
+        assert len(sub.qubits) == 1
+        assert len(sub.aux_qubits) == 1
+        assert len(sub.registers) == 0
+        assert len(sub.aux_registers) == 0
+        assert len(sub.aux_qregs) == 1
+        assert next(iter(sub.aux_qregs)) == "aaa"
+        (q,) = sub.qubits
+        (a,) = sub.aux_qregs["aaa"][:]
+        assert tuple(sub.operations) == (
+            (Inverse(S), (a,), ()),
+            (H, (q,), ()),
+        )
+        assert sub.phase == 0
+
     def test_inverse_sub_with_aux_registers(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1)
         builder = SubBuilder(1)
         (q,) = builder.qubits
         r = builder.add_aux_register()
@@ -136,7 +166,7 @@ class TestInverseSub:
         assert sub.phase == 0
 
     def test_inverse_global_phase(self) -> None:
-        F = Op(Ident(NameSpace("test"), "F"), 1, 0)
+        F = Op.from_qubit_count(Ident(NameSpace("test"), "F"), 1, 0)
         builder = SubBuilder(1)
         qs = builder.qubits
         builder.add_op(T, qs)
@@ -232,3 +262,64 @@ def test_inverse_op() -> None:
         assert len(sub.aux_registers) == 0
         assert tuple(sub.operations) == ((expect, sub.qubits, ()),)
         assert sub.phase == 0
+
+
+class TestInverseQRegs:
+    def test_inverse_qregs_preservation(self) -> None:
+        """Inverse(op) should have the same qregs as op."""
+        for op in [
+            X,
+            Y,
+            Z,
+            H,
+            S,
+            Sdag,
+            SqrtX,
+            SqrtXdag,
+            SqrtY,
+            SqrtYdag,
+            RX(0.5),
+            RY(0.5),
+            RZ(0.5),
+            Phase(0.5),
+            T,
+            Tdag,
+            CNOT,
+            CZ,
+            SWAP,
+            Toffoli,
+            Controlled(X),
+            Controlled(Controlled(X)),
+            Controlled(CNOT),
+            MultiControlled(X, 2, 0b11),
+        ]:
+            inv_op = Inverse(op)
+            assert inv_op.qregs == op.qregs
+
+    def test_inverse_resolved_sub_qregs(self) -> None:
+        """resolve_sub(Inverse(op)) should have the same qregs as
+        Inverse(op)"""
+
+        def _check_op_inv(op: Op) -> None:
+            inv_op = Inverse(op)
+            sub = resolve_sub(inv_op, repo)
+            assert sub is not None
+            assert sub.qregs is not None
+
+            expected_names = [qr.name for qr in op.qregs]
+            assert list(sub.qregs.keys()) == expected_names
+            for spec in op.qregs:
+                assert sub.qregs[spec.name].name == spec.name
+                assert len(sub.qregs[spec.name].qubits) == spec.qubit_count
+
+        A = Op.from_qregs(Ident(NameSpace("test"), "A"), qregs=(QRegSpec("a_reg", 2),))
+        builder = SubBuilder.from_qregs(A.qregs)
+        builder.add_op(X, (builder.qubits[0],))
+        builder.add_op(X, (builder.qubits[1],))
+        a_sub = builder.build()
+
+        repo = _repo.copy()
+        repo.register_sub(A, a_sub)
+
+        for op in [A, Controlled(A), MultiControlled(A, 2, 0b11)]:
+            _check_op_inv(op)

--- a/quri-parts/packages/qsub/tests/test_expand.py
+++ b/quri-parts/packages/qsub/tests/test_expand.py
@@ -6,10 +6,10 @@ from quri_parts.qsub.op import Ident, Op
 from quri_parts.qsub.qubit import Qubit
 
 NS = NameSpace("test")
-F = Op(Ident(NS, "F"), 3, 0)
-G = Op(Ident(NS, "G"), 3, 0)
-H = Op(Ident(NS, "H"), 2, 0)
-K = Op(Ident(NS, "K"), 2, 0)
+F = Op.from_qubit_count(Ident(NS, "F"), 3, 0)
+G = Op.from_qubit_count(Ident(NS, "G"), 3, 0)
+H = Op.from_qubit_count(Ident(NS, "H"), 2, 0)
+K = Op.from_qubit_count(Ident(NS, "K"), 2, 0)
 
 
 def test_expand() -> None:

--- a/quri-parts/packages/qsub/tests/test_op.py
+++ b/quri-parts/packages/qsub/tests/test_op.py
@@ -20,7 +20,9 @@ class TestOpDef:
             qubit_count = 3
 
         FooBar = op(_D)
-        assert FooBar == Op(Ident(DEFAULT, "FooBar", ()), qubit_count=3, unitary=True)
+        assert FooBar == Op.from_qubit_count(
+            Ident(DEFAULT, "FooBar", ()), qubit_count=3, unitary=True
+        )
 
     def test_unitary(self) -> None:
         class _D(UnitaryDef):
@@ -28,7 +30,9 @@ class TestOpDef:
             qubit_count = 3
 
         FooBar = op(_D)
-        assert FooBar == Op(Ident(DEFAULT, "FooBar", ()), qubit_count=3, unitary=True)
+        assert FooBar == Op.from_qubit_count(
+            Ident(DEFAULT, "FooBar", ()), qubit_count=3, unitary=True
+        )
 
     def test_non_unitary(self) -> None:
         class _D(NonUnitaryDef):
@@ -36,7 +40,9 @@ class TestOpDef:
             qubit_count = 3
 
         FooBar = op(_D)
-        assert FooBar == Op(Ident(DEFAULT, "FooBar", ()), qubit_count=3, unitary=False)
+        assert FooBar == Op.from_qubit_count(
+            Ident(DEFAULT, "FooBar", ()), qubit_count=3, unitary=False
+        )
 
     def test_op_full(self) -> None:
         namespace = NameSpace("foo")
@@ -50,7 +56,7 @@ class TestOpDef:
             unitary = False
 
         FooBar = op(_D)
-        assert FooBar == Op(
+        assert FooBar == Op.from_qubit_count(
             Ident(namespace, "FooBar", (1, 2)),
             qubit_count=3,
             reg_count=2,

--- a/quri-parts/packages/qsub/tests/test_opsub.py
+++ b/quri-parts/packages/qsub/tests/test_opsub.py
@@ -13,7 +13,7 @@ from quri_parts.qsub.opsub import (
 from quri_parts.qsub.resolve import default_repository
 from quri_parts.qsub.sub import Sub, SubBuilder
 
-X = Op(Ident(DEFAULT, "X", ()), qubit_count=1)
+X = Op.from_qubit_count(Ident(DEFAULT, "X", ()), qubit_count=1)
 
 
 class TestOpSubDef:
@@ -29,7 +29,9 @@ class TestOpSubDef:
                 builder.add_op(X, (c,))
 
         Foo, FooSub = opsub(_D, None)
-        assert Foo == Op(Ident(DEFAULT, "Foo", ()), qubit_count=3, unitary=True)
+        assert Foo == Op.from_qubit_count(
+            Ident(DEFAULT, "Foo", ()), qubit_count=3, unitary=True
+        )
         assert isinstance(FooSub, Sub)
         assert len(FooSub.qubits) == 3
         assert len(FooSub.operations) == 3
@@ -46,7 +48,9 @@ class TestOpSubDef:
                 builder.add_op(X, (c,))
 
         Foo, FooSub = opsub(_D, None)
-        assert Foo == Op(Ident(DEFAULT, "Foo", ()), qubit_count=3, unitary=True)
+        assert Foo == Op.from_qubit_count(
+            Ident(DEFAULT, "Foo", ()), qubit_count=3, unitary=True
+        )
         assert isinstance(FooSub, Sub)
         assert len(FooSub.qubits) == 3
         assert len(FooSub.operations) == 3
@@ -63,7 +67,9 @@ class TestOpSubDef:
                 builder.add_op(X, (c,))
 
         Foo, FooSub = opsub(_D, None)
-        assert Foo == Op(Ident(DEFAULT, "Foo", ()), qubit_count=3, unitary=False)
+        assert Foo == Op.from_qubit_count(
+            Ident(DEFAULT, "Foo", ()), qubit_count=3, unitary=False
+        )
         assert isinstance(FooSub, Sub)
         assert len(FooSub.qubits) == 3
         assert len(FooSub.operations) == 3
@@ -86,7 +92,7 @@ class TestOpSubDef:
                 builder.add_op(X, (c,))
 
         Foo, FooSub = opsub(_D, None)
-        assert Foo == Op(
+        assert Foo == Op.from_qubit_count(
             Ident(namespace, "Foo", (1, 2)), qubit_count=3, reg_count=2, unitary=False
         )
         assert isinstance(FooSub, Sub)
@@ -127,7 +133,7 @@ class TestParamOpSubDef:
         Foo, FooSub = param_opsub(_D, None)
         assert Foo.base_id == (DEFAULT, "Foo")
 
-        assert Foo(2) == Op(Ident(DEFAULT, "Foo", (2,)), qubit_count=3)
+        assert Foo(2) == Op.from_qubit_count(Ident(DEFAULT, "Foo", (2,)), qubit_count=3)
 
         assert isinstance(FooSub(2), Sub)
         assert len(FooSub(2).qubits) == 3
@@ -148,7 +154,9 @@ class TestParamOpSubDef:
         Foo, FooSub = param_opsub(_D, None)
         assert Foo.base_id == (DEFAULT, "Foo")
 
-        assert Foo(2) == Op(Ident(DEFAULT, "Foo", (2,)), qubit_count=3, unitary=True)
+        assert Foo(2) == Op.from_qubit_count(
+            Ident(DEFAULT, "Foo", (2,)), qubit_count=3, unitary=True
+        )
 
         assert isinstance(FooSub(2), Sub)
         assert len(FooSub(2).qubits) == 3
@@ -169,7 +177,9 @@ class TestParamOpSubDef:
         Foo, FooSub = param_opsub(_D, None)
         assert Foo.base_id == (DEFAULT, "Foo")
 
-        assert Foo(2) == Op(Ident(DEFAULT, "Foo", (2,)), qubit_count=3, unitary=False)
+        assert Foo(2) == Op.from_qubit_count(
+            Ident(DEFAULT, "Foo", (2,)), qubit_count=3, unitary=False
+        )
 
         assert isinstance(FooSub(2), Sub)
         assert len(FooSub(2).qubits) == 3
@@ -197,7 +207,7 @@ class TestParamOpSubDef:
         Foo, FooSub = param_opsub(_D, None)
         assert Foo.base_id == (namespace, "Foo")
 
-        assert Foo(2) == Op(
+        assert Foo(2) == Op.from_qubit_count(
             Ident(namespace, "Foo", (2,)), qubit_count=4, reg_count=6, unitary=False
         )
 

--- a/quri-parts/packages/qsub/tests/test_recursion.py
+++ b/quri-parts/packages/qsub/tests/test_recursion.py
@@ -14,9 +14,9 @@ from quri_parts.qsub.sub import SubBuilder
 
 def _recursive_msub_with_primitives() -> tuple[MachineSub, set[Op]]:
     NS = NameSpace("test")
-    F = Op(Ident(NS, "F"), 1)
-    G = Op(Ident(NS, "G"), 2)
-    H = Op(Ident(NS, "H"), 1)
+    F = Op.from_qubit_count(Ident(NS, "F"), 1)
+    G = Op.from_qubit_count(Ident(NS, "G"), 2)
+    H = Op.from_qubit_count(Ident(NS, "H"), 1)
 
     fb = SubBuilder(2)
     (q0, q1) = fb.qubits

--- a/quri-parts/packages/qsub/tests/test_resolve.py
+++ b/quri-parts/packages/qsub/tests/test_resolve.py
@@ -90,9 +90,9 @@ class TestSubRepository:
         assert repository.find_resolver(mc21_cy) == mcc_resolver
 
     def test_with_override(self) -> None:
-        op1 = Op(Ident(NS, "op1"), 1)
-        op2 = Op(Ident(NS, "op2"), 1)
-        op3 = Op(Ident(NS, "op3"), 1)
+        op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
+        op2 = Op.from_qubit_count(Ident(NS, "op2"), 1)
+        op3 = Op.from_qubit_count(Ident(NS, "op3"), 1)
 
         # Create parent repository with resolvers for op1 and op2
         parent_repo = SimpleSubRepository()
@@ -153,10 +153,10 @@ class TestSubRepository:
         assert sub3 == child_op3_sub()
 
     def test_composite_base_and_addition(self) -> None:
-        op0 = Op(Ident(NS, "op0"), 1)
-        op1 = Op(Ident(NS, "op1"), 1)
-        op2 = Op(Ident(NS, "op2"), 1)
-        op3 = Op(Ident(NS, "op3"), 1)
+        op0 = Op.from_qubit_count(Ident(NS, "op0"), 1)
+        op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
+        op2 = Op.from_qubit_count(Ident(NS, "op2"), 1)
+        op3 = Op.from_qubit_count(Ident(NS, "op3"), 1)
 
         # Create base repository with op0
         override0_repo = SimpleSubRepository()
@@ -238,10 +238,10 @@ class TestSubRepository:
         assert resolver0(op0, final_composite) == override0_op0_sub()
 
     def test_both_base_and_addition_composite(self) -> None:
-        op0 = Op(Ident(NS, "op0"), 1)
-        op1 = Op(Ident(NS, "op1"), 1)
-        op2 = Op(Ident(NS, "op2"), 1)
-        op3 = Op(Ident(NS, "op3"), 1)
+        op0 = Op.from_qubit_count(Ident(NS, "op0"), 1)
+        op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
+        op2 = Op.from_qubit_count(Ident(NS, "op2"), 1)
+        op3 = Op.from_qubit_count(Ident(NS, "op3"), 1)
 
         override0_repo = SimpleSubRepository()
 
@@ -314,8 +314,8 @@ class TestSubRepository:
         assert resolver0(op0, final_composite) == override0_op0_sub()
 
     def test_root_as_addition(self) -> None:
-        op1 = Op(Ident(NS, "op1"), 1)
-        op2 = Op(Ident(NS, "op2"), 1)
+        op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
+        op2 = Op.from_qubit_count(Ident(NS, "op2"), 1)
 
         repo_1 = SimpleSubRepository()
 
@@ -380,9 +380,9 @@ class TestSubRepository:
 
 class TestCollectSubs:
     def test_collect_subs(self) -> None:
-        op1 = Op(Ident(NS, "op1"), 1)
-        op2 = Op(Ident(NS, "op2"), 2)
-        op3 = Op(Ident(NS, "op3"), 3)
+        op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
+        op2 = Op.from_qubit_count(Ident(NS, "op2"), 2)
+        op3 = Op.from_qubit_count(Ident(NS, "op3"), 3)
 
         repository = SimpleSubRepository()
 
@@ -420,7 +420,7 @@ class TestCollectSubs:
         assert collected_subs == {op3: op3_sub(), op2: op2_sub()}
 
     def test_collect_subs_parametric(self) -> None:
-        op = Op(Ident(NS, "op"), 1)
+        op = Op.from_qubit_count(Ident(NS, "op"), 1)
 
         indexed_op1: OpFactory[int] = SimpleParamOp((NS, "indexed_op1"), 1)
 
@@ -481,8 +481,8 @@ class TestCollectSubs:
         }
 
     def test_collect_subs_custom_resolver(self) -> None:
-        op = Op(Ident(NS, "op"), 2)
-        op1 = Op(Ident(NS, "op1"), 1)
+        op = Op.from_qubit_count(Ident(NS, "op"), 2)
+        op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
         control: OpFactory[Op] = SimpleParamOp((NS, "control"), 2)
 
         repository = SimpleSubRepository()

--- a/quri-parts/packages/qsub/tests/test_sub.py
+++ b/quri-parts/packages/qsub/tests/test_sub.py
@@ -1,6 +1,9 @@
 import pytest
 
+from quri_parts.qsub.namespace import DEFAULT
 from quri_parts.qsub.op import OpDef, op
+from quri_parts.qsub.qubit import Qubit
+from quri_parts.qsub.register import QRegSpec
 from quri_parts.qsub.sub import ParamSubDef, Sub, SubBuilder, SubDef, param_sub, sub
 
 
@@ -132,4 +135,137 @@ def test_parametric_sub_decorator_variable_qubits() -> None:
     assert isinstance(test_sub, Sub)
     assert len(test_sub.qubits) == 6
     assert len(test_sub.registers) == 9
-    assert len(test_sub.operations) == 6
+
+
+def test_sub_add_aux_qreg() -> None:
+    builder = SubBuilder(2)
+
+    qreg = builder.add_aux_qreg("my_aux", 2)
+
+    assert qreg.name == "my_aux"
+    assert len(qreg.qubits) == 2
+    assert qreg.size == 2
+    assert "my_aux" in builder.aux_qregs
+    assert builder.aux_qregs["my_aux"] == qreg
+    assert qreg.qubits[0] == Qubit(2)
+    assert qreg.qubits[1] == Qubit(3)
+
+    q_solo = builder.add_aux_qubit()
+    assert q_solo == Qubit(4)
+
+
+def test_sub_add_aux_qubits_register_names() -> None:
+    builder = SubBuilder(2)
+
+    qubits = builder.add_aux_qubits(3)
+
+    # Each qubit should have a dedicated register named aux_{uid}
+    assert qubits[0] == Qubit(2)
+    assert qubits[1] == Qubit(3)
+    assert qubits[2] == Qubit(4)
+
+    assert "aux_2" in builder.aux_qregs
+    assert "aux_3" in builder.aux_qregs
+    assert "aux_4" in builder.aux_qregs
+
+    assert builder.aux_qregs["aux_2"].qubits == (Qubit(2),)
+    assert builder.aux_qregs["aux_3"].qubits == (Qubit(3),)
+    assert builder.aux_qregs["aux_4"].qubits == (Qubit(4),)
+
+
+def test_sub_from_qregs() -> None:
+    specs = [QRegSpec("a", 2), QRegSpec("b", 1)]
+    builder = SubBuilder.from_qregs(specs, arg_reg_count=2)
+
+    assert len(builder.qubits) == 3
+    assert len(builder.registers) == 2
+
+    assert "a" in builder.qregs
+    assert "b" in builder.qregs
+
+    reg_a = builder.qregs["a"]
+    reg_b = builder.qregs["b"]
+
+    assert reg_a.name == "a"
+    assert reg_a.size == 2
+    assert reg_b.name == "b"
+    assert reg_b.size == 1
+
+    assert reg_a.qubits[0] == Qubit(0)
+    assert reg_a.qubits[1] == Qubit(1)
+
+    assert reg_b.qubits[0] == Qubit(2)
+
+
+def test_sub_from_qregs_empty() -> None:
+    builder = SubBuilder.from_qregs([], arg_reg_count=0)
+    assert len(builder.qubits) == 0
+    assert len(builder.registers) == 0
+
+
+def test_connect_basic() -> None:
+    class _D(OpDef):
+        name = "MyOp"
+        qubit_count = 3
+        qregs = (QRegSpec("a", 1), QRegSpec("b", 2))
+
+    D = op(_D)
+
+    builder = SubBuilder.from_qregs([QRegSpec("reg1", 2), QRegSpec("reg2", 2)])
+    reg1 = builder.qregs["reg1"]
+    reg2 = builder.qregs["reg2"]
+
+    builder.connect(D, a=(reg1[1],), b=reg2)
+
+    built_sub = builder.build()
+    assert len(built_sub.operations) == 1
+    op_inst, qubits, _ = built_sub.operations[0]
+
+    assert op_inst.id.base == (DEFAULT, "MyOp")
+    assert qubits == (reg1[1], reg2[0], reg2[1])
+
+
+def test_connect_with_slices() -> None:
+    class _D(OpDef):
+        name = "MyOp"
+        qubit_count = 2
+        qregs = (QRegSpec("a", 1), QRegSpec("b", 1))
+
+    D = op(_D)
+
+    builder = SubBuilder(2)
+    qubits = builder.qubits
+    builder.connect(D, a=(qubits[0],), b=(qubits[1],))
+
+    built_sub = builder.build()
+    assert len(built_sub.operations) == 1
+    _, qs, _ = built_sub.operations[0]
+    assert qs == (qubits[0], qubits[1])
+
+
+def test_connect_mismatch() -> None:
+    class _D(OpDef):
+        name = "MyOp"
+        qubit_count = 2
+        qregs = (QRegSpec("a", 2),)  # Wants 2 qubits
+
+    D = op(_D)
+
+    builder = SubBuilder(2)
+    q = builder.qubits[0]
+
+    with pytest.raises(AssertionError, match="Qubit count mismatch.*Expected 2"):
+        builder.connect(D, a=(q,))
+
+
+def test_connect_missing_arg() -> None:
+    class _D(OpDef):
+        name = "MyOp"
+        qubit_count = 1
+        qregs = (QRegSpec("req", 1),)
+
+    D = op(_D)
+    builder = SubBuilder(1)
+
+    with pytest.raises(KeyError):
+        builder.connect(D, wrong_name=[builder.qubits[0]])


### PR DESCRIPTION
Introduce the quantum register feature for building subs easier. 
* Introduce `QRegSpec` for specifying quantum register specifications for `Op`s and `OpDef`s.
* Introduce `QuantumRegister` for `Sub` and `SubBulder` to hold the QRegSpec and concrete `Qubit`s.
* Automate the control register naming when nested and inverse register naming.
* `SubBulder`
    * Introduced `from_qreg` feature to instantiate SubBuilder from register specifications
    * Introduced `.connect` to connect Op registers to SubBulder qubits.