### PR TITLE
Build cached Qulacs wheels with portable AVX2

### DIFF
--- a/.github/workflows/quri-parts-test.yml
+++ b/.github/workflows/quri-parts-test.yml
@@ -43,6 +43,8 @@ jobs:
         python-version: ${{ matrix.python_version }}
         enable-cache: true
         cache-dependency-glob: "uv.lock"
+        # Python 3.14 builds Qulacs from source, so do not reuse the old native-CPU build cache.
+        cache-suffix: ${{ matrix.python_version == '3.14' && 'qulacs-mavx2-mfma-v1' || '' }}
 
     - uses: ./.github/actions/quri-parts/rust-install-cache
       with:
@@ -74,6 +76,9 @@ jobs:
     # qulacsvis, so no cp314 wheel) needs zlib + libjpeg.
     - name: Install dependencies (3.14)
       if: matrix.python_version == '3.14'
+      env:
+        # GitHub-hosted x86 runners share caches across CPUs, so use a portable ISA instead of -march=native.
+        QULACS_OPT_FLAGS: "-mavx2 -mfma"
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/quri-sdk-package.yml
+++ b/.github/workflows/quri-sdk-package.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-cache-v2-${{ runner.os }}-py${{ matrix.python-version }}
+          key: pip-cache-v2-${{ runner.os }}-py${{ matrix.python-version }}${{ runner.os == 'Linux' && matrix.python-version == '14' && '-qulacs-mavx2-mfma-v1' || '' }}
           
       - uses: actions/checkout@v3
 
@@ -179,6 +179,10 @@ jobs:
           BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
         shell: bash
         run: |
+          # Qulacs has no cp314 wheel and defaults to -march=native on Linux.
+          if [[ "${{ runner.os }}" = "Linux" && "${{ matrix.python-version }}" = "14" ]]; then
+              export QULACS_OPT_FLAGS="-mavx2 -mfma"
+          fi
           pip install --upgrade pytest setuptools
           if [[ "${{ runner.os }}" = "Windows" ]]; then
               pip cache purge || true
@@ -318,7 +322,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-cache-v2-${{ runner.os }}-py${{ matrix.python-version }}
+          key: pip-cache-v2-${{ runner.os }}-py${{ matrix.python-version }}${{ runner.os == 'Linux' && matrix.python-version == '14' && '-qulacs-mavx2-mfma-v1' || '' }}
 
       - uses: actions/checkout@v3
 
@@ -373,6 +377,10 @@ jobs:
           BOOST_ROOT: ${{steps.install-boost.outputs.BOOST_ROOT}}
         shell: bash
         run: |
+          # Qulacs has no cp314 wheel and defaults to -march=native on Linux.
+          if [[ "${{ runner.os }}" = "Linux" && "${{ matrix.python-version }}" = "14" ]]; then
+              export QULACS_OPT_FLAGS="-mavx2 -mfma"
+          fi
           pip install pytest
           if [[ "${{ runner.os }}" = "Windows" ]]; then
               pip cache purge || true


### PR DESCRIPTION
## Issue

N/A

## Changes

- Build Python 3.14 Qulacs wheels with `-mavx2 -mfma` instead of the runner-specific `-march=native`.
- Use distinct uv and pip cache keys so jobs cannot restore previously cached native-CPU wheels.
- Apply the portable build recipe to the regular QURI Parts test and Linux Python 3.14 package test jobs.

## Progress

- [x] Main implementation written
- [x] Functions as intended
- [ ] Unit tests have been written
- [ ] readme.md has been updated
