### PR TITLE
Add Rot op

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/__init__.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/__init__.py
@@ -49,7 +49,7 @@ from .single_clifford import (
     Y,
     Z,
 )
-from .swap import SWAP
+from .swap import SWAP, Rot, RotSub
 from .t import T, Tdag
 from .toffoli import Toffoli
 
@@ -96,6 +96,8 @@ __all__ = [
     "SqrtY",
     "SqrtYdag",
     "SWAP",
+    "Rot",
+    "RotSub",
     "T",
     "Tdag",
     "Toffoli",

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
@@ -37,8 +37,8 @@ class _Rot(ParamUnitarySubDef[int]):
     position.
 
     The rotation is implemented as a ladder of adjacent :data:`SWAP`
-    operations, moving the state of the first qubit to the last qubit while
-    shifting every other qubit one position toward the first.
+    operations, moving the state of the first qubit to the last qubit
+    while shifting every other qubit one position toward the first.
     """
 
     name = "Rot"

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
@@ -33,6 +33,14 @@ default_repository().register_sub(SWAP, _swap_sub())
 
 
 class _Rot(ParamUnitarySubDef[int]):
+    """Cyclically rotates the states of an ``n``-qubit register by one
+    position.
+
+    The rotation is implemented as a ladder of adjacent :data:`SWAP`
+    operations, moving the state of the first qubit to the last qubit while
+    shifting every other qubit one position toward the first.
+    """
+
     name = "Rot"
     unitary = True
 

--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/std/swap.py
@@ -9,6 +9,7 @@
 # limitations under the License.
 
 from quri_parts.qsub.op import Ident, Op
+from quri_parts.qsub.opsub import ParamUnitarySubDef, param_opsub
 from quri_parts.qsub.register import DEFAULT_QNAME, QRegSpec
 from quri_parts.qsub.resolve import default_repository
 from quri_parts.qsub.sub import Sub, SubBuilder
@@ -29,3 +30,19 @@ def _swap_sub() -> Sub:
 
 
 default_repository().register_sub(SWAP, _swap_sub())
+
+
+class _Rot(ParamUnitarySubDef[int]):
+    name = "Rot"
+    unitary = True
+
+    def qubit_count_fn(self, n: int) -> int:
+        return n
+
+    def sub(self, builder: SubBuilder, n: int) -> None:
+        qubits = builder.qubits
+        for i in reversed(range(1, n)):
+            builder.add_op(SWAP, (qubits[i - 1], qubits[i]))
+
+
+Rot, RotSub = param_opsub(_Rot)


### PR DESCRIPTION
This PR adds `Rot[n]` Op in qsub.

`Rot` is similar to `Shift` operation in classical computers, but it additionally move the MSB to LSB, that makes this operation unitary. `Rot` is traditional naming used in many classical ISAs.