### PR TITLE
Supply pyqret via find-links in package test jobs

### DIFF
--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -217,7 +217,8 @@ jobs:
             if [[ "3.${{matrix.python-version}}" = "3.14" && "$FILE" = *"quri_parts_qiskit"* ]]; then
               continue
             fi
-            pip install -v $FILE
+            # pyqret is not on PyPI; supply it from the QunaSys release feed.
+            pip install -v $FILE --find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2
           done
 
       - name: Run test
@@ -443,7 +444,8 @@ jobs:
             if [[ "3.${{matrix.python-version}}" = "3.14" && "$FILE" = *"quri_parts_qiskit"* ]]; then
               continue
             fi
-            pip install -v $FILE
+            # pyqret is not on PyPI; supply it from the QunaSys release feed.
+            pip install -v $FILE --find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2
           done
 
       - name: Run test


### PR DESCRIPTION
closing https://github.com/QunaSys/quri-sdk-issues/issues/702

The package release workflow's sdist/wheel test jobs `pip install` the built `quri-parts-qret`, which requires `pyqret (>=1.0.1,<2.0.0)`. pyqret is not on PyPI, so the install failed with "No matching distribution found".

Adds `--find-links https://github.com/QunaSys/quration/releases/expanded_assets/v1.0.1-2` to the two `pip install -v $FILE` loops (sdist and wheel jobs) so pip can resolve pyqret from the QunaSys release feed. The rust-wheel install step is unchanged.

Mirrors the same fix already applied to the license-check workflow in #547.

made sure it passes release workflow with temp commit
https://github.com/QunaSys/quri-sdk/actions/runs/27662046361

