### PR TITLE
Point qpe deprecation notice to quri_algo.circuit_lib.qpe

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/lib/qpe.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/lib/qpe.py
@@ -10,7 +10,7 @@
 
 # =============================================================================
 # DEPRECATED: This module is deprecated and feature-frozen.
-# Please develop on the identically named module under quri_algo.qsub instead.
+# Please develop on the identically named module under quri_algo.circuit_lib instead.
 #
 # This module should only receive critical bug fixes.
 # =============================================================================
@@ -29,7 +29,7 @@ from quri_parts.qsub.sub import SubBuilder
 from . import NS as parent_ns
 
 warnings.warn(
-    "quri_parts.qsub.lib.qpe is deprecated and no longer maintained. Please import with quri_algo.qsub.qpe instead.",
+    "quri_parts.qsub.lib.qpe is deprecated and no longer maintained. Please import with quri_algo.circuit_lib.qpe instead.",
     FutureWarning,
     stacklevel=2,
 )


### PR DESCRIPTION
The deprecation notice in `quri_parts.qsub.lib.qpe` tells users to import from `quri_algo.qsub.qpe`, which does not exist (and `quri_algo.qsub` is itself deprecated in favor of `quri_algo.circuit_lib`). The canonical module is `quri_algo.circuit_lib.qpe`. This updates the notice accordingly.