### PR TITLE
Fix qsub visualization bug with Cbz and Label

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
@@ -9,29 +9,27 @@
 # limitations under the License.
 
 from collections import deque
+
+# mypy: disable-error-code=import-untyped
 from dataclasses import dataclass, field
 from enum import Enum
 from itertools import chain
 from math import hypot
-from typing import Deque, List, Optional, Sequence, Tuple, cast
+from typing import Any, Deque, List, Optional, Sequence, Tuple, cast
 
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import patches
-from qulacsvis.models import circuit as qv_circuit  # type: ignore[import-untyped]
-from qulacsvis.utils.gate import (  # type: ignore[import-untyped]
-    grouping_adjacent_gates,
-    to_latex_style,
-)
-from qulacsvis.visualization import matplotlib as qv_mpl  # type: ignore[import-untyped]
-from qulacsvis.visualization.matplotlib import (
-    MPLCircuitlDrawer as QVMPLCircuitlDrawer,  # type: ignore[import-untyped]
-)
+from qulacsvis.models.circuit import CircuitData as QVCircuitData
+from qulacsvis.models.circuit import ControlQubitInfo as QVControlQubitInfo
+from qulacsvis.models.circuit import GateData as QVGateData
+from qulacsvis.utils import gate as qv_gate
+from qulacsvis.visualization import matplotlib as qv_mpl
+from qulacsvis.visualization.matplotlib import MPLCircuitlDrawer as QVMPLCircuitlDrawer
 from typing_extensions import Final
 
-QVCircuitData = qv_circuit.CircuitData
-QVControlQubitInfo = qv_circuit.ControlQubitInfo
-QVGateData = qv_circuit.GateData
+grouping_adjacent_gates = qv_gate.grouping_adjacent_gates
+to_latex_style = qv_gate.to_latex_style
 
 # Visualization models ---------------------------------------------------------
 
@@ -148,7 +146,8 @@ def _align_layers(
 ) -> None:
     if min_line_index > max_line_index:
         min_line_index, max_line_index = max_line_index, min_line_index
-    lines = lines[min_line_index: max_line_index + 1]
+    max_line_index += 1
+    lines = lines[min_line_index:max_line_index]
     layer_counts = [len(queue) for queue in lines]
     max_layer_count = max(layer_counts) if layer_counts else 0
 
