### PR TITLE
Fix mypy no-any-return in SPE fourier coefficient code

### DIFF
--- a/quri-algo/quri_algo/algo/phase_estimation/spe/utils/fourier/gaussian_coefficient.py
+++ b/quri-algo/quri_algo/algo/phase_estimation/spe/utils/fourier/gaussian_coefficient.py
@@ -77,7 +77,10 @@ class GaussianSampler(FourierCoefficientSampler):
 
     @property
     def distribution(self) -> npt.NDArray[np.float64]:
-        return self.fourier_coefficients / np.linalg.norm(self.fourier_coefficients, 1)
+        normalized = self.fourier_coefficients / np.linalg.norm(
+            self.fourier_coefficients, 1
+        )
+        return cast(npt.NDArray[np.float64], normalized.real)
 
     def __call__(self, n_samples: int) -> Sequence[SPEFourierCoefficient]:
         classical_samples = get_classical_samples(self.distribution.tolist(), n_samples)

--- a/quri-algo/quri_algo/algo/phase_estimation/spe/utils/fourier/step_func_coefficient.py
+++ b/quri-algo/quri_algo/algo/phase_estimation/spe/utils/fourier/step_func_coefficient.py
@@ -112,7 +112,7 @@ _f_tilde_cache: dict[tuple[int, float], npt.NDArray[np.complex128]] = {}
 
 def get_F_tilde(d: int, delta: float) -> npt.NDArray[np.complex128]:
     if (d, delta) in _f_tilde_cache:
-        return _f_tilde_cache[(d, delta)].copy()
+        return cast(npt.NDArray[np.complex128], _f_tilde_cache[(d, delta)].copy())
 
     M_fourier = get_M_tilde(d, delta)
     M_fourier = M_fourier[0 : d + 1]


### PR DESCRIPTION
## Issue

Related issue: QunaSys/quri-sdk-issues#896

## Changes

Changes proposed in this pull-request

- Added an explicit `cast` in `get_F_tilde` (`step_func_coefficient.py`) so the cached-array return path satisfies its declared `npt.NDArray[np.complex128]` return type instead of being inferred as `Any` by mypy.
- Fixed `GaussianSampler.distribution` (`gaussian_coefficient.py`) to take the real component and cast to `npt.NDArray[np.float64]`, matching its declared return type (the underlying values are real by construction; only the dtype bookkeeping changes).

## Progress

- [x] Main implementation written
- [x] Functions as intended
- [ ] Unit tests have been written
- [ ] readme.md has been updated
