### PR TITLE
Patch qulacsvis' Matplotlib drawer to support controlled SWAP gates

### DIFF
--- a/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
+++ b/quri-parts/packages/qsub/quri_parts/qsub/_visualization.py
@@ -264,6 +264,20 @@ def _to_qulacsvis_circuit(circuit: CircuitData) -> Any:
     )
 
 
+def _patch_swap_controls(drawer: Any) -> None:
+    """qulacsvis' drawer doesn't draw control markers for SWAP gates."""
+    original_swap = getattr(drawer, "_swap", None)
+    if original_swap is None:
+        return
+
+    def _swap(gate: Any, xy: Tuple[float, float]) -> None:
+        original_swap(gate, xy)
+        if gate.control_bit_infos:
+            drawer._control_bits(gate.control_bit_infos, xy)
+
+    drawer._swap = _swap
+
+
 class MPLCircuitlDrawer:
     def __init__(
         self,
@@ -301,6 +315,7 @@ class MPLCircuitlDrawer:
         base_drawer = QVMPLCircuitlDrawer(
             qv_circuit, dpi=self._dpi, scale=self._fig_scale_factor
         )
+        _patch_swap_controls(base_drawer)
         figure: matplotlib.figure.Figure = base_drawer.draw(debug=debug, filename=None)
 
         self._figure = figure

--- a/quri-parts/packages/qsub/tests/test_visualize.py
+++ b/quri-parts/packages/qsub/tests/test_visualize.py
@@ -1,6 +1,8 @@
 from typing import Any
 
+from matplotlib import colors as mcolors
 from matplotlib import patches as mpatches
+from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 from pytest import MonkeyPatch
 
@@ -279,3 +281,23 @@ class TestDrawSub:
         base_circuit = record["base_circuit"]
         assert base_circuit.qubit_count >= 1
         assert len(base_circuit.gates) == base_circuit.qubit_count
+
+    def test_multi_controlled_swap_draws_control_markers(self) -> None:
+        builder = SubBuilder(arg_qubits_count=6)
+        builder.add_op(MultiControlled(SWAP, 4, 5), builder.qubits)
+
+        figure = draw_sub(builder.build())
+        try:
+            control_markers = [
+                patch
+                for patch in figure.axes[0].patches
+                if isinstance(patch, mpatches.Circle)
+            ]
+            control_markers.sort(key=lambda marker: marker.center[1])
+
+            assert len(control_markers) == 4
+            assert [marker.get_facecolor() for marker in control_markers] == [
+                mcolors.to_rgba(color) for color in ("black", "white", "black", "white")
+            ]
+        finally:
+            plt.close(figure)


### PR DESCRIPTION
## Issue

`qulacsvis` does not draw control markers for controlled or multi-controlled SWAP gates.
QURI Parts retains the control information when converting these operations for visualization, but the upstream Matplotlib drawer's SWAP path ignores it.
As a result, controlled SWAP gates are rendered like unconditional SWAP gates, which makes circuit diagrams misleading when they are used for debugging.

Expected behavior: all control qubits are shown, including filled markers for control value 1 and open markers for control value 0.
Actual behavior: only the two SWAP targets are shown.

## Changes

Changes proposed in this pull request

- Patch the `qulacsvis` Matplotlib drawer instance created for each render so its existing SWAP rendering is followed by rendering the gate's control bits.
- Reuse the drawer's existing control-bit rendering to preserve filled and open control markers.
- Add a regression test through `draw_sub()` for a multi-controlled SWAP with four controls, verifying the black, white, black, white marker sequence.

## Progress

- [x] Main implementation written
- [x] Functions as intended
- [x] Unit tests have been written
- [x] A README update is not required because this fixes existing rendering without changing the public API