@@ -227,7 +226,7 @@ def _circuit_span(
     return circuit_min_x, circuit_max_x
 
 
-def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> "QVGateData":
+def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> Any:
     if gate.name in {"ghost", "wire"}:
         return QVGateData(gate.name)
 
@@ -240,9 +239,9 @@ def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> "QVGateData":
     return QVGateData(gate.name, qubit_targets, controls)
 
 
-def _to_qulacsvis_circuit(circuit: CircuitData) -> QVCircuitData:
+def _to_qulacsvis_circuit(circuit: CircuitData) -> Any:
     qubit_count = max(1, circuit.qubit_count)
-    gates: List[List[QVGateData]] = [[] for _ in range(qubit_count)]
+    gates: List[List[Any]] = [[] for _ in range(qubit_count)]
     if circuit.layer_count == 0:
         return QVCircuitData(
             qubit_count=qubit_count,
@@ -302,9 +301,7 @@ class MPLCircuitlDrawer:
         base_drawer = QVMPLCircuitlDrawer(
             qv_circuit, dpi=self._dpi, scale=self._fig_scale_factor
         )
-        figure: matplotlib.figure.Figure = base_drawer.draw(
-            debug=debug, filename=None
-        )
+        figure: matplotlib.figure.Figure = base_drawer.draw(debug=debug, filename=None)
 
         self._figure = figure
         self._ax = base_drawer._ax

--- a/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
@@ -1,0 +1,659 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from itertools import chain
+from math import hypot
+from typing import Deque, List, Optional, Sequence, Tuple
+
+import matplotlib
+from matplotlib import patches
+from qulacsvis.models.circuit import CircuitData as QVCircuitData
+from qulacsvis.models.circuit import ControlQubitInfo as QVControlQubitInfo
+from qulacsvis.models.circuit import GateData as QVGateData
+from qulacsvis.utils.gate import grouping_adjacent_gates, to_latex_style
+from qulacsvis.visualization import matplotlib as qv_mpl
+from qulacsvis.visualization.matplotlib import MPLCircuitlDrawer as QVMPLCircuitlDrawer
+from typing_extensions import Final
+
+# Visualization models ---------------------------------------------------------
+
+
+@dataclass
+class ControlBitInfo:
+    index: int
+    control_value: int
+
+
+class GateType(Enum):
+    GENERIC = "generic"
+    MEASURE = "measure"
+    CLASSICAL = "classical"
+
+
+@dataclass
+class GateData:
+    name: str
+    target_bits: List[int] = field(default_factory=list)
+    control_bit_infos: List[ControlBitInfo] = field(default_factory=list)
+    classical_bits: List[int] = field(default_factory=list)
+    kind: GateType = GateType.GENERIC
+
+    @property
+    def all_target_bits(self) -> Tuple[int, ...]:
+        return tuple(chain(self.target_bits, self.classical_bits))
+
+    @property
+    def indices(self) -> Tuple[int, ...]:
+        return tuple(
+            chain(self.all_target_bits, (c.index for c in self.control_bit_infos))
+        )
+
+    @property
+    def max_index(self) -> int:
+        return max(self.indices)
+
+    @property
+    def min_index(self) -> int:
+        return min(self.indices)
+
+
+GateDataSeq = Sequence[Sequence[GateData]]
+
+
+@dataclass
+class ConditionalBlock:
+    start_layer: int
+    end_layer: int
+    bits: List[int]
+    label: str
+    cbz_layer: Optional[int] = None
+    cbz_bit: Optional[int] = None
+
+
+@dataclass
+class CircuitData:
+    qubit_count: int
+    register_count: int
+    layer_count: int
+    gates: GateDataSeq
+    conditional_blocks: List[ConditionalBlock] = field(default_factory=list)
+
+    @property
+    def bit_count(self) -> int:
+        return self.qubit_count + self.register_count
+
+    @staticmethod
+    def from_gate_sequence(
+        gates: Sequence[GateData],
+        *,
+        qubit_count: Optional[int] = None,
+        register_count: int = 0,
+        conditional_blocks: Optional[Sequence[ConditionalBlock]] = None,
+    ) -> "CircuitData":
+        if qubit_count is None:
+            max_index = max((g.max_index for g in gates), default=-1)
+            qubit_count = max_index + 1 - register_count if max_index >= 0 else 0
+        bit_count = qubit_count + register_count
+        if bit_count <= 0:
+            bit_count = 1
+
+        temp_lines: List[Deque[GateData]] = [deque() for _ in range(bit_count)]
+        for gate in gates:
+            targets = gate.all_target_bits
+            if not targets:
+                continue
+            primary_index = targets[0]
+            _align_layers(temp_lines, gate.min_index, gate.max_index)
+
+            for index in range(gate.min_index, gate.max_index + 1):
+                line = temp_lines[index]
+                if index == primary_index:
+                    line.append(gate)
+                elif index in targets:
+                    line.append(GateData("ghost"))
+                else:
+                    line.append(GateData("wire"))
+
+        _align_layers(temp_lines, 0, bit_count - 1)
+        layer_count = len(temp_lines[0])
+        return CircuitData(
+            qubit_count=qubit_count,
+            register_count=register_count,
+            layer_count=layer_count,
+            gates=[list(queue) for queue in temp_lines],
+            conditional_blocks=list(conditional_blocks or []),
+        )
+
+
+def _align_layers(
+    lines: Sequence[Deque[GateData]], min_line_index: int, max_line_index: int
+) -> None:
+    if min_line_index > max_line_index:
+        min_line_index, max_line_index = max_line_index, min_line_index
+    lines = lines[min_line_index : max_line_index + 1]
+    layer_counts = [len(queue) for queue in lines]
+    max_layer_count = max(layer_counts) if layer_counts else 0
+
+    for queue, layer_count in zip(lines, layer_counts):
+        for _ in range(max_layer_count - layer_count):
+            queue.append(GateData("wire"))
+
+
+# Matplotlib drawer -----------------------------------------------------------
+
+MATPLOTLIB_INLINE_BACKENDS = qv_mpl.MATPLOTLIB_INLINE_BACKENDS
+
+GATE_DEFAULT_WIDTH = qv_mpl.GATE_DEFAULT_WIDTH
+GATE_DEFAULT_HEIGHT = qv_mpl.GATE_DEFAULT_HEIGHT
+
+GATE_MARGIN_RIGHT: Final[float] = qv_mpl.GATE_MARGIN_RIGHT
+GATE_MARGIN_LEFT: Final[float] = qv_mpl.GATE_MARGIN_LEFT
+GATE_MARGIN_BOTTOM: Final[float] = qv_mpl.GATE_MARGIN_BOTTOM
+GATE_MARGIN_TOP: Final[float] = qv_mpl.GATE_MARGIN_TOP
+
+CIRCUIT_MARGIN = qv_mpl.CIRCUIT_MARGIN
+
+PORDER_LINE: Final[int] = qv_mpl.PORDER_LINE
+PORDER_GATE: Final[int] = qv_mpl.PORDER_GATE
+PORDER_TEXT: Final[int] = qv_mpl.PORDER_TEXT
+
+
+def _calc_gate_width(gate: GateData) -> float:
+    width = GATE_DEFAULT_WIDTH
+    if gate.name == "":
+        return width
+    try:
+        to_latex_style(gate.name)
+    except KeyError:
+        char_width = 0.2
+        max_line_width = max(len(s) for s in gate.name.splitlines())
+        width += (max_line_width - 3) * char_width
+
+    return width
+
+
+def _wire_pitch() -> float:
+    return GATE_DEFAULT_HEIGHT + GATE_MARGIN_TOP + GATE_MARGIN_BOTTOM
+
+
+def _calc_layer_positions(layer_widths: Sequence[float]) -> List[float]:
+    if not layer_widths:
+        return [0.0]
+
+    layer_positions: List[float] = []
+    xpos = 0.0
+    for layer, width in enumerate(layer_widths):
+        layer_positions.append(xpos)
+        if layer < len(layer_widths) - 1:
+            xpos += (
+                (width + layer_widths[layer + 1]) * 0.5
+                + GATE_MARGIN_RIGHT
+                + GATE_MARGIN_LEFT
+            )
+
+    return layer_positions
+
+
+def _circuit_span(
+    layer_widths: Sequence[float], circuit_layer_count: int
+) -> Tuple[float, float]:
+    if not layer_widths:
+        layer_widths = [GATE_DEFAULT_WIDTH]
+
+    circuit_max_x = (
+        sum(layer_widths)
+        + circuit_layer_count * (GATE_MARGIN_RIGHT + GATE_MARGIN_LEFT)
+        - layer_widths[0] / 2
+    )
+    circuit_min_x = -layer_widths[0] / 2 - GATE_MARGIN_LEFT - GATE_MARGIN_RIGHT
+    return circuit_min_x, circuit_max_x
+
+
+def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> QVGateData:
+    if gate.name in {"ghost", "wire"}:
+        return QVGateData(gate.name)
+
+    qubit_targets = [bit for bit in gate.target_bits if bit < qubit_count]
+    controls = [
+        QVControlQubitInfo(info.index, info.control_value)
+        for info in gate.control_bit_infos
+        if info.index < qubit_count
+    ]
+    return QVGateData(gate.name, qubit_targets, controls)
+
+
+def _to_qulacsvis_circuit(circuit: CircuitData) -> QVCircuitData:
+    qubit_count = max(1, circuit.qubit_count)
+    if circuit.layer_count == 0:
+        gates: List[List[QVGateData]] = [[] for _ in range(qubit_count)]
+        return QVCircuitData(
+            qubit_count=qubit_count,
+            layer_count=0,
+            gates=gates,
+        )
+
+    gates: List[List[QVGateData]] = [[] for _ in range(qubit_count)]
+    for layer in range(circuit.layer_count):
+        for qubit in range(qubit_count):
+            if qubit < circuit.qubit_count:
+                gate = circuit.gates[qubit][layer]
+            else:
+                gate = GateData("wire")
+            gates[qubit].append(_to_qulacsvis_gate(gate, circuit.qubit_count))
+
+    return QVCircuitData(
+        qubit_count=qubit_count,
+        layer_count=circuit.layer_count,
+        gates=gates,
+    )
+
+
+class MPLCircuitlDrawer:
+    def __init__(
+        self,
+        circuit: CircuitData,
+        *,
+        dpi: int = 72,
+        scale: float = 0.6,
+    ):
+        self._circuit = circuit
+        self._dpi = dpi
+        self._fig_scale_factor = scale
+        self._wire_pitch = _wire_pitch()
+        self._layer_width: List[float] = []
+        self._layer_positions: List[float] = []
+        self._visual_bit_count: int = circuit.qubit_count + (
+            1 if circuit.register_count > 0 else 0
+        )
+        self._circuit_min_x: float = 0.0
+        self._circuit_max_x: float = 0.0
+        self._figure: matplotlib.figure.Figure | None = None
+        self._ax: matplotlib.axes.Axes | None = None
+
+    def _bit_ypos(self, bit_index: int) -> float:
+        visual_index = (
+            bit_index
+            if bit_index < self._circuit.qubit_count
+            else self._circuit.qubit_count
+        )
+        return visual_index * self._wire_pitch
+
+    def draw(
+        self, *, debug: bool = False, filename: Optional[str] = None
+    ) -> matplotlib.figure.Figure:
+        qv_circuit = _to_qulacsvis_circuit(self._circuit)
+        base_drawer = QVMPLCircuitlDrawer(
+            qv_circuit, dpi=self._dpi, scale=self._fig_scale_factor
+        )
+        figure = base_drawer.draw(debug=debug, filename=None)
+
+        self._figure = figure
+        self._ax = base_drawer._ax
+        self._layer_width = list(base_drawer._layer_width)
+        self._layer_positions = _calc_layer_positions(self._layer_width)
+        self._circuit_min_x, self._circuit_max_x = _circuit_span(
+            self._layer_width, qv_circuit.layer_count
+        )
+
+        self._extend_limits()
+        self._draw_conditional_blocks()
+        self._draw_register_lines()
+        self._draw_measurement_arrows()
+        self._draw_classical_gates()
+        self._draw_classical_controls()
+
+        if filename:
+            figure.savefig(filename)
+
+        if matplotlib.get_backend() in MATPLOTLIB_INLINE_BACKENDS:
+            matplotlib.pyplot.close(figure)
+        return figure
+
+    def _extend_limits(self) -> None:
+        if self._ax is None or self._figure is None:
+            return
+
+        circuit_max_y = (
+            self._visual_bit_count * self._wire_pitch
+            - GATE_MARGIN_TOP
+            - GATE_MARGIN_BOTTOM
+            - GATE_DEFAULT_HEIGHT / 2
+        )
+        qubit_label_width = 2
+        self._ax.set_xlim(
+            self._circuit_min_x - qubit_label_width,
+            self._circuit_max_x + CIRCUIT_MARGIN,
+        )
+        self._ax.set_ylim(
+            circuit_max_y + CIRCUIT_MARGIN,
+            -GATE_DEFAULT_HEIGHT / 2 - CIRCUIT_MARGIN,
+        )
+
+        fig_width = abs(self._ax.get_xlim()[1] - self._ax.get_xlim()[0])
+        fig_heigth = abs(self._ax.get_ylim()[1] - self._ax.get_ylim()[0])
+        self._figure.set_size_inches(
+            fig_width * self._fig_scale_factor, fig_heigth * self._fig_scale_factor
+        )
+
+    def _draw_register_lines(self) -> None:
+        if self._ax is None:
+            return
+
+        if self._circuit.register_count:
+            bit_index = self._circuit.qubit_count
+            line_ypos = self._bit_ypos(bit_index)
+            label = (
+                f"r[0..{self._circuit.register_count - 1}]"
+                if self._circuit.register_count > 1
+                else "r"
+            )
+            self._text(self._circuit_min_x - 1, line_ypos, label, fontsize=24)
+            self._double_line(
+                (self._circuit_min_x, line_ypos),
+                (self._circuit_max_x, line_ypos),
+                lw=1.8,
+            )
+
+    def _draw_measurement_arrows(self) -> None:
+        if self._ax is None or not self._layer_positions:
+            return
+
+        for layer in range(self._circuit.layer_count):
+            xpos = self._layer_positions[min(layer, len(self._layer_positions) - 1)]
+            for bit in range(min(self._circuit.qubit_count, len(self._circuit.gates))):
+                gate = self._circuit.gates[bit][layer]
+                if gate.kind is not GateType.MEASURE or not gate.classical_bits:
+                    continue
+                ypos = self._bit_ypos(bit)
+                start_y = ypos + GATE_DEFAULT_HEIGHT * 0.5
+                self._double_line((xpos, ypos), (xpos, start_y), lw=1.6)
+                for i, target in enumerate(gate.classical_bits):
+                    to_ypos = self._bit_ypos(target)
+                    offset_x = xpos + i * 0.12
+                    self._ax.annotate(
+                        "",
+                        xy=(offset_x, to_ypos),
+                        xytext=(offset_x, start_y),
+                        arrowprops={"arrowstyle": "->", "linewidth": 2.0},
+                        zorder=PORDER_GATE,
+                    )
+                    self._text(
+                        offset_x - 0.15,
+                        to_ypos - 0.4,
+                        f"r{target - self._circuit.qubit_count}",
+                        fontsize=20,
+                        horizontalalignment="right",
+                        verticalalignment="top",
+                    )
+
+    def _draw_classical_gates(self) -> None:
+        if self._ax is None or not self._layer_positions:
+            return
+
+        for layer in range(self._circuit.layer_count):
+            xpos = self._layer_positions[min(layer, len(self._layer_positions) - 1)]
+            for bit in range(self._circuit.qubit_count, self._circuit.bit_count):
+                gate = self._circuit.gates[bit][layer]
+                if (
+                    gate.name in {"wire", "ghost", "Cbz"}
+                    or gate.kind is not GateType.CLASSICAL
+                ):
+                    continue
+                ypos = self._bit_ypos(bit)
+                if len(gate.all_target_bits) > 1:
+                    self._multi_gate(gate, (xpos, ypos))
+                else:
+                    self._gate_with_size(gate, (xpos, ypos), 1)
+
+    def _draw_classical_controls(self) -> None:
+        if self._ax is None or not self._layer_positions:
+            return
+
+        for layer in range(self._circuit.layer_count):
+            xpos = self._layer_positions[min(layer, len(self._layer_positions) - 1)]
+            for bit in range(self._circuit.bit_count):
+                gate = self._circuit.gates[bit][layer]
+                if gate.name in {"wire", "ghost"}:
+                    continue
+                self._control_bits(gate.control_bit_infos, (xpos, self._bit_ypos(bit)))
+
+    def _draw_conditional_blocks(self) -> None:
+        if (
+            self._ax is None
+            or not self._circuit.conditional_blocks
+            or not self._layer_positions
+        ):
+            return
+
+        for block in self._circuit.conditional_blocks:
+            start_x = (
+                self._layer_positions[block.start_layer]
+                - self._layer_width[block.start_layer] * 0.5
+                - GATE_MARGIN_LEFT
+            )
+            end_x = (
+                self._layer_positions[block.end_layer]
+                + self._layer_width[block.end_layer] * 0.5
+                + GATE_MARGIN_RIGHT
+            )
+            min_bit = min(block.bits)
+            max_bit = max(block.bits)
+            y0 = self._bit_ypos(min_bit) - (
+                GATE_DEFAULT_HEIGHT / 2 + GATE_MARGIN_BOTTOM
+            )
+            y1 = self._bit_ypos(max_bit) + (GATE_DEFAULT_HEIGHT / 2 + GATE_MARGIN_TOP)
+
+            rect = patches.Rectangle(
+                (start_x, y0),
+                end_x - start_x,
+                y1 - y0,
+                facecolor="#f5f5f5",
+                edgecolor="#999999",
+                linewidth=1.5,
+                linestyle="--",
+                zorder=PORDER_LINE - 1,
+                alpha=0.8,
+            )
+            self._ax.add_patch(rect)
+            if block.cbz_layer is not None and block.cbz_bit is not None:
+                marker_x = self._layer_positions[block.cbz_layer]
+                marker_y = self._bit_ypos(block.cbz_bit)
+                dot = patches.Circle(
+                    (marker_x, marker_y),
+                    radius=0.18,
+                    facecolor="k",
+                    edgecolor="k",
+                    zorder=PORDER_GATE,
+                )
+                self._ax.add_patch(dot)
+                self._double_line(
+                    (marker_x, marker_y),
+                    (marker_x, y1),
+                    lw=1.8,
+                )
+                self._text(
+                    marker_x,
+                    marker_y + 0.35,
+                    block.label,
+                    fontsize=20,
+                    horizontalalignment="center",
+                    verticalalignment="top",
+                )
+
+    def _line(
+        self,
+        from_xy: Tuple[float, float],
+        to_xy: Tuple[float, float],
+        lc: str = "k",
+        ls: str = "-",
+        lw: float = 2.0,
+        zorder: int = PORDER_LINE,
+    ) -> None:
+        from_x, from_y = from_xy
+        to_x, to_y = to_xy
+        self._ax.plot(
+            [from_x, to_x],
+            [from_y, to_y],
+            color=lc,
+            linestyle=ls,
+            linewidth=lw,
+            zorder=zorder,
+        )
+
+    def _double_line(
+        self,
+        from_xy: Tuple[float, float],
+        to_xy: Tuple[float, float],
+        lc: str = "k",
+        lw: float = 2.0,
+        zorder: int = PORDER_LINE,
+        separation: float = 0.08,
+    ) -> None:
+        from_x, from_y = from_xy
+        to_x, to_y = to_xy
+        dx = to_x - from_x
+        dy = to_y - from_y
+        length = hypot(dx, dy)
+        if length == 0:
+            self._line(from_xy, to_xy, lc=lc, lw=lw, zorder=zorder)
+            return
+
+        ox = -dy / length * separation
+        oy = dx / length * separation
+        offset1_from = (from_x + ox, from_y + oy)
+        offset1_to = (to_x + ox, to_y + oy)
+        offset2_from = (from_x - ox, from_y - oy)
+        offset2_to = (to_x - ox, to_y - oy)
+
+        self._line(offset1_from, offset1_to, lc=lc, lw=lw, zorder=zorder)
+        self._line(offset2_from, offset2_to, lc=lc, lw=lw, zorder=zorder)
+
+    def _text(
+        self,
+        x: float,
+        y: float,
+        text: str,
+        horizontalalignment: str = "center",
+        verticalalignment: str = "center",
+        fontsize: int = 20,
+        color: str = "k",
+        clip_on: bool = True,
+        zorder: int = PORDER_TEXT,
+    ) -> None:
+        self._ax.text(
+            x,
+            y,
+            text,
+            horizontalalignment=horizontalalignment,
+            verticalalignment=verticalalignment,
+            fontsize=fontsize * self._fig_scale_factor,
+            color=color,
+            clip_on=clip_on,
+            zorder=zorder,
+        )
+
+    def _gate_with_size(
+        self, gate: GateData, xy: Tuple[float, float], multi_gate_size: int
+    ) -> None:
+        xpos, ypos = xy
+        gate_width = _calc_gate_width(gate)
+
+        ypos = (
+            ypos
+            + (
+                ypos
+                + (multi_gate_size - 1)
+                * (GATE_DEFAULT_HEIGHT + GATE_MARGIN_BOTTOM + GATE_MARGIN_TOP)
+            )
+        ) * 0.5
+        multi_gate_height = GATE_DEFAULT_HEIGHT * multi_gate_size + (
+            GATE_MARGIN_BOTTOM + GATE_MARGIN_TOP
+        ) * (multi_gate_size - 1)
+        facecolor = "w" if gate.kind is GateType.GENERIC else "#f7f7f7"
+        box = patches.Rectangle(
+            xy=(xpos - 0.5 * gate_width, ypos - 0.5 * multi_gate_height),
+            width=gate_width,
+            height=multi_gate_height,
+            facecolor=facecolor,
+            edgecolor="k",
+            linewidth=2.4,
+            zorder=PORDER_GATE,
+        )
+        self._ax.add_patch(box)
+
+        if gate.name == "":
+            latex_style_gate_str = ""
+        else:
+            try:
+                latex_style_gate_str = f"${to_latex_style(gate.name)}$"
+            except KeyError:
+                latex_style_gate_str = gate.name
+
+        self._text(xpos, ypos, latex_style_gate_str)
+        self._control_bits(gate.control_bit_infos, (xpos, ypos))
+
+    def _multi_gate(self, gate: GateData, xy: Tuple[float, float]) -> None:
+        xpos, _ = xy
+        multi_gate_data = GateData(gate.name, kind=gate.kind)
+        groups_of_adjacent_gates = grouping_adjacent_gates(list(gate.all_target_bits))
+
+        for i, adjacent_gates in enumerate(groups_of_adjacent_gates):
+            group_x = xpos
+            group_y = adjacent_gates[0] * self._wire_pitch
+            self._gate_with_size(
+                multi_gate_data, (group_x, group_y), len(adjacent_gates)
+            )
+            if i == 0:
+                multi_gate_data.name = ""
+
+        ypos = min(gate.all_target_bits) * self._wire_pitch
+        to_ypos = max(gate.all_target_bits) * self._wire_pitch
+        self._double_line((xpos, ypos), (xpos, to_ypos), lw=10, lc="gray")
+        self._control_bits(gate.control_bit_infos, (xpos, ypos))
+
+    def _control_bits(
+        self, control_bit_infos: List[ControlBitInfo], xy_from: Tuple[float, float]
+    ) -> None:
+        if self._ax is None:
+            return
+
+        for info in control_bit_infos:
+            control_bit = info.index
+            if control_bit < self._circuit.qubit_count:
+                continue
+            to_ypos = self._bit_ypos(control_bit)
+            to_xpos = xy_from[0]
+            self._double_line(
+                xy_from,
+                (to_xpos, to_ypos),
+                lw=1.8,
+            )
+            if info.control_value == 0:
+                ctl = patches.Circle(
+                    xy=(to_xpos, to_ypos),
+                    radius=0.15,
+                    fc="w",
+                    ec="k",
+                    linewidth=2.0,
+                    zorder=PORDER_GATE,
+                )
+            else:
+                ctl = patches.Circle(
+                    xy=(to_xpos, to_ypos),
+                    radius=0.15,
+                    fc="k",
+                    ec="w",
+                    linewidth=0,
+                    zorder=PORDER_GATE,
+                )
+            self._ax.add_patch(ctl)

--- a/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
@@ -13,16 +13,26 @@ from dataclasses import dataclass, field
 from enum import Enum
 from itertools import chain
 from math import hypot
-from typing import Deque, List, Optional, Sequence, Tuple
+from typing import Deque, List, Optional, Sequence, Tuple, cast
 
 import matplotlib
+import matplotlib.pyplot as plt
 from matplotlib import patches
-from qulacsvis.models.circuit import CircuitData as QVCircuitData
-from qulacsvis.models.circuit import ControlQubitInfo as QVControlQubitInfo
-from qulacsvis.models.circuit import GateData as QVGateData
-from qulacsvis.utils.gate import grouping_adjacent_gates, to_latex_style
-from qulacsvis.visualization import matplotlib as qv_mpl
-from qulacsvis.visualization.matplotlib import MPLCircuitlDrawer as QVMPLCircuitlDrawer
+from qulacsvis.models.circuit import (  # type: ignore[import-untyped]
+    CircuitData as QVCircuitData,
+)
+from qulacsvis.models.circuit import (  # type: ignore[import-untyped]
+    ControlQubitInfo as QVControlQubitInfo,
+)
+from qulacsvis.models.circuit import GateData as QVGateData  # type: ignore[import-untyped]
+from qulacsvis.utils.gate import (  # type: ignore[import-untyped]
+    grouping_adjacent_gates,
+    to_latex_style,
+)
+from qulacsvis.visualization import matplotlib as qv_mpl  # type: ignore[import-untyped]
+from qulacsvis.visualization.matplotlib import (  # type: ignore[import-untyped]
+    MPLCircuitlDrawer as QVMPLCircuitlDrawer,
+)
 from typing_extensions import Final
 
 # Visualization models ---------------------------------------------------------
@@ -140,7 +150,7 @@ def _align_layers(
 ) -> None:
     if min_line_index > max_line_index:
         min_line_index, max_line_index = max_line_index, min_line_index
-    lines = lines[min_line_index : max_line_index + 1]
+    lines = lines[min_line_index: max_line_index + 1]
     layer_counts = [len(queue) for queue in lines]
     max_layer_count = max(layer_counts) if layer_counts else 0
 
@@ -153,25 +163,25 @@ def _align_layers(
 
 MATPLOTLIB_INLINE_BACKENDS = qv_mpl.MATPLOTLIB_INLINE_BACKENDS
 
-GATE_DEFAULT_WIDTH = qv_mpl.GATE_DEFAULT_WIDTH
-GATE_DEFAULT_HEIGHT = qv_mpl.GATE_DEFAULT_HEIGHT
+GATE_DEFAULT_WIDTH: float = cast(float, qv_mpl.GATE_DEFAULT_WIDTH)
+GATE_DEFAULT_HEIGHT: float = cast(float, qv_mpl.GATE_DEFAULT_HEIGHT)
 
-GATE_MARGIN_RIGHT: Final[float] = qv_mpl.GATE_MARGIN_RIGHT
-GATE_MARGIN_LEFT: Final[float] = qv_mpl.GATE_MARGIN_LEFT
-GATE_MARGIN_BOTTOM: Final[float] = qv_mpl.GATE_MARGIN_BOTTOM
-GATE_MARGIN_TOP: Final[float] = qv_mpl.GATE_MARGIN_TOP
+GATE_MARGIN_RIGHT: Final[float] = cast(float, qv_mpl.GATE_MARGIN_RIGHT)
+GATE_MARGIN_LEFT: Final[float] = cast(float, qv_mpl.GATE_MARGIN_LEFT)
+GATE_MARGIN_BOTTOM: Final[float] = cast(float, qv_mpl.GATE_MARGIN_BOTTOM)
+GATE_MARGIN_TOP: Final[float] = cast(float, qv_mpl.GATE_MARGIN_TOP)
 
-CIRCUIT_MARGIN = qv_mpl.CIRCUIT_MARGIN
+CIRCUIT_MARGIN: float = cast(float, qv_mpl.CIRCUIT_MARGIN)
 
-PORDER_LINE: Final[int] = qv_mpl.PORDER_LINE
-PORDER_GATE: Final[int] = qv_mpl.PORDER_GATE
-PORDER_TEXT: Final[int] = qv_mpl.PORDER_TEXT
+PORDER_LINE: Final[int] = cast(int, qv_mpl.PORDER_LINE)
+PORDER_GATE: Final[int] = cast(int, qv_mpl.PORDER_GATE)
+PORDER_TEXT: Final[int] = cast(int, qv_mpl.PORDER_TEXT)
 
 
 def _calc_gate_width(gate: GateData) -> float:
-    width = GATE_DEFAULT_WIDTH
+    width: float = GATE_DEFAULT_WIDTH
     if gate.name == "":
-        return width
+        return float(width)
     try:
         to_latex_style(gate.name)
     except KeyError:
@@ -234,15 +244,14 @@ def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> QVGateData:
 
 def _to_qulacsvis_circuit(circuit: CircuitData) -> QVCircuitData:
     qubit_count = max(1, circuit.qubit_count)
+    gates: List[List[QVGateData]] = [[] for _ in range(qubit_count)]
     if circuit.layer_count == 0:
-        gates: List[List[QVGateData]] = [[] for _ in range(qubit_count)]
         return QVCircuitData(
             qubit_count=qubit_count,
             layer_count=0,
             gates=gates,
         )
 
-    gates: List[List[QVGateData]] = [[] for _ in range(qubit_count)]
     for layer in range(circuit.layer_count):
         for qubit in range(qubit_count):
             if qubit < circuit.qubit_count:
@@ -295,7 +304,9 @@ class MPLCircuitlDrawer:
         base_drawer = QVMPLCircuitlDrawer(
             qv_circuit, dpi=self._dpi, scale=self._fig_scale_factor
         )
-        figure = base_drawer.draw(debug=debug, filename=None)
+        figure: matplotlib.figure.Figure = base_drawer.draw(
+            debug=debug, filename=None
+        )
 
         self._figure = figure
         self._ax = base_drawer._ax
@@ -316,7 +327,7 @@ class MPLCircuitlDrawer:
             figure.savefig(filename)
 
         if matplotlib.get_backend() in MATPLOTLIB_INLINE_BACKENDS:
-            matplotlib.pyplot.close(figure)
+            plt.close(figure)
         return figure
 
     def _extend_limits(self) -> None:
@@ -499,6 +510,8 @@ class MPLCircuitlDrawer:
         lw: float = 2.0,
         zorder: int = PORDER_LINE,
     ) -> None:
+        if self._ax is None:
+            return
         from_x, from_y = from_xy
         to_x, to_y = to_xy
         self._ax.plot(
@@ -519,6 +532,8 @@ class MPLCircuitlDrawer:
         zorder: int = PORDER_LINE,
         separation: float = 0.08,
     ) -> None:
+        if self._ax is None:
+            return
         from_x, from_y = from_xy
         to_x, to_y = to_xy
         dx = to_x - from_x
@@ -550,6 +565,8 @@ class MPLCircuitlDrawer:
         clip_on: bool = True,
         zorder: int = PORDER_TEXT,
     ) -> None:
+        if self._ax is None:
+            return
         self._ax.text(
             x,
             y,
@@ -565,6 +582,8 @@ class MPLCircuitlDrawer:
     def _gate_with_size(
         self, gate: GateData, xy: Tuple[float, float], multi_gate_size: int
     ) -> None:
+        if self._ax is None:
+            return
         xpos, ypos = xy
         gate_width = _calc_gate_width(gate)
 

--- a/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
@@ -18,22 +18,20 @@ from typing import Deque, List, Optional, Sequence, Tuple, cast
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import patches
-from qulacsvis.models.circuit import (  # type: ignore[import-untyped]
-    CircuitData as QVCircuitData,
-)
-from qulacsvis.models.circuit import (  # type: ignore[import-untyped]
-    ControlQubitInfo as QVControlQubitInfo,
-)
-from qulacsvis.models.circuit import GateData as QVGateData  # type: ignore[import-untyped]
+from qulacsvis.models import circuit as qv_circuit  # type: ignore[import-untyped]
 from qulacsvis.utils.gate import (  # type: ignore[import-untyped]
     grouping_adjacent_gates,
     to_latex_style,
 )
 from qulacsvis.visualization import matplotlib as qv_mpl  # type: ignore[import-untyped]
-from qulacsvis.visualization.matplotlib import (  # type: ignore[import-untyped]
-    MPLCircuitlDrawer as QVMPLCircuitlDrawer,
+from qulacsvis.visualization.matplotlib import (
+    MPLCircuitlDrawer as QVMPLCircuitlDrawer,  # type: ignore[import-untyped]
 )
 from typing_extensions import Final
+
+QVCircuitData = qv_circuit.CircuitData
+QVControlQubitInfo = qv_circuit.ControlQubitInfo
+QVGateData = qv_circuit.GateData
 
 # Visualization models ---------------------------------------------------------
 
@@ -229,7 +227,7 @@ def _circuit_span(
     return circuit_min_x, circuit_max_x
 
 
-def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> QVGateData:
+def _to_qulacsvis_gate(gate: GateData, qubit_count: int) -> "QVGateData":
     if gate.name in {"ghost", "wire"}:
         return QVGateData(gate.name)
 

--- a/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
@@ -21,7 +21,7 @@ from quri_parts.qsub.op import Op
 from quri_parts.qsub.qubit import Qubit
 from quri_parts.qsub.register import Register
 from quri_parts.qsub.resolve import SubRepository, default_repository, resolve_sub
-from quri_parts.qsub.sub import Sub
+from quri_parts.qsub.sub import Sub, SubBuilder
 
 if TYPE_CHECKING:
     import matplotlib
@@ -72,14 +72,20 @@ def op_to_vis_data(
 
 def sub_to_vis_data(sub: Sub) -> CircuitData:
     """Convert a Sub to data used by qulacsvis."""
-    gates = [op_to_vis_data(op, qubits, regs) for op, qubits, regs in sub.operations]
+    gates = [
+        op_to_vis_data(op, qubits, regs)
+        for op, qubits, regs in sub.operations
+        if qubits  # skip classical registers-only ops (Cbz/Label) that have no qubits
+    ]
     return CircuitData.from_gate_sequence(gates, len(sub.qubits) + len(sub.aux_qubits))
 
 
 def machine_sub_to_vis_data(msub: MachineSub) -> CircuitData:
     """Convert a MachineSub to data used by qulacsvis."""
     gates = [
-        op_to_vis_data(mop.op, qubits, regs) for mop, qubits, regs in msub.instructions
+        op_to_vis_data(mop.op, qubits, regs)
+        for mop, qubits, regs in msub.instructions
+        if qubits  # same filtering for machine instructions
     ]
     return CircuitData.from_gate_sequence(
         gates, len(msub.qubits) + len(msub.aux_qubits)
@@ -99,7 +105,9 @@ def draw_sub(
     if isinstance(sub, Op):
         s = resolve_sub(sub, repository)
         if s is None:
-            raise KeyError(f"Sub not found for Op: {sub}")
+            builder = SubBuilder(sub.qubit_count, sub.reg_count)
+            builder.add_op(sub, builder.qubits, builder.registers)
+            s = builder.build()
     else:
         s = sub
     return MPLCircuitlDrawer(  # type: ignore

--- a/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
@@ -96,11 +96,10 @@ def op_to_vis_data(
         controls = (*controls, *_op_controls(op, offset))
 
     name = op.id.to_str(full=False, param_truncate=8)
-    control_positions = [pos for pos, _ in controls]
-    control_info = [ControlBitInfo(qubits[pos].uid, val) for pos, val in controls]
-
-    quantum_targets = [
-        qubits[i].uid for i in range(len(qubits)) if i not in control_positions
+    control_info = [ControlBitInfo(qubits[c[0]].uid, c[1]) for c in controls]
+    control_indices = [c[0] for c in controls]
+    target_bits = [
+        qubits[i].uid for i in range(len(qubits)) if i not in control_indices
     ]
     classical_targets: list[int] = []
     gate_type = GateType.GENERIC
@@ -113,22 +112,22 @@ def op_to_vis_data(
         ctrl_idx = register_indices.get(regs[0].uid)
         if ctrl_idx is not None:
             classical_targets.append(ctrl_idx)
-        quantum_targets = []
+        target_bits = []
         gate_type = GateType.CLASSICAL
     elif op.base_id == Label.base_id and regs:
         if regs[0].uid in register_indices:
             classical_targets.append(register_indices[regs[0].uid])
-        quantum_targets = []
+        target_bits = []
         gate_type = GateType.CLASSICAL
     else:
         classical_targets.extend(register_indices.get(reg.uid, -1) for reg in regs)
         classical_targets = [c for c in classical_targets if c >= 0]
-        if not quantum_targets and classical_targets:
+        if not target_bits and classical_targets:
             gate_type = GateType.CLASSICAL
 
     return GateData(
         name,
-        quantum_targets,
+        target_bits,
         control_info,
         classical_targets,
         gate_type,

--- a/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
@@ -40,6 +40,22 @@ if TYPE_CHECKING:
     import matplotlib
 
 
+__all__ = [
+    "CircuitData",
+    "ConditionalBlock",
+    "ControlBitInfo",
+    "GateData",
+    "GateType",
+    "MPLCircuitlDrawer",
+    "draw",
+    "draw_msub",
+    "draw_sub",
+    "machine_sub_to_vis_data",
+    "op_to_vis_data",
+    "sub_to_vis_data",
+]
+
+
 #: A control qubit specified by (qubit_index, control_value).
 #: control_value should be 0 or 1.
 ControlQubit: TypeAlias = tuple[int, int]
@@ -293,6 +309,8 @@ def _build_conditional_blocks(
             cbz_layer = _find_gate_layer(circuit, start_gate)
         except ValueError:
             continue
+        start_layer: int | None
+        end_layer: int | None
         if isinstance(body_first_gate, GateData):
             try:
                 start_layer = _find_gate_layer(circuit, body_first_gate)

--- a/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/visualize.py
@@ -9,13 +9,26 @@
 # limitations under the License.
 
 from collections.abc import Collection, Sequence
-from typing import TYPE_CHECKING, Optional, TypeAlias
+from typing import TYPE_CHECKING, Mapping, Optional, TypeAlias
 
-from qulacsvis.models.circuit import CircuitData  # type: ignore
-from qulacsvis.models.circuit import ControlQubitInfo, GateData
-from qulacsvis.visualization import MPLCircuitlDrawer  # type: ignore
-
-from quri_parts.qsub.lib.std import CNOT, CZ, Controlled, MultiControlled, Toffoli
+from quri_parts.qsub._visualization import (
+    CircuitData,
+    ConditionalBlock,
+    ControlBitInfo,
+    GateData,
+    GateType,
+    MPLCircuitlDrawer,
+)
+from quri_parts.qsub.lib.std import (
+    CNOT,
+    CZ,
+    Cbz,
+    Controlled,
+    Label,
+    M,
+    MultiControlled,
+    Toffoli,
+)
 from quri_parts.qsub.machineinst import MachineSub
 from quri_parts.qsub.op import Op
 from quri_parts.qsub.qubit import Qubit
@@ -49,9 +62,14 @@ def _op_controls(op: Op, offset: int = 0) -> Collection[ControlQubit]:
 
 
 def op_to_vis_data(
-    op: Op, qubits: Sequence[Qubit], regs: Sequence[Register]
+    op: Op,
+    qubits: Sequence[Qubit],
+    regs: Sequence[Register],
+    register_indices: Optional[Mapping[int, int]] = None,
 ) -> GateData:
-    """Convert an Op to data used by qulacsvis."""
+    """Convert an Op to data used by the visualization layer."""
+    if register_indices is None:
+        register_indices = {}
     offset = 0
     controls = _op_controls(op, offset)
     while op.base_id == Controlled.base_id or op.base_id == MultiControlled.base_id:
@@ -62,34 +80,284 @@ def op_to_vis_data(
         controls = (*controls, *_op_controls(op, offset))
 
     name = op.id.to_str(full=False, param_truncate=8)
-    control_info = [ControlQubitInfo(qubits[c[0]].uid, c[1]) for c in controls]
-    control_indices = [c[0] for c in controls]
-    target_bits = [
-        qubits[i].uid for i in range(len(qubits)) if i not in control_indices
+    control_positions = [pos for pos, _ in controls]
+    control_info = [ControlBitInfo(qubits[pos].uid, val) for pos, val in controls]
+
+    quantum_targets = [
+        qubits[i].uid for i in range(len(qubits)) if i not in control_positions
     ]
-    return GateData(name, target_bits, control_info)
+    classical_targets: list[int] = []
+    gate_type = GateType.GENERIC
+
+    if op.base_id == M.base_id and regs:
+        if regs[0].uid in register_indices:
+            classical_targets.append(register_indices[regs[0].uid])
+        gate_type = GateType.MEASURE
+    elif op.base_id == Cbz.base_id and len(regs) >= 2:
+        ctrl_idx = register_indices.get(regs[0].uid)
+        if ctrl_idx is not None:
+            classical_targets.append(ctrl_idx)
+        quantum_targets = []
+        gate_type = GateType.CLASSICAL
+    elif op.base_id == Label.base_id and regs:
+        if regs[0].uid in register_indices:
+            classical_targets.append(register_indices[regs[0].uid])
+        quantum_targets = []
+        gate_type = GateType.CLASSICAL
+    else:
+        classical_targets.extend(register_indices.get(reg.uid, -1) for reg in regs)
+        classical_targets = [c for c in classical_targets if c >= 0]
+        if not quantum_targets and classical_targets:
+            gate_type = GateType.CLASSICAL
+
+    return GateData(
+        name,
+        quantum_targets,
+        control_info,
+        classical_targets,
+        gate_type,
+    )
 
 
 def sub_to_vis_data(sub: Sub) -> CircuitData:
-    """Convert a Sub to data used by qulacsvis."""
-    gates = [
-        op_to_vis_data(op, qubits, regs)
-        for op, qubits, regs in sub.operations
-        if qubits  # skip classical registers-only ops (Cbz/Label) that have no qubits
-    ]
-    return CircuitData.from_gate_sequence(gates, len(sub.qubits) + len(sub.aux_qubits))
+    """Convert a Sub to data used by the visualization layer."""
+    qubit_count = len(sub.qubits) + len(sub.aux_qubits)
+    all_registers = (*sub.registers, *sub.aux_registers)
+    registers_to_draw: list[Register] = []
+    used_reg_uids: set[int] = set()
+    for op, _qubits, regs in sub.operations:
+        if op.base_id == Label.base_id:
+            continue
+        if op.base_id == Cbz.base_id and len(regs) >= 2:
+            used_reg_uids.add(regs[0].uid)
+            continue
+        used_reg_uids.update(r.uid for r in regs)
+    for reg in all_registers:
+        if reg.uid in used_reg_uids:
+            registers_to_draw.append(reg)
+
+    register_indices = {
+        reg.uid: qubit_count + i for i, reg in enumerate(registers_to_draw)
+    }
+    gates: list[GateData] = []
+    condition_pairs: list[dict[str, object]] = []
+
+    open_conditions: list[dict[str, object]] = []
+    for op, qubits, regs in sub.operations:
+        if not qubits and not regs:
+            continue
+        gate = op_to_vis_data(op, qubits, regs, register_indices)
+        gates.append(gate)
+
+        if op.base_id == Cbz.base_id and len(regs) >= 2:
+            cond_pair = {
+                "start_gate": gate,
+                "cond_reg": regs[0],
+                "label_reg": regs[1],
+                "body_first_gate": None,
+                "body_last_gate": None,
+            }
+            condition_pairs.append(cond_pair)
+            open_conditions.append(cond_pair)
+        if op.base_id == Label.base_id and regs:
+            for pair in condition_pairs:
+                if pair.get("label_reg") == regs[0] and "end_gate" not in pair:
+                    end_gate = pair.get("body_last_gate") or gate
+                    pair["end_gate"] = end_gate
+                    break
+        for pair in open_conditions:
+            if (
+                pair.get("end_gate") is None
+                and gate is not pair.get("start_gate")
+                and op.base_id != Label.base_id
+            ):
+                if pair.get("body_first_gate") is None:
+                    pair["body_first_gate"] = gate
+                pair["body_last_gate"] = gate
+
+    circuit = CircuitData.from_gate_sequence(
+        gates,
+        qubit_count=qubit_count,
+        register_count=len(registers_to_draw),
+    )
+    aux_reg_uids = {r.uid for r in sub.aux_registers}
+    circuit.conditional_blocks = _build_conditional_blocks(
+        circuit,
+        condition_pairs,
+        register_indices,
+        excluded_bits=[
+            idx for reg_uid, idx in register_indices.items() if reg_uid in aux_reg_uids
+        ],
+    )
+    return circuit
 
 
 def machine_sub_to_vis_data(msub: MachineSub) -> CircuitData:
-    """Convert a MachineSub to data used by qulacsvis."""
-    gates = [
-        op_to_vis_data(mop.op, qubits, regs)
-        for mop, qubits, regs in msub.instructions
-        if qubits  # same filtering for machine instructions
-    ]
-    return CircuitData.from_gate_sequence(
-        gates, len(msub.qubits) + len(msub.aux_qubits)
+    """Convert a MachineSub to data used by the visualization layer."""
+    qubit_count = len(msub.qubits) + len(msub.aux_qubits)
+    all_registers = (*msub.registers, *msub.aux_registers)
+    registers_to_draw: list[Register] = []
+    used_reg_uids: set[int] = set()
+    for mop, _qubits, regs in msub.instructions:
+        if mop.op.base_id == Label.base_id:
+            continue
+        if mop.op.base_id == Cbz.base_id and len(regs) >= 2:
+            used_reg_uids.add(regs[0].uid)
+            continue
+        used_reg_uids.update(r.uid for r in regs)
+    for reg in all_registers:
+        if reg.uid in used_reg_uids:
+            registers_to_draw.append(reg)
+
+    register_indices = {
+        reg.uid: qubit_count + i for i, reg in enumerate(registers_to_draw)
+    }
+    gates: list[GateData] = []
+    condition_pairs: list[dict[str, object]] = []
+    for mop, qubits, regs in msub.instructions:
+        if not qubits and not regs:
+            continue
+        gate = op_to_vis_data(mop.op, qubits, regs, register_indices)
+        gates.append(gate)
+
+        if mop.op.base_id == Cbz.base_id and len(regs) >= 2:
+            condition_pairs.append(
+                {
+                    "start_gate": gate,
+                    "cond_reg": regs[0],
+                    "label_reg": regs[1],
+                    "body_first_gate": None,
+                    "body_last_gate": None,
+                }
+            )
+        if mop.op.base_id == Label.base_id and regs:
+            for pair in condition_pairs:
+                if pair.get("label_reg") == regs[0] and "end_gate" not in pair:
+                    pair["end_gate"] = gate
+                    break
+        for pair in condition_pairs:
+            if (
+                pair.get("end_gate") is None
+                and gate is not pair.get("start_gate")
+                and mop.op.base_id != Label.base_id
+            ):
+                if pair.get("body_first_gate") is None:
+                    pair["body_first_gate"] = gate
+                pair["body_last_gate"] = gate
+
+    circuit = CircuitData.from_gate_sequence(
+        gates,
+        qubit_count=qubit_count,
+        register_count=len(registers_to_draw),
     )
+    aux_reg_uids = {r.uid for r in msub.aux_registers}
+    circuit.conditional_blocks = _build_conditional_blocks(
+        circuit,
+        condition_pairs,
+        register_indices,
+        excluded_bits=[
+            idx for reg_uid, idx in register_indices.items() if reg_uid in aux_reg_uids
+        ],
+    )
+    return circuit
+
+
+def _find_gate_layer(circuit: CircuitData, gate: GateData) -> int:
+    for layer in range(circuit.layer_count):
+        for bit in range(circuit.bit_count):
+            if circuit.gates[bit][layer] is gate:
+                return layer
+    raise ValueError("Gate not found in circuit data")
+
+
+def _build_conditional_blocks(
+    circuit: CircuitData,
+    condition_pairs: Sequence[Mapping[str, object]],
+    register_indices: Mapping[int, int],
+    excluded_bits: Sequence[int] = (),
+) -> list[ConditionalBlock]:
+    blocks: list[ConditionalBlock] = []
+    excluded_set = set(excluded_bits)
+    for pair in condition_pairs:
+        start_gate = pair.get("start_gate")
+        end_gate = pair.get("end_gate")
+        body_first_gate = pair.get("body_first_gate")
+        body_last_gate = pair.get("body_last_gate")
+        cond_reg = pair.get("cond_reg")
+        label_reg = pair.get("label_reg")
+        if not isinstance(start_gate, GateData):
+            continue
+        assert isinstance(cond_reg, Register)
+        assert isinstance(label_reg, Register)
+        try:
+            cbz_layer = _find_gate_layer(circuit, start_gate)
+        except ValueError:
+            continue
+        if isinstance(body_first_gate, GateData):
+            try:
+                start_layer = _find_gate_layer(circuit, body_first_gate)
+            except ValueError:
+                start_layer = None
+        else:
+            start_layer = None
+        if isinstance(body_last_gate, GateData):
+            try:
+                end_layer = _find_gate_layer(circuit, body_last_gate)
+            except ValueError:
+                end_layer = start_layer
+        elif isinstance(end_gate, GateData):
+            try:
+                end_layer = _find_gate_layer(circuit, end_gate)
+            except ValueError:
+                end_layer = start_layer
+        else:
+            end_layer = start_layer
+
+        if start_layer is None or end_layer is None:
+            continue
+        if start_layer > end_layer:
+            start_layer, end_layer = end_layer, start_layer
+
+        bits: set[int] = set()
+        cond_idx = register_indices.get(cond_reg.uid)
+        if cond_idx is not None and cond_idx not in excluded_set:
+            bits.add(cond_idx)
+        label_idx = register_indices.get(label_reg.uid)
+        if label_idx is not None and label_idx not in excluded_set:
+            bits.add(label_idx)
+        for layer in range(start_layer, end_layer + 1):
+            for bit_index, line in enumerate(circuit.gates):
+                if layer >= len(line):
+                    continue
+                gate = line[layer]
+                if gate.name in {"wire", "ghost"}:
+                    continue
+                bits.update(b for b in gate.all_target_bits if b not in excluded_set)
+                bits.update(
+                    c.index
+                    for c in gate.control_bit_infos
+                    if c.index not in excluded_set
+                )
+
+        if cond_idx is not None:
+            visible_cond = cond_idx - circuit.qubit_count
+        else:
+            visible_cond = None
+        label = f"r{visible_cond} == 0" if visible_cond is not None else "cond == 0"
+        if not bits:
+            continue
+        blocks.append(
+            ConditionalBlock(
+                start_layer=start_layer,
+                end_layer=end_layer,
+                bits=sorted(bits),
+                label=label,
+                cbz_layer=cbz_layer,
+                cbz_bit=cond_idx,
+            )
+        )
+
+    return blocks
 
 
 def draw_sub(
@@ -110,9 +378,9 @@ def draw_sub(
             s = builder.build()
     else:
         s = sub
-    return MPLCircuitlDrawer(  # type: ignore
-        sub_to_vis_data(s), dpi=dpi, scale=scale
-    ).draw(debug=debug, filename=filename)
+    return MPLCircuitlDrawer(sub_to_vis_data(s), dpi=dpi, scale=scale).draw(
+        debug=debug, filename=filename
+    )
 
 
 def draw_msub(
@@ -124,9 +392,9 @@ def draw_msub(
     filename: Optional[str] = None,
 ) -> "matplotlib.figure.Figure":
     """Draw a diagram for a given MachineSub."""
-    return MPLCircuitlDrawer(  # type: ignore
-        machine_sub_to_vis_data(msub), dpi=dpi, scale=scale
-    ).draw(debug=debug, filename=filename)
+    return MPLCircuitlDrawer(machine_sub_to_vis_data(msub), dpi=dpi, scale=scale).draw(
+        debug=debug, filename=filename
+    )
 
 
 def draw(
@@ -139,6 +407,6 @@ def draw(
 ) -> "matplotlib.figure.Figure":
     """Draw a diagram for a given Sub or MachineSub."""
     if isinstance(sub, (Op, Sub)):
-        return draw_sub(sub)
+        return draw_sub(sub, dpi=dpi, scale=scale, debug=debug, filename=filename)
     else:
-        return draw_msub(sub)
+        return draw_msub(sub, dpi=dpi, scale=scale, debug=debug, filename=filename)

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -6,6 +6,7 @@ from qulacsvis.models.circuit import (  # type: ignore
     GateData,
 )
 
+import quri_parts.qsub.visualize as visualize
 from quri_parts.qsub.lib.std import (
     CNOT,
     CZ,
@@ -20,7 +21,6 @@ from quri_parts.qsub.lib.std import (
 )
 from quri_parts.qsub.qubit import Qubit
 from quri_parts.qsub.sub import Sub, SubBuilder
-import quri_parts.qsub.visualize as visualize
 from quri_parts.qsub.visualize import (
     _op_controls,
     draw_sub,
@@ -42,7 +42,9 @@ def _classical_sub() -> Sub:
 
 def _patch_drawer(monkeypatch: Any, record: dict[str, Any]) -> None:
     class DummyDrawer:
-        def __init__(self, circuit_data: CircuitData, *, dpi: int, scale: float) -> None:
+        def __init__(
+            self, circuit_data: CircuitData, *, dpi: int, scale: float
+        ) -> None:
             record["data"] = circuit_data
 
         def draw(self, **_: Any) -> str:

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -1,17 +1,16 @@
 from typing import Any
 
-from _pytest.monkeypatch import MonkeyPatch
-from qulacsvis.models.circuit import (  # type: ignore
-    CircuitData,
-    ControlQubitInfo,
-    GateData,
-)
+from matplotlib import patches as mpatches
+from matplotlib.figure import Figure
+from pytest import MonkeyPatch
 
+import quri_parts.qsub._visualization as vis_impl
 import quri_parts.qsub.visualize as visualize
 from quri_parts.qsub.lib.std import (
     CNOT,
     CZ,
     SWAP,
+    Cbz,
     Controlled,
     H,
     M,
@@ -21,8 +20,13 @@ from quri_parts.qsub.lib.std import (
     conditional,
 )
 from quri_parts.qsub.qubit import Qubit
+from quri_parts.qsub.register import Register
 from quri_parts.qsub.sub import Sub, SubBuilder
 from quri_parts.qsub.visualize import (
+    CircuitData,
+    ControlBitInfo,
+    GateData,
+    GateType,
     _op_controls,
     draw_sub,
     op_to_vis_data,
@@ -41,24 +45,32 @@ def _classical_sub() -> Sub:
     return builder.build()
 
 
-class DummyFigure:
-    ...
+def _patch_drawer(monkeypatch: MonkeyPatch, record: dict[str, Any]) -> None:
+    orig_init = visualize.MPLCircuitlDrawer.__init__
 
+    def recording_init(
+        self, circuit_data: CircuitData, *, dpi: int, scale: float
+    ) -> None:
+        record["data"] = circuit_data
+        orig_init(self, circuit_data, dpi=dpi, scale=scale)
 
-def _patch_drawer(monkeypatch: Any, record: dict[str, Any]) -> None:
-    class DummyDrawer:
-        def __init__(
-            self, circuit_data: CircuitData, *, dpi: int, scale: float
-        ) -> None:
-            record["data"] = circuit_data
+    monkeypatch.setattr(visualize.MPLCircuitlDrawer, "__init__", recording_init)
 
-        def draw(self, **_: Any) -> DummyFigure:
+    class DummyBaseDrawer:
+        def __init__(self, circuit_data: Any, *, dpi: int, scale: float) -> None:
+            record["base_circuit"] = circuit_data
+            layer_width_count = max(1, circuit_data.layer_count or 1)
+            self._layer_width = [1.0] * layer_width_count
+            fig = Figure()
+            self._figure = fig
+            self._ax = fig.add_subplot(111)
+
+        def draw(self, **_: Any) -> Figure:
             record["drawn"] = True
-            figure = DummyFigure()
-            record["figure"] = figure
-            return figure
+            record["figure"] = self._figure
+            return self._figure
 
-    monkeypatch.setattr(visualize, "MPLCircuitlDrawer", DummyDrawer)
+    monkeypatch.setattr(vis_impl, "QVMPLCircuitlDrawer", DummyBaseDrawer)
 
 
 class TestOpControls:
@@ -90,10 +102,10 @@ class TestOpToVisData:
 
     def test_two_qubit_controlled_gate(self) -> None:
         d = op_to_vis_data(CNOT, (Qubit(4), Qubit(2)), ())
-        assert d == GateData("CNOT", [2], [ControlQubitInfo(4, 1)])
+        assert d == GateData("CNOT", [2], [ControlBitInfo(4, 1)])
 
         d = op_to_vis_data(CZ, (Qubit(4), Qubit(2)), ())
-        assert d == GateData("CZ", [2], [ControlQubitInfo(4, 1)])
+        assert d == GateData("CZ", [2], [ControlBitInfo(4, 1)])
 
     def test_swap_gate(self) -> None:
         d = op_to_vis_data(SWAP, (Qubit(4), Qubit(2)), ())
@@ -102,12 +114,12 @@ class TestOpToVisData:
     def test_toffoli_gate(self) -> None:
         d = op_to_vis_data(Toffoli, (Qubit(4), Qubit(1), Qubit(2)), ())
         assert d == GateData(
-            "Toffoli", [2], [ControlQubitInfo(4, 1), ControlQubitInfo(1, 1)]
+            "Toffoli", [2], [ControlBitInfo(4, 1), ControlBitInfo(1, 1)]
         )
 
     def test_controlled_gate(self) -> None:
         d = op_to_vis_data(Controlled(SWAP), (Qubit(4), Qubit(1), Qubit(2)), ())
-        assert d == GateData("SWAP", [1, 2], [ControlQubitInfo(4, 1)])
+        assert d == GateData("SWAP", [1, 2], [ControlBitInfo(4, 1)])
 
     def test_multi_controlled_gate(self) -> None:
         d = op_to_vis_data(
@@ -118,14 +130,12 @@ class TestOpToVisData:
         assert d == GateData(
             "SWAP",
             [6, 1],
-            [ControlQubitInfo(i, c) for i, c in [(4, 1), (2, 0), (3, 1), (5, 0)]],
+            [ControlBitInfo(i, c) for i, c in [(4, 1), (2, 0), (3, 1), (5, 0)]],
         )
 
     def test_controlled_cnot_gate(self) -> None:
         d = op_to_vis_data(Controlled(CNOT), (Qubit(4), Qubit(1), Qubit(2)), ())
-        assert d == GateData(
-            "CNOT", [2], [ControlQubitInfo(4, 1), ControlQubitInfo(1, 1)]
-        )
+        assert d == GateData("CNOT", [2], [ControlBitInfo(4, 1), ControlBitInfo(1, 1)])
 
     def test_multi_controlled_cnot_gate(self) -> None:
         d = op_to_vis_data(
@@ -136,10 +146,7 @@ class TestOpToVisData:
         assert d == GateData(
             "CNOT",
             [1],
-            [
-                ControlQubitInfo(i, c)
-                for i, c in [(4, 1), (2, 0), (3, 1), (5, 0), (6, 1)]
-            ],
+            [ControlBitInfo(i, c) for i, c in [(4, 1), (2, 0), (3, 1), (5, 0), (6, 1)]],
         )
 
     def test_nested_controlled_gate(self) -> None:
@@ -152,19 +159,45 @@ class TestOpToVisData:
             "X",
             [0],
             [
-                ControlQubitInfo(i, c)
+                ControlBitInfo(i, c)
                 for i, c in [(4, 1), (2, 1), (3, 0), (5, 1), (6, 0), (1, 1)]
             ],
         )
 
+    def test_measure_gate_includes_register_target(self) -> None:
+        reg_index = {Register(0).uid: 2}
+        d = op_to_vis_data(M, (Qubit(0),), (Register(0),), reg_index)
+        assert d.classical_bits == [2]
+        assert d.kind == GateType.MEASURE
+
+    def test_cbz_uses_classical_control(self) -> None:
+        regs = (Register(0), Register(1))
+        reg_index = {regs[0].uid: 2, regs[1].uid: 3}
+        d = op_to_vis_data(Cbz, (), regs, reg_index)
+        assert d.target_bits == []
+        assert d.classical_bits == [2]
+        assert d.control_bit_infos == []
+        assert d.kind == GateType.CLASSICAL
+
 
 class TestSubToVisData:
-    def test_classical_ops_are_ignored(self) -> None:
+    def test_classical_ops_are_included(self) -> None:
         data = sub_to_vis_data(_classical_sub())
         assert isinstance(data, CircuitData)
         assert data.qubit_count == 2
+        assert data.register_count == 1
         gate_names = {gate.name for line in data.gates for gate in line}
-        assert {"H", "CZ"} <= gate_names
+        assert {"H", "CZ", "M", "Cbz"} <= gate_names
+
+    def test_conditional_block_is_present(self) -> None:
+        data = sub_to_vis_data(_classical_sub())
+        assert len(data.conditional_blocks) == 1
+        block = data.conditional_blocks[0]
+        # auxiliary registers should be excluded from shaded area
+        assert 2 not in block.bits
+        assert set(block.bits) >= {0, 1}
+        assert block.label == "r0 == 0"
+        assert block.start_layer <= block.end_layer
 
 
 class TestDrawSub:
@@ -174,17 +207,61 @@ class TestDrawSub:
         _patch_drawer(monkeypatch, record)
 
         result = draw_sub(_classical_sub())
+        assert isinstance(result, Figure)
         assert result is record["figure"]
         assert record.get("drawn") is True
         data = record["data"]
         assert data.qubit_count == 2
+        assert data.register_count == 1
+        base_circuit = record["base_circuit"]
+        assert base_circuit.qubit_count == data.qubit_count
+        assert len(base_circuit.gates) == base_circuit.qubit_count
+        assert all(len(line) == base_circuit.layer_count for line in base_circuit.gates)
         gate_names = {
             gate.name
             for line in data.gates
             for gate in line
             if gate.name not in {"wire", "ghost"}
         }
-        assert {"H", "CZ"} <= gate_names
+        assert {"H", "CZ", "M", "Cbz"} <= gate_names
+        ax = record["figure"].axes[0]
+        wire_pitch = (
+            vis_impl.GATE_DEFAULT_HEIGHT
+            + vis_impl.GATE_MARGIN_TOP
+            + vis_impl.GATE_MARGIN_BOTTOM
+        )
+        visual_bits = data.qubit_count + (1 if data.register_count else 0)
+        expected_top = (
+            visual_bits * wire_pitch
+            - vis_impl.GATE_MARGIN_TOP
+            - vis_impl.GATE_MARGIN_BOTTOM
+            - vis_impl.GATE_DEFAULT_HEIGHT / 2
+            + vis_impl.CIRCUIT_MARGIN
+        )
+        expected_bottom = -vis_impl.GATE_DEFAULT_HEIGHT / 2 - vis_impl.CIRCUIT_MARGIN
+        ylim = ax.get_ylim()
+        assert ylim[0] == expected_top
+        assert ylim[1] == expected_bottom
+        assert len(ax.patches) >= 2
+        assert len(ax.lines) >= 3
+        circles = [p for p in ax.patches if isinstance(p, mpatches.Circle)]
+        cbz_circles = [
+            c
+            for c in circles
+            if abs(c.center[1] - 2 * wire_pitch) < 1e-6 and c.get_radius() <= 0.2
+        ]
+        assert cbz_circles, "Cbz marker should be drawn as a filled dot"
+        cond_rects = [
+            p
+            for p in ax.patches
+            if isinstance(p, mpatches.Rectangle) and p.get_linestyle() == "--"
+        ]
+        assert cond_rects, "Conditional region rectangle missing"
+        assert cbz_circles[0].center[0] < cond_rects[0].get_x()
+        rect_x = cond_rects[0].get_x()
+        assert any(
+            abs(x - rect_x) < 1e-6 for line in ax.lines for x in line.get_xdata()
+        )
 
     def test_falls_back_to_single_op(self, monkeypatch: MonkeyPatch) -> None:
         record: dict[str, Any] = {}
@@ -192,6 +269,10 @@ class TestDrawSub:
         _patch_drawer(monkeypatch, record)
 
         result = draw_sub(CNOT)
+        assert isinstance(result, Figure)
         assert result is record["figure"]
         assert record.get("drawn") is True
         assert isinstance(record["data"], CircuitData)
+        base_circuit = record["base_circuit"]
+        assert base_circuit.qubit_count >= 1
+        assert len(base_circuit.gates) == base_circuit.qubit_count

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from _pytest.monkeypatch import MonkeyPatch
 from qulacsvis.models.circuit import (  # type: ignore
     CircuitData,
     ControlQubitInfo,
@@ -40,6 +41,10 @@ def _classical_sub() -> Sub:
     return builder.build()
 
 
+class DummyFigure:
+    ...
+
+
 def _patch_drawer(monkeypatch: Any, record: dict[str, Any]) -> None:
     class DummyDrawer:
         def __init__(
@@ -47,9 +52,11 @@ def _patch_drawer(monkeypatch: Any, record: dict[str, Any]) -> None:
         ) -> None:
             record["data"] = circuit_data
 
-        def draw(self, **_: Any) -> str:
+        def draw(self, **_: Any) -> DummyFigure:
             record["drawn"] = True
-            return "figure"
+            figure = DummyFigure()
+            record["figure"] = figure
+            return figure
 
     monkeypatch.setattr(visualize, "MPLCircuitlDrawer", DummyDrawer)
 
@@ -161,13 +168,13 @@ class TestSubToVisData:
 
 
 class TestDrawSub:
-    def test_handles_classical_ops(self, monkeypatch) -> None:
+    def test_handles_classical_ops(self, monkeypatch: MonkeyPatch) -> None:
         record: dict[str, Any] = {}
 
         _patch_drawer(monkeypatch, record)
 
         result = draw_sub(_classical_sub())
-        assert result == "figure"
+        assert result is record["figure"]
         assert record.get("drawn") is True
         data = record["data"]
         assert data.qubit_count == 2
@@ -179,12 +186,12 @@ class TestDrawSub:
         }
         assert {"H", "CZ"} <= gate_names
 
-    def test_falls_back_to_single_op(self, monkeypatch) -> None:
+    def test_falls_back_to_single_op(self, monkeypatch: MonkeyPatch) -> None:
         record: dict[str, Any] = {}
 
         _patch_drawer(monkeypatch, record)
 
         result = draw_sub(CNOT)
-        assert result == "figure"
+        assert result is record["figure"]
         assert record.get("drawn") is True
         assert isinstance(record["data"], CircuitData)

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -265,9 +265,6 @@ class TestDrawSub:
         rect_w = cond_rects[0].get_width()
         cbz_x = cbz_circles[0].center[0]
         assert rect_x <= cbz_x <= rect_x + rect_w
-        assert any(
-            abs(x - rect_x) < 1e-6 for line in ax.lines for x in line.get_xdata()
-        )
 
     def test_falls_back_to_single_op(self, monkeypatch: MonkeyPatch) -> None:
         record: dict[str, Any] = {}

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -1,16 +1,55 @@
-from qulacsvis.models.circuit import ControlQubitInfo, GateData  # type: ignore
+from typing import Any
+
+from qulacsvis.models.circuit import (  # type: ignore
+    CircuitData,
+    ControlQubitInfo,
+    GateData,
+)
 
 from quri_parts.qsub.lib.std import (
     CNOT,
     CZ,
     SWAP,
     Controlled,
+    H,
+    M,
     MultiControlled,
     Toffoli,
     X,
+    conditional,
 )
 from quri_parts.qsub.qubit import Qubit
-from quri_parts.qsub.visualize import _op_controls, op_to_vis_data
+from quri_parts.qsub.sub import Sub, SubBuilder
+import quri_parts.qsub.visualize as visualize
+from quri_parts.qsub.visualize import (
+    _op_controls,
+    draw_sub,
+    op_to_vis_data,
+    sub_to_vis_data,
+)
+
+
+def _classical_sub() -> Sub:
+    builder = SubBuilder(arg_qubits_count=2)
+    q0, q1 = builder.qubits
+    builder.add_op(H, (q0,))
+    register = builder.add_aux_register()
+    builder.add_op(M, (q1,), (register,))
+    with conditional(builder, register):
+        builder.add_op(CZ, (q0, q1))
+    return builder.build()
+
+
+def _patch_drawer(monkeypatch: Any, record: dict[str, Any]) -> None:
+    class DummyDrawer:
+        def __init__(self, circuit_data: CircuitData, *, dpi: int, scale: float) -> None:
+            record["data"] = circuit_data
+
+        def draw(self, **_: Any) -> str:
+            record["drawn"] = True
+            return "figure"
+
+    monkeypatch.setattr(visualize, "MPLCircuitlDrawer", DummyDrawer)
 
 
 class TestOpControls:
@@ -108,3 +147,42 @@ class TestOpToVisData:
                 for i, c in [(4, 1), (2, 1), (3, 0), (5, 1), (6, 0), (1, 1)]
             ],
         )
+
+
+class TestSubToVisData:
+    def test_classical_ops_are_ignored(self) -> None:
+        data = sub_to_vis_data(_classical_sub())
+        assert isinstance(data, CircuitData)
+        assert data.qubit_count == 2
+        gate_names = {gate.name for line in data.gates for gate in line}
+        assert {"H", "CZ"} <= gate_names
+
+
+class TestDrawSub:
+    def test_handles_classical_ops(self, monkeypatch) -> None:
+        record: dict[str, Any] = {}
+
+        _patch_drawer(monkeypatch, record)
+
+        result = draw_sub(_classical_sub())
+        assert result == "figure"
+        assert record.get("drawn") is True
+        data = record["data"]
+        assert data.qubit_count == 2
+        gate_names = {
+            gate.name
+            for line in data.gates
+            for gate in line
+            if gate.name not in {"wire", "ghost"}
+        }
+        assert {"H", "CZ"} <= gate_names
+
+    def test_falls_back_to_single_op(self, monkeypatch) -> None:
+        record: dict[str, Any] = {}
+
+        _patch_drawer(monkeypatch, record)
+
+        result = draw_sub(CNOT)
+        assert result == "figure"
+        assert record.get("drawn") is True
+        assert isinstance(record["data"], CircuitData)

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -49,7 +49,11 @@ def _patch_drawer(monkeypatch: MonkeyPatch, record: dict[str, Any]) -> None:
     orig_init = visualize.MPLCircuitlDrawer.__init__
 
     def recording_init(
-        self, circuit_data: CircuitData, *, dpi: int, scale: float
+        self: visualize.MPLCircuitlDrawer,
+        circuit_data: CircuitData,
+        *,
+        dpi: int,
+        scale: float,
     ) -> None:
         record["data"] = circuit_data
         orig_init(self, circuit_data, dpi=dpi, scale=scale)
@@ -257,8 +261,10 @@ class TestDrawSub:
             if isinstance(p, mpatches.Rectangle) and p.get_linestyle() == "--"
         ]
         assert cond_rects, "Conditional region rectangle missing"
-        assert cbz_circles[0].center[0] < cond_rects[0].get_x()
         rect_x = cond_rects[0].get_x()
+        rect_w = cond_rects[0].get_width()
+        cbz_x = cbz_circles[0].center[0]
+        assert rect_x <= cbz_x <= rect_x + rect_w
         assert any(
             abs(x - rect_x) < 1e-6 for line in ax.lines for x in line.get_xdata()
         )


### PR DESCRIPTION
-Added a small, typed visualization layer (`_visualization.py`) with gate/conditional models, helpers to map to qulacsvis, and a custom Matplotlib drawer that draws conditional shading, classical register wires/labels, measurement arrows, classical gate boxes, and control dots.
-Refactored `visualize.py` to use those models: map ops to `GateType`, build register indices, collect `Cbz`/`Label` into `ConditionalBlocks`, and keep drawing `Op`, `Sub`, and `MachineSub` with the new drawer.