### PR TITLE
Bump version to 0.26.2

### DIFF
--- a/.github/workflows/quri-parts-licensed.yml
+++ b/.github/workflows/quri-parts-licensed.yml
@@ -33,7 +33,8 @@ jobs:
     - run: python -m venv venv
     - run: |
         . venv/bin/activate
-        pip install -e packages/*
+        # pyqret is not on PyPI; supply it from the QunaSys release feed.
+        pip install -e packages/* --find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -6191,7 +6191,7 @@ temp = ">=2020.7.2,<2021.0.0"
 
 [[package]]
 name = "quri-algo"
-version = "0.26.1"
+version = "0.26.2"
 description = "Algorithm library based on QURI Parts"
 optional = false
 python-versions = ">=3.10,<4"
@@ -6556,7 +6556,7 @@ url = "quri-parts/packages/qulacs"
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.26.1"
+version = "0.26.2"
 description = "Platform-independent quantum circuit library"
 optional = false
 python-versions = "^3.9.8"
@@ -6638,7 +6638,7 @@ url = "quri-parts/packages/tket"
 
 [[package]]
 name = "quri-vm"
-version = "0.26.1"
+version = "0.26.2"
 description = ""
 optional = false
 python-versions = "<4,>=3.10"

--- a/poetry.lock
+++ b/poetry.lock
@@ -999,7 +999,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "python_version >= \"3.10\" and sys_platform == \"win32\" or platform_system == \"Windows\" and (extra == \"cirq\" or extra == \"openfermion\")", dev = "sys_platform == \"win32\" or platform_system == \"Windows\"", lint = "platform_system == \"Windows\""}
+markers = {main = "python_version >= \"3.10\" and sys_platform == \"win32\" or platform_system == \"Windows\" and (extra == \"cirq\" or extra == \"openfermion\")", dev = "platform_system == \"Windows\" or sys_platform == \"win32\"", lint = "platform_system == \"Windows\""}
 
 [[package]]
 name = "comm"
@@ -1892,7 +1892,7 @@ markers = {main = "python_version < \"3.14\" and extra == \"openfermion\"", dev 
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.63.2,<2.0.0"
 grpcio = [
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
@@ -4847,7 +4847,7 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
 groups = ["dev", "doc"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or sys_platform != \"win32\" and python_version < \"3.10\""
+markers = "(python_version >= \"3.10\" and python_version < \"3.14\" and (sys_platform == \"linux\" or sys_platform == \"darwin\" or sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\" and sys_platform != \"emscripten\") or python_version >= \"3.14\" and sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.10\" or python_version < \"3.10\" and sys_platform != \"win32\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -5267,7 +5267,7 @@ files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-markers = {dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or sys_platform != \"win32\" and python_version < \"3.10\"", doc = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\" or sys_platform != \"win32\" and python_version < \"3.10\""}
+markers = {dev = "(python_version >= \"3.10\" and python_version < \"3.14\" and (sys_platform == \"linux\" or sys_platform == \"darwin\" or sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\" and sys_platform != \"emscripten\") or python_version >= \"3.14\" and sys_platform != \"win32\" and sys_platform != \"emscripten\") and python_version >= \"3.10\" or python_version < \"3.10\" and sys_platform != \"win32\"", doc = "os_name != \"nt\" or sys_platform == \"linux\" or sys_platform == \"darwin\" or python_version < \"3.14\" and sys_platform != \"emscripten\" and sys_platform != \"win32\" or python_version < \"3.10\" and sys_platform != \"win32\" or sys_platform != \"win32\" and sys_platform != \"emscripten\""}
 
 [[package]]
 name = "pubchempy"
@@ -5613,7 +5613,7 @@ groups = ["main", "dev"]
 files = [
     {file = "pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:2949e5e3f7a075acefb30155146b08d59a762412061b5aea11c8c73f458e7be0"},
 ]
-markers = {main = "python_version >= \"3.10\" and extra == \"qret\"", dev = "python_version >= \"3.10\""}
+markers = {main = "python_version == \"3.10\" and sys_platform == \"darwin\" and extra == \"qret\"", dev = "python_version == \"3.10\" and sys_platform == \"darwin\""}
 
 [package.dependencies]
 typing_extensions = "*"
@@ -5626,6 +5626,222 @@ tests = ["coverage", "numpy", "pytest"]
 [package.source]
 type = "url"
 url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ab1af344fd54f4ded20f68997a44eade10a936980eaa92e024bd453249321a4"},
+]
+markers = {main = "python_version == \"3.10\" and sys_platform == \"linux\" and extra == \"qret\"", dev = "python_version == \"3.10\" and sys_platform == \"linux\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:b69d55d4708c9e222f033e8cfc2e6fb16af0fecb063d78a75bfdb13fa6f8a4e6"},
+]
+markers = {main = "python_version == \"3.10\" and sys_platform == \"win32\" and extra == \"qret\"", dev = "python_version == \"3.10\" and sys_platform == \"win32\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-win_amd64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:eec7aa833b4021bcf5dc51d4bc1caed8c9695ce1e4be1c873f0b1ac236495239"},
+]
+markers = {main = "python_version == \"3.11\" and sys_platform == \"darwin\" and extra == \"qret\"", dev = "python_version == \"3.11\" and sys_platform == \"darwin\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43f315fb6d3a4e8a9abd4a93bc2b2db1a81ae57b74720d54c5aea672f973f2c5"},
+]
+markers = {main = "python_version == \"3.11\" and sys_platform == \"linux\" and extra == \"qret\"", dev = "python_version == \"3.11\" and sys_platform == \"linux\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:5a37d34ae614d39c25fdde928856316e3624fd7dd897b43a176a59321f033e3c"},
+]
+markers = {main = "python_version == \"3.11\" and sys_platform == \"win32\" and extra == \"qret\"", dev = "python_version == \"3.11\" and sys_platform == \"win32\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-win_amd64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl", hash = "sha256:6da572e95e0b2290c06551e02e13f266ce62db0a50f25f0a1cc4215ee71d7979"},
+]
+markers = {main = "python_version >= \"3.12\" and extra == \"qret\" and sys_platform == \"darwin\"", dev = "python_version >= \"3.12\" and sys_platform == \"darwin\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ffb3f4b8cb17a842e276ea7764f4df8485913c59b915c664e66a60821879be5"},
+]
+markers = {main = "python_version >= \"3.12\" and extra == \"qret\" and sys_platform == \"linux\"", dev = "python_version >= \"3.12\" and sys_platform == \"linux\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1-cp312-abi3-win_amd64.whl", hash = "sha256:17a097cdcd505d8d8151d1703f406fec14dce78e31c4abf912947e9b0aedf8ab"},
+]
+markers = {main = "python_version >= \"3.12\" and extra == \"qret\" and sys_platform == \"win32\"", dev = "python_version >= \"3.12\" and sys_platform == \"win32\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-win_amd64.whl"
+
+[[package]]
+name = "pyqret"
+version = "1.0.1"
+description = "Python wrapper of QRET"
+optional = false
+python-versions = "*"
+groups = ["main", "dev"]
+files = [
+    {file = "pyqret-1.0.1.tar.gz", hash = "sha256:0dcfc1615cab003190f1a85c759758f53daca8880868f7ac657eb2bbdc91a70d"},
+]
+markers = {main = "sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\" and extra == \"qret\" and python_version >= \"3.10\"", dev = "sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\""}
+
+[package.dependencies]
+typing_extensions = "*"
+
+[package.extras]
+dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
+docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
+tests = ["coverage", "numpy", "pytest"]
+
+[package.source]
+type = "url"
+url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1.tar.gz"
 
 [[package]]
 name = "pyscf"
@@ -6485,7 +6701,7 @@ markers = {main = "python_version >= \"3.10\" and extra == \"qret\"", dev = "pyt
 
 [package.dependencies]
 numpy = ">=1.22.0"
-pyqret = "1.0.1"
+pyqret = "^1.0.1"
 quri-parts-circuit = "*"
 quri-parts-core = "*"
 quri-parts-qsub = "*"
@@ -7844,7 +8060,7 @@ files = [
     {file = "sspilib-0.5.0-cp39-cp39-win_arm64.whl", hash = "sha256:f7a81176e0b59e68259c22f712ce3c411975b897dd32649f22a3aad41e621a21"},
     {file = "sspilib-0.5.0.tar.gz", hash = "sha256:b62f7f2602aa1add0505eee2417e2df24421224cb411e53bf3ae42a71b62fe98"},
 ]
-markers = {main = "python_version < \"3.14\" and extra == \"qiskit\" and sys_platform == \"win32\"", dev = "python_version < \"3.14\" and sys_platform == \"win32\""}
+markers = {main = "python_version < \"3.14\" and sys_platform == \"win32\" and extra == \"qiskit\"", dev = "python_version < \"3.14\" and sys_platform == \"win32\""}
 
 [[package]]
 name = "stack-data"
@@ -8481,4 +8697,4 @@ tket = ["quri-parts-tket"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.8"
-content-hash = "af72106e9cab5345a3cc61a2072cf12495e605a9d9866c1f7e552ce233a7559b"
+content-hash = "36c40739049945d8db2ee25f4a827018cd3d5dddc31e0429281044b3694688e9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1892,7 +1892,7 @@ markers = {main = "python_version < \"3.14\" and extra == \"openfermion\"", dev 
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.63.2,<2.0.0"
 grpcio = [
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0.0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
     {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
@@ -4847,7 +4847,7 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
 groups = ["dev", "doc"]
-markers = "sys_platform == \"linux\" or sys_platform == \"darwin\" or sys_platform != \"win32\" and sys_platform != \"emscripten\" and python_version >= \"3.13\" or sys_platform != \"win32\" and sys_platform != \"emscripten\" and sys_platform != \"linux\" and sys_platform != \"darwin\" or python_version < \"3.10\" and sys_platform != \"win32\""
+markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or sys_platform != \"win32\" and python_version < \"3.10\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -5267,7 +5267,7 @@ files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
-markers = {dev = "sys_platform == \"linux\" or sys_platform == \"darwin\" or sys_platform != \"win32\" and sys_platform != \"emscripten\" and python_version >= \"3.13\" or sys_platform != \"win32\" and sys_platform != \"emscripten\" and sys_platform != \"linux\" and sys_platform != \"darwin\" or python_version < \"3.10\" and sys_platform != \"win32\"", doc = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or sys_platform == \"linux\" or sys_platform == \"darwin\" or os_name != \"nt\" or sys_platform != \"win32\" and python_version < \"3.10\""}
+markers = {dev = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or sys_platform != \"win32\" and python_version < \"3.10\"", doc = "sys_platform != \"win32\" and sys_platform != \"emscripten\" or os_name != \"nt\" or sys_platform != \"win32\" and python_version < \"3.10\""}
 
 [[package]]
 name = "pubchempy"
@@ -5613,7 +5613,7 @@ groups = ["main", "dev"]
 files = [
     {file = "pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:2949e5e3f7a075acefb30155146b08d59a762412061b5aea11c8c73f458e7be0"},
 ]
-markers = {main = "python_version == \"3.10\" and sys_platform == \"darwin\" and extra == \"qret\"", dev = "python_version == \"3.10\" and sys_platform == \"darwin\""}
+markers = {main = "python_version >= \"3.10\" and extra == \"qret\"", dev = "python_version >= \"3.10\""}
 
 [package.dependencies]
 typing_extensions = "*"
@@ -5626,222 +5626,6 @@ tests = ["coverage", "numpy", "pytest"]
 [package.source]
 type = "url"
 url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ab1af344fd54f4ded20f68997a44eade10a936980eaa92e024bd453249321a4"},
-]
-markers = {main = "python_version == \"3.10\" and sys_platform == \"linux\" and extra == \"qret\"", dev = "python_version == \"3.10\" and sys_platform == \"linux\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:b69d55d4708c9e222f033e8cfc2e6fb16af0fecb063d78a75bfdb13fa6f8a4e6"},
-]
-markers = {main = "python_version == \"3.10\" and sys_platform == \"win32\" and extra == \"qret\"", dev = "python_version == \"3.10\" and sys_platform == \"win32\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-win_amd64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:eec7aa833b4021bcf5dc51d4bc1caed8c9695ce1e4be1c873f0b1ac236495239"},
-]
-markers = {main = "python_version == \"3.11\" and sys_platform == \"darwin\" and extra == \"qret\"", dev = "python_version == \"3.11\" and sys_platform == \"darwin\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43f315fb6d3a4e8a9abd4a93bc2b2db1a81ae57b74720d54c5aea672f973f2c5"},
-]
-markers = {main = "python_version == \"3.11\" and sys_platform == \"linux\" and extra == \"qret\"", dev = "python_version == \"3.11\" and sys_platform == \"linux\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:5a37d34ae614d39c25fdde928856316e3624fd7dd897b43a176a59321f033e3c"},
-]
-markers = {main = "python_version == \"3.11\" and sys_platform == \"win32\" and extra == \"qret\"", dev = "python_version == \"3.11\" and sys_platform == \"win32\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-win_amd64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl", hash = "sha256:6da572e95e0b2290c06551e02e13f266ce62db0a50f25f0a1cc4215ee71d7979"},
-]
-markers = {main = "python_version >= \"3.12\" and extra == \"qret\" and sys_platform == \"darwin\"", dev = "python_version >= \"3.12\" and sys_platform == \"darwin\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ffb3f4b8cb17a842e276ea7764f4df8485913c59b915c664e66a60821879be5"},
-]
-markers = {main = "python_version >= \"3.12\" and extra == \"qret\" and sys_platform == \"linux\"", dev = "python_version >= \"3.12\" and sys_platform == \"linux\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1-cp312-abi3-win_amd64.whl", hash = "sha256:17a097cdcd505d8d8151d1703f406fec14dce78e31c4abf912947e9b0aedf8ab"},
-]
-markers = {main = "python_version >= \"3.12\" and extra == \"qret\" and sys_platform == \"win32\"", dev = "python_version >= \"3.12\" and sys_platform == \"win32\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-win_amd64.whl"
-
-[[package]]
-name = "pyqret"
-version = "1.0.1"
-description = "Python wrapper of QRET"
-optional = false
-python-versions = "*"
-groups = ["main", "dev"]
-files = [
-    {file = "pyqret-1.0.1.tar.gz", hash = "sha256:0dcfc1615cab003190f1a85c759758f53daca8880868f7ac657eb2bbdc91a70d"},
-]
-markers = {main = "sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\" and extra == \"qret\" and python_version >= \"3.10\"", dev = "python_version >= \"3.10\" and sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\""}
-
-[package.dependencies]
-typing_extensions = "*"
-
-[package.extras]
-dev = ["nb-clean", "pyqret[algorithm,docs,tests]", "ruff"]
-docs = ["breathe (>=4.28.0)", "furo", "graphviz", "ipykernel", "jupyter", "myst-nb", "myst-parser", "ortools", "sphinx (>=7.2,<8.0)", "sphinx-design", "sphinx_copybutton", "sphinxcontrib-bibtex", "sphinxcontrib-mermaid"]
-tests = ["coverage", "numpy", "pytest"]
-
-[package.source]
-type = "url"
-url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1.tar.gz"
 
 [[package]]
 name = "pyscf"
@@ -6701,18 +6485,7 @@ markers = {main = "python_version >= \"3.10\" and extra == \"qret\"", dev = "pyt
 
 [package.dependencies]
 numpy = ">=1.22.0"
-pyqret = [
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl", markers = "python_version == \"3.10\" and sys_platform == \"darwin\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version == \"3.10\" and sys_platform == \"linux\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-win_amd64.whl", markers = "python_version == \"3.10\" and sys_platform == \"win32\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", markers = "python_version == \"3.11\" and sys_platform == \"darwin\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version == \"3.11\" and sys_platform == \"linux\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-win_amd64.whl", markers = "python_version == \"3.11\" and sys_platform == \"win32\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl", markers = "python_version >= \"3.12\" and sys_platform == \"darwin\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version >= \"3.12\" and sys_platform == \"linux\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-win_amd64.whl", markers = "python_version >= \"3.12\" and sys_platform == \"win32\""},
-    {url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1.tar.gz", markers = "sys_platform != \"linux\" and sys_platform != \"darwin\" and sys_platform != \"win32\""},
-]
+pyqret = "1.0.1"
 quri-parts-circuit = "*"
 quri-parts-core = "*"
 quri-parts-qsub = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,22 @@ quri-parts-tket = { path = "quri-parts/packages/tket", develop = true, python = 
 quri-parts-qsub = { path = "quri-parts/packages/qsub", develop = true, python = ">=3.10" }
 quri-parts-qret = { path = "quri-parts/packages/qret", develop = true, python = ">=3.10" }
 
+# pyqret is not on PyPI. The qret package declares it as a plain version dep so the
+# published wheel stays clean for PyPI; here in the dev group we supply the actual
+# wheels by URL so `poetry install` works for local dev and CI.
+pyqret = [
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version == '3.10' and sys_platform == 'linux'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl", markers = "python_version == '3.10' and sys_platform == 'darwin'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-win_amd64.whl", markers = "python_version == '3.10' and sys_platform == 'win32'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version == '3.11' and sys_platform == 'linux'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", markers = "python_version == '3.11' and sys_platform == 'darwin'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-win_amd64.whl", markers = "python_version == '3.11' and sys_platform == 'win32'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version >= '3.12' and sys_platform == 'linux'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl", markers = "python_version >= '3.12' and sys_platform == 'darwin'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-win_amd64.whl", markers = "python_version >= '3.12' and sys_platform == 'win32'" },
+  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1.tar.gz", markers = "sys_platform != 'linux' and sys_platform != 'darwin' and sys_platform != 'win32'" },
+]
+
 # To avoid poetry downloading hundreds versions of botocore
 # https://github.com/python-poetry/poetry/issues/7858
 botocore = ">=1.34,<2.0"

--- a/quri-algo/pyproject.toml
+++ b/quri-algo/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quri-algo"
-version = "0.26.1"
+version = "0.26.2"
 description = "Algorithm library based on QURI Parts"
 license = "MIT"
 authors = ["QunaSys"]

--- a/quri-parts/Cargo.lock
+++ b/quri-parts/Cargo.lock
@@ -186,14 +186,14 @@ dependencies = [
 
 [[package]]
 name = "quri-parts"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "quri-parts-rust"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "num-complex",
  "pyo3",

--- a/quri-parts/Cargo.toml
+++ b/quri-parts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quri-parts"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2021"
 description = "Platform-independent quantum computing library"
 authors = ["QURI Parts Authors <opensource@qunasys.com>"]

--- a/quri-parts/packages/qret/pyproject.toml
+++ b/quri-parts/packages/qret/pyproject.toml
@@ -28,4 +28,4 @@ quri-parts-qsub = "*"
 
 # pyqret is not on PyPI; users install it manually from
 # https://github.com/QunaSys/quration/releases
-pyqret = "1.0.1"
+pyqret = "^1.0.1"

--- a/quri-parts/packages/qret/pyproject.toml
+++ b/quri-parts/packages/qret/pyproject.toml
@@ -26,17 +26,6 @@ quri-parts-circuit = "*"
 quri-parts-core = "*"
 quri-parts-qsub = "*"
 
-# TODO: restore platform_machine markers once we switch to uv.
-# Dropped here as a temporary workaround to speed up poetry lock.
-pyqret = [
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version == '3.10' and sys_platform == 'linux'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-macosx_15_0_arm64.whl", markers = "python_version == '3.10' and sys_platform == 'darwin'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp310-cp310-win_amd64.whl", markers = "python_version == '3.10' and sys_platform == 'win32'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version == '3.11' and sys_platform == 'linux'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-macosx_15_0_arm64.whl", markers = "python_version == '3.11' and sys_platform == 'darwin'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp311-cp311-win_amd64.whl", markers = "python_version == '3.11' and sys_platform == 'win32'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", markers = "python_version >= '3.12' and sys_platform == 'linux'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-macosx_15_0_arm64.whl", markers = "python_version >= '3.12' and sys_platform == 'darwin'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1-cp312-abi3-win_amd64.whl", markers = "python_version >= '3.12' and sys_platform == 'win32'" },
-  { url = "https://github.com/QunaSys/quration/releases/download/v1.0.1-2/pyqret-1.0.1.tar.gz", markers = "sys_platform != 'linux' and sys_platform != 'darwin' and sys_platform != 'win32'" },
-]
+# pyqret is not on PyPI; users install it manually from
+# https://github.com/QunaSys/quration/releases
+pyqret = "1.0.1"

--- a/quri-parts/packages/qret/pyproject.toml
+++ b/quri-parts/packages/qret/pyproject.toml
@@ -26,6 +26,6 @@ quri-parts-circuit = "*"
 quri-parts-core = "*"
 quri-parts-qsub = "*"
 
-# pyqret is not on PyPI; users install it manually from
-# https://github.com/QunaSys/quration/releases
+# pyqret is not on PyPI; supply it from the QunaSys release feed, e.g.
+#   pip install quri-parts-qret --find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2
 pyqret = "^1.0.1"

--- a/quri-parts/packages/rust/Cargo.toml
+++ b/quri-parts/packages/rust/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "quri-parts-rust"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2021"
 publish = false
 
 [dependencies]
 num-complex = "0.4.6"
-quri-parts = { path = "../../", version = "0.26.1", features = ["python"] }
+quri-parts = { path = "../../", version = "0.26.2", features = ["python"] }
 rayon = "1.10"
 
 [dependencies.pyo3]

--- a/quri-parts/packages/rust/pyproject.toml
+++ b/quri-parts/packages/rust/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools_rust_bundled.setuptools"
 [project]
 dependencies = ["typing-extensions>=4.1.1,<5.0.0", "numpy>=1.22.0"]
 name = "quri-parts-rust"
-version = "0.26.1"
+version = "0.26.2"
 description = "Platform-independent quantum circuit library"
 license = { text = "Apache-2.0" }
 
@@ -38,7 +38,7 @@ Documentation = "https://quri-parts.qunasys.com"
 # The followings is needed for rust-sdist-package CI
 [tool.poetry]
 name = "quri-parts-rust"
-version = "0.26.1"
+version = "0.26.2"
 description = "Platform-independent quantum circuit library"
 license = "Apache-2.0"
 authors = ["QURI Parts Authors <opensource@qunasys.com>"]

--- a/quri-vm/pyproject.toml
+++ b/quri-vm/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quri-vm"
-version = "0.26.1"
+version = "0.26.2"
 description = ""
 authors = ["QunaSys"]
 readme = "README.md"


### PR DESCRIPTION
Bump version to 0.26.2.

- qret now declares `pyqret = "^1.0.1"` (a plain version), so the uploaded wheel is clean. `pyqret` is not on PyPI, so installing qret requires supplying it, e.g. `--find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2`.
- The actual wheel URLs moved to the root `dev` group so `poetry install` still works for local dev and CI without polluting any published wheel.
- The license-check workflow installs with `--find-links` to resolve `pyqret`.
