### PR TITLE
Trigger package workflow on release only

### DIFF
--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -1,8 +1,6 @@
 name: QURI SDK Package and release
 
 on:
-  push:
-    branches: [main, 'quri-parts-qret*']
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary
- Removes the `push: branches: [main, 'quri-parts-qret*']` trigger from `.github/workflows/quri-sdk-package.yml` so the full build/test matrix no longer runs on every PR merge. This means this workflow gets triggered only when a new release is created on github.
