### PR TITLE
Implement __hash__() for Ident to support non-hashable Params like Op

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/op.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/op.py
@@ -45,7 +45,7 @@ def _param_hash(p: object) -> int:
             return hash(tuple(_param_hash(v) for v in p))
         elif isinstance(p, Op):
             return hash(p.id)
-        elif isinstance(p, OpFactory):
+        elif hasattr(p, "base_id"):  # p is OpFactory
             return hash(p.base_id)
         else:
             raise e
@@ -79,7 +79,9 @@ class Ident(NamedTuple):
         return self.to_str(full=True)
 
     def __hash__(self) -> int:
-        return hash((self.ns, self.local_name, tuple(_param_hash(p) for p in self.params)))
+        return hash(
+            (self.ns, self.local_name, tuple(_param_hash(p) for p in self.params))
+        )
 
 
 class AbstractOp(Protocol):

--- a/quri-parts/packages/qsub/quri_parts/qsub/op.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/op.py
@@ -37,6 +37,20 @@ def _param_short_str(p: Param) -> str:
         return str(p)
 
 
+def _param_hash(p: object) -> int:
+    try:
+        return hash(p)
+    except TypeError as e:
+        if isinstance(p, tuple):
+            return hash(tuple(_param_hash(v) for v in p))
+        elif isinstance(p, Op):
+            return hash(p.id)
+        elif isinstance(p, OpFactory):
+            return hash(p.base_id)
+        else:
+            raise e
+
+
 class Ident(NamedTuple):
     ns: NameSpace
     local_name: str
@@ -63,6 +77,9 @@ class Ident(NamedTuple):
 
     def __str__(self) -> str:
         return self.to_str(full=True)
+
+    def __hash__(self) -> int:
+        return hash((self.ns, self.local_name, tuple(_param_hash(p) for p in self.params)))
 
 
 class AbstractOp(Protocol):

--- a/quri-parts/packages/qsub/tests/test_resolve.py
+++ b/quri-parts/packages/qsub/tests/test_resolve.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from quri_parts.qsub.lib.std import MCX, H, MultiControlled, Pauli, X, Y
 from quri_parts.qsub.namespace import NameSpace
 from quri_parts.qsub.op import Ident, Op, OpFactory, SimpleParamOp
+from quri_parts.qsub.opsub import ParamOpSubDef, param_opsub
 from quri_parts.qsub.qubit import Qubit
 from quri_parts.qsub.resolve import (
     CompositeSubRepository,
@@ -10,6 +11,7 @@ from quri_parts.qsub.resolve import (
     SimpleSubResolver,
     SubCollector,
     SubRepository,
+    resolve_sub,
 )
 from quri_parts.qsub.resolve.simulator_repo import simulator_repository
 from quri_parts.qsub.sub import Sub, SubBuilder
@@ -379,6 +381,41 @@ class TestSubRepository:
 
 
 class TestCollectSubs:
+    def test_resolve_param_opsub_with_op_param(self) -> None:
+        inner_op = Op.from_qubit_count(Ident(NS, "inner", (X,)), 1)
+
+        repository = SimpleSubRepository()
+
+        def inner_sub() -> Sub:
+            builder = SubBuilder(1)
+            (q,) = builder.qubits
+            builder.add_op(Y, (q,))
+            return builder.build()
+
+        repository.register_sub(inner_op, inner_sub())
+
+        class _Wrapper(ParamOpSubDef[Op]):
+            ns = NS
+            name = "Wrapper"
+            qubit_count = 1
+
+            def sub(self, builder: SubBuilder, target_op: Op) -> None:
+                (q,) = builder.qubits
+                builder.add_op(target_op, (q,))
+
+        Wrapper, WrapperSub = param_opsub(_Wrapper, repository)
+        wrapped_op = Wrapper(inner_op)
+
+        resolved = resolve_sub(wrapped_op, repository)
+        assert resolved == WrapperSub(inner_op)
+
+        collector = SubCollector(repository)
+        collected_subs = collector.collect_subs(wrapped_op)
+        assert collected_subs == {
+            wrapped_op: WrapperSub(inner_op),
+            inner_op: inner_sub(),
+        }
+
     def test_collect_subs(self) -> None:
         op1 = Op.from_qubit_count(Ident(NS, "op1"), 1)
         op2 = Op.from_qubit_count(Ident(NS, "op2"), 2)


### PR DESCRIPTION
This PR add support of non-hashable parameters in qsub

# Background

- There are some algorithms in qsub, which presumes that the `Op` is hashable (for example, `dict[Op, Sub]`)
- `Op` is currently unhashable because it has 

# Solution

In this PR, I add `Op.__hash__()` implementation manually, and hashing algorithm:

```py
def _param_hash(p: object) -> int:
    try:
        return hash(p)
    except TypeError as e:
        if isinstance(p, tuple):
            return hash(tuple(_param_hash(v) for v in p))
        elif isinstance(p, Op):
            return hash(p.id)
        elif hasattr(p, "base_id"):  # p is OpFactory
            return hash(p.base_id)
        else:
            raise e
```

This algorithm should be extended when we encounter some additional patterns that use other unhashable types in `Param`.